### PR TITLE
Re-add hydrology dataset symlinks

### DIFF
--- a/t/Test25-hydrology.sh
+++ b/t/Test25-hydrology.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bats
-set -x
 
 @test "Wrapper complete hydrology test" {
 

--- a/t/Test25-hydrology.sh
+++ b/t/Test25-hydrology.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+set -x
 
 @test "Wrapper complete hydrology test" {
 
@@ -18,7 +19,7 @@
   run $top_srcdir/tools/simple_hydrog/share/make_simple_hydrog.csh
   [ "$status" -eq 1 ]
 
-  mkdir tmpdir
+  mkdir -p tmpdir
   export TMPDIR=tmpdir
 
   #Run wrapper hydrology script

--- a/tools/simple_hydrog/share/gigbp2_0ll.nc
+++ b/tools/simple_hydrog/share/gigbp2_0ll.nc
@@ -1,0 +1,1 @@
+/home/fms/fre-nctools/share-datasets/gigbp2_0ll_v001.nc

--- a/tools/simple_hydrog/share/river_network_mrg_0.5deg_ad3nov_fill_coast_auto1_0.125.nc
+++ b/tools/simple_hydrog/share/river_network_mrg_0.5deg_ad3nov_fill_coast_auto1_0.125.nc
@@ -1,0 +1,1 @@
+/home/fms/fre-nctools/share-datasets/river_network_mrg_0.5deg_ad3nov_fill_coast_auto1_0.125_v001.nc


### PR DESCRIPTION
The hydrology grid-generating script (make_simple_hydrog.csh) uses two input files, which are too large to be included in the repo. For now we will symlink to GFDL's filesystem but plan to keep these and other large files in a GDFL-managed git LFS server.

This update lets "make install" install the hydrology script dependencies properly at GFDL