### PR TITLE
Small fixes for GFDL gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,15 +7,14 @@ before_script:
 
 variables:
   buildDir: build.${FRE_SITE}.${CI_COMMIT_REF_SLUG}
-  CONFIG_SITE: ${CI_PROJECT_DIR}/site-configs/${FRE_SITE}/config.site
 .buildScript: &buildScript
   script:
-    - . ${CI_PROJECT_DIR}/site-configs/${FRE_SITE}/env.sh
+    - eval `${CI_PROJECT_DIR}/site-configs/${FRE_SITE}/env.sh`
     - autoreconf -i
     - mkdir ${buildDir}
     - cd ${buildDir}
     - ../configure --prefix=${FMS_HOME}/local/opt/fre-nctools/test/${FRE_SITE}
-    - make -j
+    - make
     - make -j check
   artifacts:
     expire_in: 1 month

--- a/site-configs/ncrc/env.sh
+++ b/site-configs/ncrc/env.sh
@@ -51,3 +51,6 @@ setenv MPICH_PTL_UNEX_EVENTS 160k
 setenv KMP_STACKSIZE 2g
 setenv F_UFMTENDIAN big
 setenv NC_BLKSZ 64K
+
+# Set CONFIG_SITE to the correct config.site file for the system
+setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site

--- a/site-configs/orion/env.sh
+++ b/site-configs/orion/env.sh
@@ -36,3 +36,5 @@ module load netcdf
 module load hdf5
 module load nccmp
 
+# Set CONFIG_SITE to the correct config.site file for the system
+setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site

--- a/t/Test25-hydrology.sh
+++ b/t/Test25-hydrology.sh
@@ -29,6 +29,11 @@
   # TODO: Get a way to download Test25-input if missing
   test ! -e $top_srcdir/t/Test25-input/grid_spec.nc && skip 'Input directory does not exist on this system'
 
+  # skip test if needed input dataset is empty
+  if ! ncdump -h $top_srcdir/tools/simple_hydrog/share/river_network_mrg_0.5deg_ad3nov_fill_coast_auto1_0.125.nc; then
+      skip 'Input dataset is not available'
+  fi
+
   if [ ! -d "Test25" ]
   then
                 mkdir Test25


### PR DESCRIPTION
* Use the new "eval `env.sh`" method to set the GFDL site environments
* Turn off parallel compilation (make -j)
* Set the SITE_CONFIG variable in ncrc/orion's env.sh script
* Skip the failing hydrology script test if the input dataset is empty