### PR TITLE
Fix poly_area when side of grid cell polygon crosses pole

### DIFF
--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -407,11 +407,16 @@ double poly_area(const double x[], const double y[], int n)
     /*When the path goes through a Pole the line integral cannot be
       approximated by the fomula below. But we can show for these
       special grid cells the contribution of such paths to the area is pi.
-      We apply a fix to fix_lon function by adding a couple
+      We may also apply a fix to fix_lon function by adding a couple
       of twin poles to the polygon side that crosses the pole (diagnosed by dx=+/-pi).
       Note in that situation we should extend the if(dx < -M_PI) to if(dx <= -M_PI)
       so the resulting contribution to area is positive.
     */
+    if(fabs(dx+M_PI)< SMALL_VALUE || fabs(dx-M_PI)< SMALL_VALUE){
+      area += M_PI;
+      continue; //next i
+    }
+
     if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
       area -= dx*sin(0.5*(lat1+lat2));
     else {
@@ -525,6 +530,7 @@ int fix_lon(double x[], double y[], int n, double tlon)
   }
 
   /*If a polygon side passes through a Pole insert twin vertices at the Pole*/
+  /*A fix was directly applied to poly_area to handle this case
   for (i=0;i<nn;i++) {
     int im=(i+nn-1)%nn, ip=(i+1)%nn;
     double dx = x[i]-x[im];
@@ -538,7 +544,7 @@ int fix_lon(double x[], double y[], int n, double tlon)
       break;
     }
   }
-  
+  */
   if (nn) x_sum = x[0]; else return(0);
   for (i=1;i<nn;i++) {
     double dx = x[i]-x[i-1];

--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -32,6 +32,7 @@
 #include <mpi.h>
 #endif
 
+#define R2D (180./M_PI)
 #define HPI (0.5*M_PI)
 #define TPI (2.0*M_PI)
 #define TOLORENCE (1.e-6)
@@ -309,6 +310,85 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
 
 }; /* poly_area */
 
