### PR TITLE
Search libm for ceil()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,8 @@ AC_FC_MODULE_EXTENSION()
 GX_FC_DEFAULT_REAL_KIND8_FLAG()
 GX_FC_DEFAULT_REAL_KIND4_FLAG()
 
+AC_SEARCH_LIBS([ceil],[m])
+
 # Check for the MPI compilers
 # Default MPI build is off
 build_mpi=no


### PR DESCRIPTION
On many Linux platforms, libm is not linked by default with libc and
must be explicitly added (-lm).  When building these tools on Hera, libm
was not linked and the ceil() function was unavailable.

This patch adds a search for ceil() in configure.ac, which resolves the
build on Hera.

Note that there are many missing libm functions (e.g. my own laptop
fails because of a missing acos() function) so there might be a more
general way of forcing libm to be used.