### PR TITLE
Update split_ncvar.pl shebang header to use first perl found in user's PATH

### DIFF
--- a/postprocessing/split_ncvars/split_ncvars.pl
+++ b/postprocessing/split_ncvars/split_ncvars.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 #***********************************************************************
 #                   GNU Lesser General Public License


### PR DESCRIPTION
resolves #92

In particular, this will help PP/AN CentOS 7 transition