### PR TITLE
Compiler flags to for release 18.1 - running on AMD and Intel

### DIFF
--- a/site-configs/ncrc/config.site
+++ b/site-configs/ncrc/config.site
@@ -29,8 +29,8 @@ test -z "$CC" && CC=cc
 test -z "$FC" && FC=ftn
 
 # Compile/Link flags
-test -z "$CFLAGS" && CFLAGS="-msse2"
-test -z "$FCFLAGS" && FCFLAGS="-fltconsistency -fno-alias -stack_temps -ftz -assume byterecl -i4 -traceback -msse2"
+test -z "$CFLAGS" && CFLAGS="-xSSE2"
+test -z "$FCFLAGS" && FCFLAGS="-fltconsistency -fno-alias -stack_temps -ftz -assume byterecl -i4 -traceback -xSSE2"
 test -z "$LIBS" && LIBS=-static
 test -z "$NETCDF_LIBS" && NETCDF_LIBS="-lnetcdf -lhdf5_hl -lhdf5 -lz -lm"
 test -z "$NETCDF_LDFLAGS" && NETCDF_LDFLAGS="-L${NETCDF_DIR}/lib -L${HDF5_DIR}/lib"


### PR DESCRIPTION
The compiler flags were modified so that the executables could run on the  DTN AMD Epyc hardware 
as well as the Gaea Intel hardware. It was necessary to change the ncrc config.site file to use the
"-xSSE2" flag in lieu of the "-msse2" flag. It was not necessary to change the flags for the gfdl or the gfdl-ws sites.

One of the goals was also to compile executables whose output was most similar to the fre-bronx/18 output. 
The files compared with the outputs of all the unit tests normally run - a total of 164 files for fre-bronx/18 and 176 from the current baseline.  Compiling with "-xSSE2" produced, by a significant margin,  the least number off non-reproducing files between the baseline and  fre/bronx-18.  With this flag, the ncrc Intel hardware there are 15 (out of 164) non-reproducing files, all which are produced by fregrid and make_hgrid within Test04, Test05 and Test15. .  If we use nccmp with “Tolerance” of 10^-10, the number of “non-reproducing” files drops from 15 to 8. They are all produced by make_hgrid (one of two highly modified programs) , and the differences are all (probably)  signs changes ( e.g. 180 vs -180). With other compilation flags tested we observed additional apps producing even more non-reproducing files.

On Analysis and the gfdl-ws sites, there was no difference observed in the output produced by compiler flags "-xSSE2" and the baseline's default (which seems to be "-msse2").  The number of non-reproducing files (vs bronx-18) for the default  are slightly worse in number and produced by the same executables and unit tests as in the ncrc case with flag "-xSSE2".

Additional testing:
Besides the comparison testing, the standard unit tests were run at several sites and there were no failures added by this work,