+/*------------------------------------------------------------------------------
+  double poly_area(const x[], const y[], int n)
+  obtains area of input polygon by line integrating -sin(lat)d(lon)
+  Vertex coordinates must be in Radians.
+  Vertices must be listed counter-clockwise around polygon.
+  grid is in radians.
+
+  Derivation of line integrating -sin(lat)d(lon) formula:
+  Consider a vector function in spherical coordinates (r,lon,lat) 
+  with only a lon component :
+      A=(0, (1-sin(lat))/cos(lat)/r , 0)  
+  Then  
+      Curl(A)=(1/r**2 , 0, 0) .  
+  Now consider any loop C on the suface of the sphere enclosing an area S 
+  and apply the Stokes theorem: 
+      \integral_surface_S Curl(A).da = \integral_loop_C A.dl 
+  where da and dl are the vectorial suface and line elements on sphere:
+      da=(da, 0, 0) and dl=(0, R*d(lon), R*cos(lat)*d(lon)).
+  We get
+      \integral_surface_S Curl(A) = \integral_surface_S (da/r**2) = S/R**2
+  and
+      \integral_loop_C A.dl = \integral_loop_C (1-sin(lat))*d(lon) 
+
+  Hence per Stokes formula:
+      S/R**2 = \integral_loop_C d(lon) - \integral_loop_C sin(lat)*d(lon). 
+  But 
+   \integral_loop_C d(lon)=0 as long as the loop does not go over the South Pole!
+   \integral_loop_C d(lon)=2*pi otherwise
+  Careful, is this true?
+
+  Now the approximation used for loop integral 
+    \integral_loop_C sin(lat)*d(lon)
+  = sum_over_loop_segments \integral_loop_C sin(lat)*d(lon)
+  = sum_over_loop_segments \integral_loop_C sin(lat)*d(lat) *d(lon)/d(lat)
+
+  If d(lon)/d(lat) is assumed contant over a loop segment, given that the segments
+  used here are the sides of a grid cell, then we can take it outside the integral
+    sum_over_loop_segments \integral_loop_C sin(lat)*d(lat) *d(lon)/d(lat)
+   =sum_over_loop_segments delta(lon)/delta(lat) \int_segment sin(lat)*d(lat) 
+   =sum_over_grid_sides (lon2-lon1)/(lat2-lat1) (-(cos(lat2)-cos(lat1)))
+
+  Finally:
+   S/R**2 = (lon2-lon1)/(lat2-lat1)*(cos(lat2)-cos(lat1))  + 0 or 2pi
+
+  Special cases:
+   As we saw this approximation is based on the assumtion that  d(lon)/d(lat) is
+   almost a constant over each segment of the path. This assumption breaks down 
+   if the path passes through a pole, e.g. along a longitude great circle where
+   lon abruptly changes by 2*pi as it goes through the pole. This actually happens
+   for some of the stretched ATM grids in the mix like this: 
+       x----x----x  
+       |    |    |
+       |   Pole  |
+       |    |    |
+       |    |    |
+       x----x----x  
+    x denotes grid points. In this situation we cannot use the above approximation
+    for the middle vertical path. 
+    To fix this we "assume" that the two loop integrals straddling the pole
+    are equal. Let's set
+      I = - \integral_loop_double_cell sin(lat)*d(lon), S =double_cell area /R**2
+      Il= - \integral_loop_left_cell sin(lat)*d(lon)  , Sl=left_cell area   /R**2
+      Ir= - \integral_loop_right_cell sin(lat)*d(lon) , Sr=right_cell area  /R**2
+    Then assume
+      I = Il+Ir 
+
+    According to Stoke's formula above
+      S =I + 2*pi 
+      Sl=Il
+      Sr=Ir
+      S=Sl+Sr => I+2*pi = (Il+Ir)=2*Ir (assuming Il=Ir if the grid cells are symmetric)
+    But 
+      I=Il_exclude+Ir_exclude =2*Ir_exclude 
+    where Ir_exclude is Ir excluding the common segment in the two grid cells. So:
+      Ir=Il=(2*Ir_exclude+2*pi)/2 =Ir_exclude+pi  
+    or put it another way
+      Ir_thru_pole = Il_thru_pole = pi  
+    where Ir_thru_pole is the integral over the segment passing through the pole.
+   ----------------------------------------------------------------------------*/
 double poly_area(const double x[], const double y[], int n)
 {
   double area = 0.0;
@@ -323,19 +403,26 @@ double poly_area(const double x[], const double y[], int n)
     lat1 = y[ip];
     lat2 = y[i];
     if(dx > M_PI)  dx = dx - 2.0*M_PI;
-    if(dx < -M_PI) dx = dx + 2.0*M_PI;
-    if (dx==0.0) continue;
-
+    if(dx <= -M_PI) dx = dx + 2.0*M_PI;
+    /*When the path goes through a Pole the line integral cannot be
+      approximated by the fomula below. But we can show for these
+      special grid cells the contribution of such paths to the area is pi.
+      We apply a fix to fix_lon function by adding a couple
+      of twin poles to the polygon side that crosses the pole (diagnosed by dx=+/-pi).
+      Note in that situation we should extend the if(dx < -M_PI) to if(dx <= -M_PI)
+      so the resulting contribution to area is positive.
+    */
     if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
       area -= dx*sin(0.5*(lat1+lat2));
     else {
       if(reproduce_siena) {
-   area += dx*(cos(lat1)-cos(lat2))/(lat1-lat2);
+	area += dx*(cos(lat1)-cos(lat2))/(lat1-lat2);
       }
       else {
-   dy = 0.5*(lat1-lat2);
-   dat = sin(dy)/dy;
-   area -= dx*sin(0.5*(lat1+lat2))*dat;
+	//This expression is a trig identity with the above reproduce_siena case
+	dy = 0.5*(lat1-lat2);
+	dat = sin(dy)/dy;
+	area -= dx*sin(0.5*(lat1+lat2))*dat; 
       }
     }
   }
