### PR TITLE
Fix for logic to skip fregrid reference test for non-Intel compilers

### DIFF
--- a/t/Test24-reference_fregrid.sh
+++ b/t/Test24-reference_fregrid.sh
@@ -24,7 +24,7 @@
 
 @test "Test fregrid ocean data" {
 
-  if [ "$CC" != "icc" ]; then skip "Test fails reference check without icc"; fi
+  if ! type icc; then skip "Test fails reference check without icc"; fi
   if [ ! -d "Test24" ] 
   then
   		mkdir Test24


### PR DESCRIPTION
This bitwise test for fregrid is not expected to pass on
non-Intel compilers, so a test was added to skip the test
if the $CC environment variable was not set to "icc".
In GFDL environments, the CC variable is not set to "icc" when
the Intel compilers are module loaded, so this test is not ever running.
Instead the test should be skipped if "icc" isn't in the PATH.