### PR TITLE
Enable telescoping nests (multiple levels)

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -56,6 +56,7 @@ TESTS = Test01-check_programs_exist.sh \
         Test24-reference_fregrid.sh \
         Test25-hydrology.sh \
         Test26-reference_fregrid_gcc.sh \
+        Test27-multiple_nests.sh \
         01-make_hgrid.sh \
         01-make_vgrid.sh
 

--- a/t/Test27-multiple_nests.sh
+++ b/t/Test27-multiple_nests.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+#
+# FRE-NCTools is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FRE-NCTools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FRE-NCTools.  If not, see
+# <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# Test grid for multiple same level and telescoping nests 
+
+@test "Test grid for multiple same level and telescoping nests" {
+
+  if [ ! -d "Test27" ] 
+  then
+  		mkdir Test27
+  fi
+
+  cd Test27
+
+#Make_hgrid: create three same level -level1- nests in tiles 2,5,6"
+  run command make_hgrid \
+		--grid_type gnomonic_ed \
+		--nlon 96 \
+		--grid_name C48_grid \
+		--do_schmidt \
+		--stretch_factor 1.0 \
+		--target_lon -97.5 \
+		--target_lat 36.5 \
+		--nest_grids 3 \
+		--parent_tile 2,5,6 \
+        --refine_ratio 2,2,2 \
+        --istart_nest 7,13,7 \
+        --jstart_nest 7,7,23 \
+        --iend_nest 58,68,40 \
+        --jend_nest 58,68,48 \
+        --halo 3 \
+        --great_circle_algorithm \
+        --verbose 1
+  [ "$status" -eq 0 ]
+
+#Make_hgrid: create two same level -level1- nests in tiles 2,5 
+#            and one -level2- telescoping nest in tile7"
+#          ( tile7 refers to the first nest on the first level)
+  run command make_hgrid \
+		--grid_type gnomonic_ed \
+		--nlon 96 \
+		--grid_name C48_grid \
+		--do_schmidt \
+		--stretch_factor 1.0 \
+		--target_lon -97.5 \
+		--target_lat 36.5 \
+		--nest_grids 3 \
+		--parent_tile 2,5,7 \
+        --refine_ratio 2,2,2 \
+        --istart_nest 7,13,7 \
+        --jstart_nest 7,7,23 \
+        --iend_nest 58,68,40 \
+        --jend_nest 58,68,48 \
+        --halo 3 \
+        --great_circle_algorithm \
+        --verbose 1
+  [ "$status" -eq 0 ]
+
+
+
+#Remove the workdir 
+  cd ..
+  rm -rf Test27
+}

--- a/tools/make_hgrid/create_gnomonic_cubic_grid.c
+++ b/tools/make_hgrid/create_gnomonic_cubic_grid.c
@@ -30,7 +30,8 @@
   12/07/2020  -- Global refinement bug fix. Kyle Ahern, AOML/HRD
   12/10/2020  -- Make multiple nest functionality consistent with latest
                  NOAA-GFDL source. Kyle Ahern, AOML/HRD
-
+  03/05/2020  -- Enable many level Telescoping nests
+                 (Nests within nests). Joseph Mouallem FV3/GFDL
 *******************************************************************************/
 
 /**
@@ -107,6 +108,7 @@ void create_gnomonic_cubic_grid( char* grid_type, int *nlon, int *nlat, double *
 
   int nx_nest[MAX_NESTS], ny_nest[MAX_NESTS];
   int ni_nest[MAX_NESTS], nj_nest[MAX_NESTS];
+  int ni_parent[MAX_NESTS], nj_parent[MAX_NESTS];
   int istart[MAX_NESTS], iend[MAX_NESTS], jstart[MAX_NESTS], jend[MAX_NESTS];
 
   int *nx_nest_arr=NULL;
@@ -165,6 +167,8 @@ void create_gnomonic_cubic_grid( char* grid_type, int *nlon, int *nlat, double *
   for (nn=0; nn < MAX_NESTS; nn++) {
     ni_nest[nn] = 0;
     nj_nest[nn] = 0;  
+    ni_parent[nn] = 0;
+    nj_parent[nn] = 0;  
   }
 
   ntiles2=ntiles;
@@ -188,6 +192,16 @@ void create_gnomonic_cubic_grid( char* grid_type, int *nlon, int *nlat, double *
       
       nx_nest[nn] = ni_nest[nn]*2;
       ny_nest[nn] = nj_nest[nn]*2;
+      
+      /* Setup parent ni */
+      if (parent_tile[nn] <= ntiles) {
+        ni_parent[nn] = ni;
+        nj_parent[nn] = nj;
+      }
+      else {
+        ni_parent[nn] = ni_nest[parent_tile[nn]-ntiles-1];
+        nj_parent[nn] = nj_nest[parent_tile[nn]-ntiles-1];
+      }
     }
   }
 
@@ -416,7 +430,7 @@ void create_gnomonic_cubic_grid( char* grid_type, int *nlon, int *nlat, double *
       /* The pointer arithmetic is complicated */
       /* ni = number of points on supergrid */
       /* nip = ni + 1 */
-      setup_aligned_nest(ni, ni, xc+tile_offset[parent_tile[nn]-1],
+      setup_aligned_nest(ni_parent[nn], nj_parent[nn], xc+tile_offset[parent_tile[nn]-1],
 			 yc+tile_offset[parent_tile[nn]-1], halo, refine_ratio[nn],
 			 istart[nn], iend[nn], jstart[nn], jend[nn],
 			 xc+tile_offset[ntiles+nn], yc+tile_offset[ntiles+nn]);


### PR DESCRIPTION
These modifications will allow multiple telescoping nests functionality.
Telescoping nests are defined as nests within nests.
This works for many nest levels.