@@ -399,7 +486,7 @@ void v_print(double x[], double y[], int n)
 {
   int i;
 
-  for (i=0;i<n;i++) printf(" %20g   %20g\n", x[i], y[i]);
+  for (i=0;i<n;i++) printf(" %20g   %20g\n", x[i]*R2D, y[i]*R2D);
 } /* v_print */
 
 int fix_lon(double x[], double y[], int n, double tlon)
@@ -415,6 +502,8 @@ int fix_lon(double x[], double y[], int n, double tlon)
   }
 
   /* all pole points must be paired */
+  /* The reason is poly_area() function needs a contribution equal to the angle (in radians) 
+     between the sides that connect to the pole. */
   for (i=0;i<nn;i++) if (fabs(y[i])>=HPI-TOLORENCE) {
     int im=(i+nn-1)%nn, ip=(i+1)%nn;
 
@@ -435,6 +524,21 @@ int fix_lon(double x[], double y[], int n, double tlon)
     if (y[ip]!=y[i]) x[i] = x[ip];
   }
 
+  /*If a polygon side passes through a Pole insert twin vertices at the Pole*/
+  for (i=0;i<nn;i++) {
+    int im=(i+nn-1)%nn, ip=(i+1)%nn;
+    double dx = x[i]-x[im];
+    if(fabs(dx+M_PI)< SMALL_VALUE || fabs(dx-M_PI)< SMALL_VALUE){
+      double x1=x[im];
+      double x2=x[i];
+      double ypole= HPI;
+      if(y[i]<0.0) ypole = -HPI ;
+      nn = insert_vtx(x, y, nn, i, x2, ypole);
+      nn = insert_vtx(x, y, nn, i, x1, ypole);
+      break;
+    }
+  }
+  
   if (nn) x_sum = x[0]; else return(0);
   for (i=1;i<nn;i++) {
     double dx = x[i]-x[i-1];

--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -530,7 +530,7 @@ int fix_lon(double x[], double y[], int n, double tlon)
   }
 
   /*If a polygon side passes through a Pole insert twin vertices at the Pole*/
-  /*A fix was directly applied to poly_area to handle this case
+  /*A fix is also directly applied to poly_area to handle this case.*/
   for (i=0;i<nn;i++) {
     int im=(i+nn-1)%nn, ip=(i+1)%nn;
     double dx = x[i]-x[im];
@@ -544,7 +544,6 @@ int fix_lon(double x[], double y[], int n, double tlon)
       break;
     }
   }
-  */
   if (nn) x_sum = x[0]; else return(0);
   for (i=1;i<nn;i++) {
     double dx = x[i]-x[i-1];


### PR DESCRIPTION
Fix poly_area when polygon side crosses a pole fixes issue #45 
    
    - Added the derivation for poly_area formula to the comments .
    - The area needs a fix for the case that the polygon side crosses a pole (d(longitude)=+- pi).
      In that case the  area formula was missing an additive factor of pi.
    - Missing a pi in the formula results a huge discrepancy of the order of the Earth area!
    - Similarly, if the polygon has a corner with angle A, then the formula
      needs an additive factor of A (in radians). But this latter case is
      already handled by fix_lon() and is the reason it creates a twin pole vertex
      (with longitudes paired with the preceding and following vertices)
      if the original polygon has a vertex at the pole.
    - Put the fix also in fix_lon() too. 
    - Investigate why putting the fix in poly_area alone is not enough?
      If I put the fix in poly_area only some cells near NP come with inaccurate area.
    - Unit tests in create_xgrid.c in PR #59 includes area calculation for these special grid box and show this fix works.
    - This does not fix issue #44  which is due to a numerical inaccuracy that has to be worked out separately (probably via quadrature). 

@ceblanton please assign this for review to @bensonr and @ngs333 or anyone who might be more familiar with poly_area calculation.