### PR TITLE
Improvements for CI and workaround for test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,24 +1,28 @@
 # Github actions CI file
 # Ryan Mulhall 2020
-# Configures with and without mpi and runs make check
-name: build_FRE-NCtools
-
+# Builds and runs make check in two containers, one with mpi, one without
+name: FRE-NCtools CI
 on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        with_mpi: ['--with-mpi', '']
+        with_mpi: ['','--with-mpi']
     env:
-      MPI: ${{ matrix.with_mpi }}
+        MPI: ${{ matrix.with_mpi }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup
-        run: sudo apt-get install -y libnetcdf-dev libnetcdff-dev netcdf-bin libopenmpi-dev openmpi-bin 
-      - name: Build
-        run: | 
-          autoreconf -i configure.ac
-          ./configure $MPI
-          make -j check LOG_DRIVER_FLAGS=--comments
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build container
+      run: |
+        if [[ "$MPI" != "" ]]; then sed -i 's/autoconf/autoconf libopenmpi-dev openmpi-bin/' Dockerfile; fi
+        docker build . -t fre-nctools$MPI
+    - name: Build and run tests
+      run: docker run -u root --entrypoint "/bin/sh" fre-nctools$MPI /build.sh
+    - name: Save log file on failure
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-suite${{ matrix.with_mpi}}.log
+          path: t/test-suite.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         if [[ "$MPI" != "" ]]; then sed -i 's/autoconf/autoconf libopenmpi-dev openmpi-bin/' Dockerfile; fi
         docker build . -t fre-nctools$MPI
     - name: Build and run tests
-      run: docker run -u root --entrypoint "/bin/sh" fre-nctools$MPI /build.sh
+      run: docker run -u root --entrypoint "/bin/sh" --env MPI fre-nctools$MPI /build.sh
     - name: Save log file on failure
       uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Build and run tests
       run: docker run -u root --entrypoint "/bin/sh" fre-nctools$MPI /build.sh
     - name: Save log file on failure
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
           name: test-suite${{ matrix.with_mpi}}.log
           path: t/test-suite.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+## install dependencies
+RUN apt-get update \
+ && apt-get -y install software-properties-common \
+ && add-apt-repository ppa:remik-ziemlinski/nccmp --update \
+ && apt-get install -y libnetcdf-dev libnetcdff-dev netcdf-bin gfortran bats nccmp autoconf
+## copy repo into container
+COPY . .
+## run tests
+ENTRYPOINT ["build.sh"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd FRE-NCtools
+autoreconf -i configure.ac
+./configure $MPI
+make -j check LOG_DRIVER_FLAGS=--comments

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd FRE-NCtools
+#Builds FRE-NCtools and runs regression tests
 autoreconf -i configure.ac
 ./configure $MPI
 make -j check LOG_DRIVER_FLAGS=--comments

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -30,6 +30,7 @@ TESTS = Test01-check_programs_exist.sh \
         Test22-reference_combine-ncc.sh \
         Test23-reference_decompress-ncc.sh \
         Test24-reference_fregrid.sh \
+        Test26-reference_fregrid_gcc.sh \
 	01-make_hgrid.sh \
         01-make_vgrid.sh
 

--- a/t/Test26-reference_fregrid_gcc.sh
+++ b/t/Test26-reference_fregrid_gcc.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bats
 # test regrid ocean restart file 
-
+# same as Test24 except checks result with float tolerance, added in for compatibility with gcc
 @test "Test fregrid ocean data" {
 
-  if [ "$CC" != "icc" ]; then skip "Test fails reference check without icc"; fi
-  if [ ! -d "Test24" ] 
+  if [ ! -d "Test26" ] 
   then
-  		mkdir Test24
+  		mkdir Test26
   fi
 
-  cd Test24
+  cd Test26
   cp $top_srcdir/t/Test20-input/CM2.1_mosaic.nc .
   cp $top_srcdir/t/Test20-input/CM2.1_grid.nc .
   cp $top_srcdir/t/Test20-input/ocean_temp_salt.res.nc .
@@ -49,8 +48,8 @@
 
    run nccmp -V
    [ "$status" -eq 0 ]
-   # This check will fail if fregrid was not compiled with icc due to differences in reference file
-   run nccmp -d  ocean_temp_salt.res.latlon.nc  $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc
+   # checks values with float tolerance to bypass any result differences from compilers
+   run nccmp -d -t 0.000001  ocean_temp_salt.res.latlon.nc  $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc
    [ "$status" -eq 0 ]
 
    [ -e latlon_mosaic.nc ]
@@ -60,5 +59,5 @@
    [ "$status" -eq 0 ]
 
   cd ..
-  rm -rf Test24
+  rm -rf Test26
 }


### PR DESCRIPTION
Updates the github action to use docker containers to compile and run tests with and without mpi enabled, and will save the log file upon failure.

Also added in a check to skip Test24 since it fails with gcc, and adds Test26 as a workaround for Test24.