### PR TITLE
Fix clip 2dx2d cells include poles

### DIFF
--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -1278,7 +1278,7 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
   for(i1=0; i1<n1_in; i1++) {
     lon_tmp[i1] = lon1_in[i1];
     lat_tmp[i1] = lat1_in[i1];
-    if(lon_tmp[i1]>TPI) gttwopi = 1;
+    if(lon_tmp[i1]>TPI || lon_tmp[i1]<0.0) gttwopi = 1;
   }
   for(i2=0; i2<n2_in; i2++) {
     lon2_tmp[i2] = lon2_in[i2];

--- a/tools/libfrencutils/create_xgrid.h
+++ b/tools/libfrencutils/create_xgrid.h
@@ -37,6 +37,7 @@ void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double 
 void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, double ll_lat,
 	 double ur_lon, double ur_lat, double lon_out[], double lat_out[]);
+void pimod(double x[],int nn);
 int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in, 
 	       const double lon2_in[], const double lat2_in[], int n2_in, 
 	       double lon_out[], double lat_out[]);


### PR DESCRIPTION
- This update addresses and fixes issue #42 
-  Fixes clip_2dx2d for grids surrounding the Poles
    - The clip_2dx2d issue #42 seems to arise when the first box passes through
      the NorthPole and corners have a longitude greater than 2*pi or when
      the SouthPole and corners have a longitude less than 0.
    - This heuristic fix shifts ALL the longitudes of the two boxes to be
      within -pi and pi and it seems to cure the clipping issues. 
    - I can't figure out why this fixes the issue. Need help!
    - Shifting all angles (regardless of location of the grid boxes) to be within -pi and pi does not work and ruins the clipper! Only the boxes that cross the poles have to be shifted!
    
    - I added some unit tests to create_xgrid.c to show this.

@ceblanton please assign this for review to @jwdGFDL and @bensonr . Please add anyone you think might be familiar with the clip_2dx2d algorithm.