### PR TITLE
Set the executable rpath to include needed netcdf libraries

### DIFF
--- a/site-configs/gfdl-ws/env.sh
+++ b/site-configs/gfdl-ws/env.sh
@@ -62,3 +62,6 @@ module load mpich/$mpi_version
 
 # Set CONFIG_SITE to the correct config.site file for the system
 setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site
+
+# Include the netcdf-c/netcdf-fortran library paths during linking
+setenv LD_RUN_PATH \$LD_LIBRARY_PATH

--- a/site-configs/gfdl/env.sh
+++ b/site-configs/gfdl/env.sh
@@ -66,3 +66,6 @@ module load mpich/$mpi_version
 
 # Set CONFIG_SITE to the correct config.site file for the system
 setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site
+
+# Include the netcdf-c/netcdf-fortran library paths during linking
+setenv LD_RUN_PATH \$LD_LIBRARY_PATH

--- a/site-configs/ncrc/env.sh
+++ b/site-configs/ncrc/env.sh
@@ -54,3 +54,6 @@ setenv NC_BLKSZ 64K
 
 # Set CONFIG_SITE to the correct config.site file for the system
 setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site
+
+# Include the netcdf-c/netcdf-fortran library paths during linking
+setenv LD_RUN_PATH \$LD_LIBRARY_PATH

--- a/site-configs/nescc/env.sh
+++ b/site-configs/nescc/env.sh
@@ -62,3 +62,6 @@ module load impi/$mpi_version
 
 # Set CONFIG_SITE to the correct config.site file for the system
 setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site
+
+# Include the netcdf-c/netcdf-fortran library paths during linking
+setenv LD_RUN_PATH \$LD_LIBRARY_PATH

--- a/site-configs/orion/env.sh
+++ b/site-configs/orion/env.sh
@@ -55,3 +55,6 @@ module load nccmp
 
 # Set CONFIG_SITE to the correct config.site file for the system
 setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site
+
+# Include the netcdf-c/netcdf-fortran library paths during linking
+setenv LD_RUN_PATH \$LD_LIBRARY_PATH


### PR DESCRIPTION
#87 Temporary workaround to set the LD_RUN_PATH environment variable until a more native Autotools method can be added.

With this change, users using the site-configs/env.sh file to set their build environment will compile executables that have the rpath properly set (i.e. won't have to set $LD_LIBRARY_PATH in order to run the executables)