### PR TITLE
Use input_file format for the output netcdf file type if the format arguement is not specified.

### DIFF
--- a/tools/fregrid/fregrid.c
+++ b/tools/fregrid/fregrid.c
@@ -23,20 +23,20 @@
 
  AUTHOR: Zhi Liang (Zhi.Liang@noaa.gov)
           NOAA Geophysical Fluid Dynamics Lab, Princeton, NJ
- 
+
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2 of the License, or
   (at your option) any later version.
- 
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
- 
+
   For the full text of the GNU General Public License,
   write to: Free Software Foundation, Inc.,
-            675 Mass Ave, Cambridge, MA 02139, USA.  
+            675 Mass Ave, Cambridge, MA 02139, USA.
 -----------------------------------------------------------------------
 */
 #include <stdlib.h>
@@ -97,7 +97,7 @@ char *usage[] = {
   "                              information for each tile.                              ",
   "                                                                                      ",
   "OPTIONAL FLAGS                                                                        ",
-  "                                                                                      ",  
+  "                                                                                      ",
   "--input_file    input_file    specify the input file name. The suffix '.nc' can be    ",
   "                              omitted. The suffix 'tile#' should not present for      ",
   "                              multiple-tile files. The number of files must be 1 for  ",
@@ -106,15 +106,15 @@ char *usage[] = {
   "                                                                                      ",
   "--scalar_field    scalar_fld  specify the scalar field name to be regridded. The      ",
   "                              multiple entry field names are seperated by comma.      ",
-  "                                                                                      ",    
+  "                                                                                      ",
   "--u_field         u_fld       specify the vector field u-componentname to be          ",
   "                              regridded. The multiple entry field names are seperated ",
   "                              by comma. u_field must be paired together with v_field. ",
-  "                                                                                      ",    
+  "                                                                                      ",
   "--v_field         v_fld       specify the vector field v-componentname to be          ",
   "                              regridded. The multiple entry field names are seperated ",
   "                              by comma. v_field must be paired together with u_field. ",
-  "                                                                                      ",  
+  "                                                                                      ",
   "--output_mosaic output_mosaic specify the output mosaic information. This file        ",
   "                              contains list of tile files which specify the grid      ",
   "                              information for each tile. If output_mosaic is not      ",
@@ -134,32 +134,32 @@ char *usage[] = {
   "                                                                                      ",
   "--latEnd   #decimal           specify the ending latitude(in degree) of the           ",
   "                              geographical region of the target grid on which the     ",
-  "                              output is desired. The default value is 90.             ",  
+  "                              output is desired. The default value is 90.             ",
   "                                                                                      ",
   "--nlon #integer               specify number of grid box cells in x-direction for a   ",
   "                              regular lat-lon grid.                                   ",
   "                                                                                      ",
   "--nlat #integer               specify number of grid box cells in y-direction for a   ",
   "                              regular lat-lon grid.                                   ",
-  "                                                                                      ",  
+  "                                                                                      ",
   "--KlevelBegin #integer        specify begin index of the k-level (depth axis) that    ",
   "                              to be regridded.                                        ",
   "                                                                                      ",
   "--KlevelEnd #integer          specify end index of the k-level (depth axis) that      ",
-  "                              to be regridded.                                        ",  
+  "                              to be regridded.                                        ",
   "                                                                                      ",
   "--LstepBegin #integer         specify the begin index of L-step (time axis) that      ",
   "                              to be regridded.                                        ",
   "                                                                                      ",
   "--LstepEnd #integer           specify the end index of L-step (time axis) that        ",
-  "                              to be regridded.                                        ",  
-  "                                                                                      ",  
+  "                              to be regridded.                                        ",
+  "                                                                                      ",
   "--output_file   output_file   specify the output file name. If not presented,         ",
   "                              output_file will take the value of input_file. The      ",
   "                              suffix '.nc' can be omitted. The suffix 'tile#' should  ",
   "                              not present for multiple-tile files. The number of      ",
   "                              files must be 1 for scalar regridding and can be 1 or 2 ",
-  "                              for vector regridding. File path should not be includes.",  
+  "                              for vector regridding. File path should not be includes.",
   "                                                                                      ",
   "--input_dir     input_dir     specify the path that stores input_file. If not         ",
   "                              presented, the input file is assumed to be stored in    ",
@@ -262,7 +262,7 @@ char *usage[] = {
   "--shuffle #                   If using NetCDF4 , use shuffle if 1 and don't use if 0  ",
   "                              Defaults to input file settings.                        ",
   "                                                                                      ",
-  "  Example 1: Remap C48 data onto N45 grid.                                            ",          
+  "  Example 1: Remap C48 data onto N45 grid.                                            ",
   "             (use GFDL-CM3 data as example)                                           ",
   "   fregrid --input_mosaic C48_mosaic.nc --input_dir input_dir --input_file input_file ",
   "           --scalar_field temp,salt --nlon 144 --nlat 90                              ",
@@ -279,6 +279,8 @@ char *usage[] = {
 #define EPSLN10  (1.e-10)
 const double D2R = M_PI/180.;
 char tagname[] = "$Name: bronx-10_performance_z1l $";
+
+extern int in_format; //declared in mpp_io.c
 
 int main(int argc, char* argv[])
 {
@@ -302,9 +304,9 @@ int main(int argc, char* argv[])
   char    *associated_file_dir = NULL;
   int     check_conserve = 0; /* 0 means no check */
   double  lonbegin = 0, lonend = 360;
-  double  latbegin = -90, latend = 90;			  
+  double  latbegin = -90, latend = 90;
   int     nlon = 0, nlat = 0;
-  int     kbegin = 0, kend = -1; 
+  int     kbegin = 0, kend = -1;
   int     lbegin = 0, lend = -1;
   char    *remap_file = NULL;
   char    interp_method[STRING] = "conserve_order1";
@@ -327,7 +329,7 @@ int main(int argc, char* argv[])
   int     deflation = -1;
   int     shuffle = -1;
   char    *format=NULL;
-  
+
   char          wt_file_obj[512];
   char          *weight_file=NULL;
   char          *weight_field = NULL;
@@ -350,14 +352,14 @@ int main(int argc, char* argv[])
   Interp_config *interp     = NULL;   /* store remapping information */
   int save_weight_only      = 0;
   int nthreads = 1;
-  
+
   double time_get_in_grid=0, time_get_out_grid=0, time_get_input=0;
   double time_setup_interp=0, time_do_interp=0, time_write=0;
   clock_t time_start, time_end;
-  
+
   int errflg = (argc == 1);
   int fid;
-  
+
   static struct option long_options[] = {
     {"input_mosaic",     required_argument, NULL, 'a'},
     {"output_mosaic",    required_argument, NULL, 'b'},
@@ -403,283 +405,295 @@ int main(int argc, char* argv[])
     {"format",           required_argument, NULL, 'U'},
     {"help",             no_argument,       NULL, 'h'},
     {0, 0, 0, 0},
-  };  
-  
+  };
+
   /* start parallel */
   mpp_init(&argc, &argv);
   mpp_domain_init();
-  
+
   while ((c = getopt_long(argc, argv, "", long_options, &option_index)) != -1) {
     switch (c) {
-    case 'a':
-      mosaic_in  = optarg;
-      break;
-    case 'b':
-      mosaic_out = optarg;
-      break;
-    case 'c':
-      dir_in = optarg;
-      break;
-    case 'd':
-      dir_out = optarg;
-      break;
-    case 'e':
-      if(strlen(optarg) >= MAXSTRING) mpp_error("fregrid: the entry is not long for option -e");
-      strcpy(entry, optarg);
-      tokenize(entry, ",", STRING, NFILE, (char *)input_file, &nfiles);
-      break;
-    case 'f':
-      if(strlen(optarg) >= MAXSTRING)  mpp_error("fregrid: the entry is not long for option -f");      
-      strcpy(entry, optarg);
-      tokenize(entry, ",", STRING, NFILE, (char *)output_file, &nfiles_out);
-      break;
-    case 'g':
-      remap_file = optarg;
-      break;
-    case 's':
-      if(strlen(optarg) >= MAXSTRING) mpp_error("fregrid: the entry is not long for option -s");      
-      strcpy(entry, optarg);
-      tokenize(entry, ",", STRING, NVAR, (char *)scalar_name, &nscalar);
-      break;
-    case 'u':
-      if(strlen(optarg) >= MAXSTRING) mpp_error("fregrid: the entry is not long for option -u");      
-      strcpy(entry, optarg);
-      tokenize(entry, ",", STRING, NVAR, (char *)u_name, &nvector);
-      break;        
-    case 'v':
-      if(strlen(optarg) >= MAXSTRING) mpp_error("fregrid: the entry is not long for option -v");      
-      strcpy(entry, optarg);
-      tokenize(entry, ",", STRING, NVAR, (char *)v_name, &nvector2);
-      break;      
-    case 'j':
-      strcpy(interp_method, optarg);
-      break;
-    case 'i':
-      test_case = optarg;
-      break;
-    case 'k':
-      test_param = atof(optarg);
-      break;      
-    case 'l':
-      opcode |= SYMMETRY;
-      break;
-    case 'm':
-      if(strcmp(optarg, "AGRID") == 0)
-	grid_type = AGRID;
-      else if(strcmp(optarg, "BGRID") == 0)
-	grid_type = BGRID;
-      else
-	mpp_error("fregrid: only AGRID and BGRID vector regridding are implmented, contact developer");
-      break;
-    case 'n':
-      opcode |= TARGET;
-      break;
-    case 'o':
-      finer_step = atoi(optarg);
-      break;
-    case 'p':
-      fill_missing = 1;
-      break;
-    case 'q':
-      nlon = atoi(optarg);
-      break;
-    case 'r':
-      nlat = atoi(optarg);
-      break;
-    case 't':
-      check_conserve = 1;
-      break;
-    case 'y':
-      y_at_center = 1;
-      break;
-    case 'A':
-      lonbegin = atof(optarg);
-      break;
-    case 'B':
-      lonend = atof(optarg);
-      break;
-    case 'C':
-      latbegin = atof(optarg);
-      break;
-    case 'D':
-      latend = atof(optarg);
-      break;
-    case 'E':
-      kbegin = atoi(optarg);
-      break;
-    case 'F':
-      kend = atoi(optarg);
-      break;
-    case 'G':
-      lbegin = atoi(optarg);
-      break;
-    case 'H':
-      lend = atoi(optarg);
-      break;
-    case 'I':
-      weight_file = optarg;
-      break;
-    case 'J':
-      weight_field = optarg;
-      break;
-    case 'L':
-      extrapolate = 1;
-      break;
-    case 'M':
-      dst_vgrid = optarg;
-      vertical_interp = 1;
-      break;
-    case 'N':
-      stop_crit = atof(optarg);
-      break;
-    case 'O':
-      opcode |= STANDARD_DIMENSION;
-      break;
-    case 'P':
-      debug = 1;
-      break;  
-    case 'Q':
-      nthreads = atoi(optarg);
-      break;
-    case 'R':
-      associated_file_dir = optarg;
-      break;
-    case 'S':
-      deflation = atoi(optarg);
-      break;
-    case 'T':
-      shuffle = atoi(optarg);
-	break;
-    case 'U':
-      format = optarg;
-      break;
-    case '?':
-      errflg++;
-      break;
+      case 'a':
+        mosaic_in = optarg;
+        break;
+      case 'b':
+        mosaic_out = optarg;
+        break;
+      case 'c':
+        dir_in = optarg;
+        break;
+      case 'd':
+        dir_out = optarg;
+        break;
+      case 'e':
+        if (strlen(optarg) >= MAXSTRING) mpp_error("fregrid: the entry is not long for option -e");
+        strcpy(entry, optarg);
+        tokenize(entry, ",", STRING, NFILE, (char *)input_file, &nfiles);
+        break;
+      case 'f':
+        if (strlen(optarg) >= MAXSTRING) mpp_error("fregrid: the entry is not long for option -f");
+        strcpy(entry, optarg);
+        tokenize(entry, ",", STRING, NFILE, (char *)output_file, &nfiles_out);
+        break;
+      case 'g':
+        remap_file = optarg;
+        break;
+      case 's':
+        if (strlen(optarg) >= MAXSTRING) mpp_error("fregrid: the entry is not long for option -s");
+        strcpy(entry, optarg);
+        tokenize(entry, ",", STRING, NVAR, (char *)scalar_name, &nscalar);
+        break;
+      case 'u':
+        if (strlen(optarg) >= MAXSTRING) mpp_error("fregrid: the entry is not long for option -u");
+        strcpy(entry, optarg);
+        tokenize(entry, ",", STRING, NVAR, (char *)u_name, &nvector);
+        break;
+      case 'v':
+        if (strlen(optarg) >= MAXSTRING) mpp_error("fregrid: the entry is not long for option -v");
+        strcpy(entry, optarg);
+        tokenize(entry, ",", STRING, NVAR, (char *)v_name, &nvector2);
+        break;
+      case 'j':
+        strcpy(interp_method, optarg);
+        break;
+      case 'i':
+        test_case = optarg;
+        break;
+      case 'k':
+        test_param = atof(optarg);
+        break;
+      case 'l':
+        opcode |= SYMMETRY;
+        break;
+      case 'm':
+        if (strcmp(optarg, "AGRID") == 0)
+          grid_type = AGRID;
+        else if (strcmp(optarg, "BGRID") == 0)
+          grid_type = BGRID;
+        else
+          mpp_error("fregrid: only AGRID and BGRID vector regridding are implmented, contact developer");
+        break;
+      case 'n':
+        opcode |= TARGET;
+        break;
+      case 'o':
+        finer_step = atoi(optarg);
+        break;
+      case 'p':
+        fill_missing = 1;
+        break;
+      case 'q':
+        nlon = atoi(optarg);
+        break;
+      case 'r':
+        nlat = atoi(optarg);
+        break;
+      case 't':
+        check_conserve = 1;
+        break;
+      case 'y':
+        y_at_center = 1;
+        break;
+      case 'A':
+        lonbegin = atof(optarg);
+        break;
+      case 'B':
+        lonend = atof(optarg);
+        break;
+      case 'C':
+        latbegin = atof(optarg);
+        break;
+      case 'D':
+        latend = atof(optarg);
+        break;
+      case 'E':
+        kbegin = atoi(optarg);
+        break;
+      case 'F':
+        kend = atoi(optarg);
+        break;
+      case 'G':
+        lbegin = atoi(optarg);
+        break;
+      case 'H':
+        lend = atoi(optarg);
+        break;
+      case 'I':
+        weight_file = optarg;
+        break;
+      case 'J':
+        weight_field = optarg;
+        break;
+      case 'L':
+        extrapolate = 1;
+        break;
+      case 'M':
+        dst_vgrid = optarg;
+        vertical_interp = 1;
+        break;
+      case 'N':
+        stop_crit = atof(optarg);
+        break;
+      case 'O':
+        opcode |= STANDARD_DIMENSION;
+        break;
+      case 'P':
+        debug = 1;
+        break;
+      case 'Q':
+        nthreads = atoi(optarg);
+        break;
+      case 'R':
+        associated_file_dir = optarg;
+        break;
+      case 'S':
+        deflation = atoi(optarg);
+        break;
+      case 'T':
+        shuffle = atoi(optarg);
+        break;
+      case 'U':
+        format = optarg;
+        break;
+      case '?':
+        errflg++;
+        break;
     }
   }
 
   if (errflg) {
     char **u = usage;
-    while (*u) { fprintf(stderr, "%s\n", *u); u++; }
+    while (*u) {
+      fprintf(stderr, "%s\n", *u);
+      u++;
+    }
     exit(2);
-  }      
-  /* check the arguments */
-  if( !mosaic_in  ) mpp_error("fregrid: input_mosaic is not specified");
-  if( !mosaic_out ) {
-    if(nlon == 0 || nlat ==0 ) mpp_error("fregrid: when output_mosaic is not specified, nlon and nlat should be specified");
-    if(lonend <= lonbegin) mpp_error("fregrid: when output_mosaic is not specified, lonEnd should be larger than lonBegin");
-    if(latend <= latbegin) mpp_error("fregrid: when output_mosaic is not specified, latEnd should be larger than latBegin");
   }
-  else {
-    if(nlon !=0 || nlat != 0) mpp_error("fregrid: when output_mosaic is specified, nlon and nlat should not be specified");
+  /* check the arguments */
+  if (!mosaic_in) mpp_error("fregrid: input_mosaic is not specified");
+  if (!mosaic_out) {
+    if (nlon == 0 || nlat == 0)
+      mpp_error("fregrid: when output_mosaic is not specified, nlon and nlat should be specified");
+    if (lonend <= lonbegin)
+      mpp_error("fregrid: when output_mosaic is not specified, lonEnd should be larger than lonBegin");
+    if (latend <= latbegin)
+      mpp_error("fregrid: when output_mosaic is not specified, latEnd should be larger than latBegin");
+  } else {
+    if (nlon != 0 || nlat != 0)
+      mpp_error("fregrid: when output_mosaic is specified, nlon and nlat should not be specified");
   }
 
-  if(!strcmp(interp_method, "conserve_order1") ) {
-    if(mpp_pe() == mpp_root_pe())printf("****fregrid: first order conservative scheme will be used for regridding.\n");
+  if (!strcmp(interp_method, "conserve_order1")) {
+    if (mpp_pe() == mpp_root_pe())
+      printf("****fregrid: first order conservative scheme will be used for regridding.\n");
     opcode |= CONSERVE_ORDER1;
-  }
-  else if(!strcmp(interp_method, "conserve_order2") ) {
-    if(mpp_pe() == mpp_root_pe())printf("****fregrid: second order conservative scheme will be used for regridding.\n");
+  } else if (!strcmp(interp_method, "conserve_order2")) {
+    if (mpp_pe() == mpp_root_pe())
+      printf("****fregrid: second order conservative scheme will be used for regridding.\n");
     opcode |= CONSERVE_ORDER2;
-  }
-  else if(!strcmp(interp_method, "conserve_order2_monotonic") ) {
-    if(mpp_pe() == mpp_root_pe())printf("****fregrid: second order monotonic conservative scheme will be used for regridding.\n");
+  } else if (!strcmp(interp_method, "conserve_order2_monotonic")) {
+    if (mpp_pe() == mpp_root_pe())
+      printf("****fregrid: second order monotonic conservative scheme will be used for regridding.\n");
     opcode |= CONSERVE_ORDER2;
     opcode |= MONOTONIC;
-  }
-  else if(!strcmp(interp_method, "bilinear") ) {
-    if(mpp_pe() == mpp_root_pe())printf("****fregrid: bilinear remapping scheme will be used for regridding.\n");  
+  } else if (!strcmp(interp_method, "bilinear")) {
+    if (mpp_pe() == mpp_root_pe()) printf("****fregrid: bilinear remapping scheme will be used for regridding.\n");
     opcode |= BILINEAR;
-  }
-  else
-    mpp_error("fregrid: interp_method must be 'conserve_order1', 'conserve_order2', 'conserve_order2_monotonic'  or 'bilinear'");
+  } else
+    mpp_error(
+        "fregrid: interp_method must be 'conserve_order1', 'conserve_order2', 'conserve_order2_monotonic'  or "
+        "'bilinear'");
 
   save_weight_only = 0;
-  if( nfiles == 0) {
-    if(nvector > 0 || nscalar > 0 || nvector2 > 0)
-      mpp_error("fregrid: when --input_file is not specified, --scalar_field, --u_field and --v_field should also not be specified");
-    if(!remap_file) mpp_error("fregrid: when --input_file is not specified, remap_file must be specified to save weight information");
+  if (nfiles == 0) {
+    if (nvector > 0 || nscalar > 0 || nvector2 > 0)
+      mpp_error(
+          "fregrid: when --input_file is not specified, --scalar_field, --u_field and --v_field should also not be "
+          "specified");
+    if (!remap_file)
+      mpp_error("fregrid: when --input_file is not specified, remap_file must be specified to save weight information");
     save_weight_only = 1;
-    if(mpp_pe()==mpp_root_pe())printf("NOTE: No input file specified in this run, no data file will be regridded "
-				      "and only weight information is calculated.\n");
-  }
-  else if( nfiles == 1 || nfiles ==2) {
-    if( nvector != nvector2 ) mpp_error("fregrid: number of fields specified in u_field must be the same as specified in v_field");
-    if( nscalar+nvector==0 ) mpp_error("fregrid: both scalar_field and vector_field are not specified");
+    if (mpp_pe() == mpp_root_pe())
+      printf(
+          "NOTE: No input file specified in this run, no data file will be regridded "
+          "and only weight information is calculated.\n");
+  } else if (nfiles == 1 || nfiles == 2) {
+    if (nvector != nvector2)
+      mpp_error("fregrid: number of fields specified in u_field must be the same as specified in v_field");
+    if (nscalar + nvector == 0) mpp_error("fregrid: both scalar_field and vector_field are not specified");
     /* when nvector =2 and nscalar=0, nfiles can be 2 otherwise nfiles must be 1 */
-    if( nscalar && nfiles != 1 )
-      mpp_error("fregrid: when scalar_field is specified, number of files must be 1");
-    if( nfiles_out == 0 ) {
-      for(i=0; i<nfiles; i++) strcpy(output_file[i], input_file[i]);
-    }
-    else if (nfiles_out != nfiles )
+    if (nscalar && nfiles != 1) mpp_error("fregrid: when scalar_field is specified, number of files must be 1");
+    if (nfiles_out == 0) {
+      for (i = 0; i < nfiles; i++) strcpy(output_file[i], input_file[i]);
+    } else if (nfiles_out != nfiles)
       mpp_error("fregrid:number of input file is not equal to number of output file");
-  }
-  else
+  } else
     mpp_error("fregrid: number of input file should be 1 or 2");
 
-  if(kbegin != 0 || kend != -1) { /* at least one of kbegin and kend is set */
-    if(kbegin < 1 || kend < kbegin) mpp_error("fregrid:KlevelBegin should be a positive integer and no larger "
-					      "than KlevelEnd when you want pick certain klevel");
+  if (kbegin != 0 || kend != -1) { /* at least one of kbegin and kend is set */
+    if (kbegin < 1 || kend < kbegin)
+      mpp_error(
+          "fregrid:KlevelBegin should be a positive integer and no larger "
+          "than KlevelEnd when you want pick certain klevel");
   }
-  if(lbegin != 0 || lend != -1) { /* at least one of lbegin and lend is set */
-     if(lbegin < 1 || lend < lbegin) mpp_error("fregrid:LstepBegin should be a positive integer and no larger "
-					      "than LstepEnd when you want pick certain Lstep");
+  if (lbegin != 0 || lend != -1) { /* at least one of lbegin and lend is set */
+    if (lbegin < 1 || lend < lbegin)
+      mpp_error(
+          "fregrid:LstepBegin should be a positive integer and no larger "
+          "than LstepEnd when you want pick certain Lstep");
   }
 
-  if(weight_field) {
-    if(nvector >0) mpp_error("fregrid: weight_field should not be specified for vector interpolation, contact developer");
-    if(!weight_file) {
-      
-      if(nfiles==0) mpp_error("fregrid: weight_field is specified, but both weight_file and input_file are not specified");
-      if(dir_in)
-	sprintf(wt_file_obj, "%s/%s", dir_in, input_file[0]);
+  if (weight_field) {
+    if (nvector > 0)
+      mpp_error("fregrid: weight_field should not be specified for vector interpolation, contact developer");
+    if (!weight_file) {
+      if (nfiles == 0)
+        mpp_error("fregrid: weight_field is specified, but both weight_file and input_file are not specified");
+      if (dir_in)
+        sprintf(wt_file_obj, "%s/%s", dir_in, input_file[0]);
       else
-	sprintf(wt_file_obj, "./%s", input_file[0]);
+        sprintf(wt_file_obj, "./%s", input_file[0]);
       weight_file = wt_file_obj;
     }
   }
 
-  if(nvector > 0) {
+  if (nvector > 0) {
     opcode |= VECTOR;
-    if(grid_type == AGRID)
+    if (grid_type == AGRID)
       opcode |= AGRID;
-    else if(grid_type == BGRID)
+    else if (grid_type == BGRID)
       opcode |= BGRID;
   }
 
-  if (shuffle < -1 || shuffle > 1)
-    mpp_error("fregrid: shuffle must be 0 (off) or 1 (on)");
-  if (deflation < -1 || deflation > 9)
-    mpp_error("fregrid: deflation must be between 0 (off) and 9");
-  
-  /* define history to be the history in the grid file */
-  strcpy(history,argv[0]);
+  if (shuffle < -1 || shuffle > 1) mpp_error("fregrid: shuffle must be 0 (off) or 1 (on)");
+  if (deflation < -1 || deflation > 9) mpp_error("fregrid: deflation must be between 0 (off) and 9");
 
-  for(i=1;i<argc;i++) {
+  /* define history to be the history in the grid file */
+  strcpy(history, argv[0]);
+
+  for (i = 1; i < argc; i++) {
     strcat(history, " ");
-    if(strlen(argv[i]) > MAXENTRY) { /* limit the size of each entry, here we are assume the only entry that is longer than
-					MAXENTRY= 256 is the option --scalar_field --u_field and v_field */
-      if(strcmp(argv[i-1], "--scalar_field") && strcmp(argv[i-1], "--u_field") && strcmp(argv[i-1], "--v_field") )
-	mpp_error("fregrid: the entry ( is not scalar_field, u_field, v_field ) is too long, need to increase parameter MAXENTRY");
-      strcat(history, "(**please see the field list in this file**)" );
-    }
-    else
+    if (strlen(argv[i]) > MAXENTRY) { /* limit the size of each entry, here we are assume the only entry that is longer
+                                         than MAXENTRY= 256 is the option --scalar_field --u_field and v_field */
+      if (strcmp(argv[i - 1], "--scalar_field") && strcmp(argv[i - 1], "--u_field") && strcmp(argv[i - 1], "--v_field"))
+        mpp_error(
+            "fregrid: the entry ( is not scalar_field, u_field, v_field ) is too long, need to increase parameter "
+            "MAXENTRY");
+      strcat(history, "(**please see the field list in this file**)");
+    } else
       strcat(history, argv[i]);
   }
-  
-{
-  int base_cpu;
+
+  {
+    int base_cpu;
 
 #if defined(_OPENMP)
-  omp_set_num_threads(nthreads);
-  base_cpu = get_cpu_affinity();
+    omp_set_num_threads(nthreads);
+    base_cpu = get_cpu_affinity();
 #pragma omp parallel
-  set_cpu_affinity(base_cpu+omp_get_thread_num() );
+    set_cpu_affinity(base_cpu + omp_get_thread_num());
 #endif
-
-}
+  }
 
   /* get the mosaic information of input and output mosaic*/
   fid = mpp_open(mosaic_in, MPP_READ);
@@ -687,427 +701,444 @@ int main(int argc, char* argv[])
   mpp_close(fid);
 
   /* second order conservative interpolation is only avail for the cubic sphere input grid */
-  if( ntiles_in != 6 && (opcode & CONSERVE_ORDER2) ) 
+  if (ntiles_in != 6 && (opcode & CONSERVE_ORDER2))
     mpp_error("fregrid: when the input grid is not cubic sphere grid, interp_method can not be conserve_order2");
 
-  if(mosaic_out) {
+  if (mosaic_out) {
     fid = mpp_open(mosaic_out, MPP_READ);
     ntiles_out = mpp_get_dimlen(fid, "ntiles");
     mpp_close(fid);
-  }
-  else
+  } else
     ntiles_out = 1;
 
-  if(test_case) {
-    if(nfiles != 1) mpp_error("fregrid: when test_case is specified, nfiles should be 1");
+  if (test_case) {
+    if (nfiles != 1) mpp_error("fregrid: when test_case is specified, nfiles should be 1");
     sprintf(output_file[0], "%s.%s.output", test_case, interp_method);
   }
 
-  if(check_conserve) opcode |= CHECK_CONSERVE;
+  if (check_conserve) opcode |= CHECK_CONSERVE;
 
-  if( opcode & STANDARD_DIMENSION ) printf("fregrid: --standard_dimension is set\n");
-  
-  if( opcode & BILINEAR ) {
+  if (opcode & STANDARD_DIMENSION) printf("fregrid: --standard_dimension is set\n");
+
+  if (opcode & BILINEAR) {
     int ncontact;
     ncontact = read_mosaic_ncontacts(mosaic_in);
-    if( nlon == 0 || nlat == 0) mpp_error("fregrid: when interp_method is bilinear, nlon and nlat should be specified");
-    if(ntiles_in != 6) mpp_error("fregrid: when interp_method is bilinear, the input mosaic should be 6 tile cubic grid");
-    if(ncontact !=12)  mpp_error("fregrid: when interp_method is bilinear, the input mosaic should be 12 contact cubic grid");
-    if(mpp_npes() > 1) mpp_error("fregrid: parallel is not implemented for bilinear remapping");
-  }
-  else 
+    if (nlon == 0 || nlat == 0) mpp_error("fregrid: when interp_method is bilinear, nlon and nlat should be specified");
+    if (ntiles_in != 6)
+      mpp_error("fregrid: when interp_method is bilinear, the input mosaic should be 6 tile cubic grid");
+    if (ncontact != 12)
+      mpp_error("fregrid: when interp_method is bilinear, the input mosaic should be 12 contact cubic grid");
+    if (mpp_npes() > 1) mpp_error("fregrid: parallel is not implemented for bilinear remapping");
+  } else
     y_at_center = 1;
 
-  if(extrapolate) opcode |= EXTRAPOLATE;
-  
-  /* memory allocation for data structure */
-  grid_in   = (Grid_config *)malloc(ntiles_in *sizeof(Grid_config));
-  grid_out  = (Grid_config *)malloc(ntiles_out*sizeof(Grid_config));
-  bound_T   = (Bound_config *)malloc(ntiles_in *sizeof(Bound_config));
-  interp    = (Interp_config *)malloc(ntiles_out*sizeof(Interp_config));
+  if (extrapolate) opcode |= EXTRAPOLATE;
 
-  if(debug) {
+  /* memory allocation for data structure */
+  grid_in = (Grid_config *)malloc(ntiles_in * sizeof(Grid_config));
+  grid_out = (Grid_config *)malloc(ntiles_out * sizeof(Grid_config));
+  bound_T = (Bound_config *)malloc(ntiles_in * sizeof(Bound_config));
+  interp = (Interp_config *)malloc(ntiles_out * sizeof(Interp_config));
+
+  if (debug) {
     print_mem_usage("Before calling get_input_grid");
     time_start = clock();
   }
-  get_input_grid( ntiles_in, grid_in, bound_T, mosaic_in, opcode, &great_circle_algorithm_in, save_weight_only );
-  if(debug) {
+  get_input_grid(ntiles_in, grid_in, bound_T, mosaic_in, opcode, &great_circle_algorithm_in, save_weight_only);
+  if (debug) {
     time_end = clock();
-    time_get_in_grid = 1.0*(time_end - time_start)/CLOCKS_PER_SEC;
+    time_get_in_grid = 1.0 * (time_end - time_start) / CLOCKS_PER_SEC;
     print_mem_usage("After calling get_input_grid");
     time_start = clock();
   }
-  if(mosaic_out) 
-    get_output_grid_from_mosaic( ntiles_out, grid_out, mosaic_out, opcode, &great_circle_algorithm_out );
+  if (mosaic_out)
+    get_output_grid_from_mosaic(ntiles_out, grid_out, mosaic_out, opcode, &great_circle_algorithm_out);
   else {
     great_circle_algorithm_out = 0;
-    get_output_grid_by_size(ntiles_out, grid_out, lonbegin, lonend, latbegin, latend,
-			    nlon, nlat, finer_step, y_at_center, opcode);
+    get_output_grid_by_size(ntiles_out, grid_out, lonbegin, lonend, latbegin, latend, nlon, nlat, finer_step,
+                            y_at_center, opcode);
   }
-  if(debug) {
+  if (debug) {
     time_end = clock();
-    time_get_out_grid = 1.0*(time_end - time_start)/CLOCKS_PER_SEC;
+    time_get_out_grid = 1.0 * (time_end - time_start) / CLOCKS_PER_SEC;
     print_mem_usage("After calling get_output_grid");
   }
   /* find out if great_circle algorithm is used in the input grid or output grid */
-  
-  if( great_circle_algorithm_in == 0 && great_circle_algorithm_out == 0 )
+
+  if (great_circle_algorithm_in == 0 && great_circle_algorithm_out == 0)
     opcode |= LEGACY_CLIP;
   else {
     opcode |= GREAT_CIRCLE;
     /* currently only first-order conservative is implemented */
-    if( !(opcode & CONSERVE_ORDER1) )
-      mpp_error("fregrid: when clip_method is 'conserve_great_circle', interp_methos need to be 'conserve_order1', contact developer");
+    if (!(opcode & CONSERVE_ORDER1))
+      mpp_error(
+          "fregrid: when clip_method is 'conserve_great_circle', interp_methos need to be 'conserve_order1', contact "
+          "developer");
   }
 
   /* get the grid cell_area */
   get_input_output_cell_area(ntiles_in, grid_in, ntiles_out, grid_out, opcode);
-  if(debug) print_mem_usage("After get_input_output_cell_area");  
+  if (debug) print_mem_usage("After get_input_output_cell_area");
   /* currently extrapolate are limited to ntiles = 1. extrapolate are limited to lat-lon input grid */
-  if( extrapolate ) {
+  if (extrapolate) {
     int i, j, ind0, ind1, ind2;
-    if(test_case ) mpp_error("fregrid: extrapolate is limited to test_case is false");
-    if(ntiles_in != 1) mpp_error("fregrid: extrapolate is limited to ntile_in = 1");
+    if (test_case) mpp_error("fregrid: extrapolate is limited to test_case is false");
+    if (ntiles_in != 1) mpp_error("fregrid: extrapolate is limited to ntile_in = 1");
     /* check if the grid is lat-lon grid */
-    for(j=1; j<=grid_in[0].ny; j++) for(i=1; i<=grid_in[0].nx; i++) {
-      ind0 = j*(grid_in[0].nx+2)+i;
-      ind1 = j*(grid_in[0].nx+2)+1;
-      ind2 = 1*(grid_in[0].nx+2)+i;
-      if(fabs( grid_in[0].lont[ind0]-grid_in[0].lont[ind2] ) > EPSLN10 ||
-	 fabs( grid_in[0].latt[ind0]-grid_in[0].latt[ind1] ) > EPSLN10 )
-	mpp_error("fregrid: extrapolate is limited to lat-lon grid");
-	  
-    }
+    for (j = 1; j <= grid_in[0].ny; j++)
+      for (i = 1; i <= grid_in[0].nx; i++) {
+        ind0 = j * (grid_in[0].nx + 2) + i;
+        ind1 = j * (grid_in[0].nx + 2) + 1;
+        ind2 = 1 * (grid_in[0].nx + 2) + i;
+        if (fabs(grid_in[0].lont[ind0] - grid_in[0].lont[ind2]) > EPSLN10 ||
+            fabs(grid_in[0].latt[ind0] - grid_in[0].latt[ind1]) > EPSLN10)
+          mpp_error("fregrid: extrapolate is limited to lat-lon grid");
+      }
   }
 
   /* when vertical_interp is set, extrapolate must be set */
-  if( vertical_interp) extrapolate = 1;
+  if (vertical_interp) extrapolate = 1;
   /* vertical_interp and extrapolate is not supported for vector interpolation */
-  if( nvector > 0) {
-    if(vertical_interp) mpp_error("fregrid: vertical_interp is not supported for vector fields");
-    if(extrapolate) mpp_error("fregrid: extrapolate is not supported for vector fields");
+  if (nvector > 0) {
+    if (vertical_interp) mpp_error("fregrid: vertical_interp is not supported for vector fields");
+    if (extrapolate) mpp_error("fregrid: extrapolate is not supported for vector fields");
   }
-  
-  if(remap_file) set_remap_file(ntiles_out, mosaic_out, remap_file, interp, &opcode, save_weight_only);  
 
-  if(!save_weight_only) {
-    file_in   = (File_config *)malloc(ntiles_in *sizeof(File_config));
-    file_out  = (File_config *)malloc(ntiles_out*sizeof(File_config));
- 
-    if(nfiles == 2) {
-      file2_in   = (File_config *)malloc(ntiles_in *sizeof(File_config));
-      file2_out  = (File_config *)malloc(ntiles_out*sizeof(File_config));
+  if (remap_file) set_remap_file(ntiles_out, mosaic_out, remap_file, interp, &opcode, save_weight_only);
+
+  if (!save_weight_only) {
+    file_in = (File_config *)malloc(ntiles_in * sizeof(File_config));
+    file_out = (File_config *)malloc(ntiles_out * sizeof(File_config));
+
+    if (nfiles == 2) {
+      file2_in = (File_config *)malloc(ntiles_in * sizeof(File_config));
+      file2_out = (File_config *)malloc(ntiles_out * sizeof(File_config));
     }
 
-    set_mosaic_data_file(ntiles_in, mosaic_in, dir_in, file_in,  input_file[0]);
+    set_mosaic_data_file(ntiles_in, mosaic_in, dir_in, file_in, input_file[0]);
     set_mosaic_data_file(ntiles_out, mosaic_out, dir_out, file_out, output_file[0]);
 
     vgrid_out.nz = 0;
     vgrid_in.nz = 0;
-    if(vertical_interp) {
+    if (vertical_interp) {
       get_output_vgrid(&vgrid_out, dst_vgrid);
       get_input_vgrid(&vgrid_in, file_in[0].name, scalar_name[0]);
       setup_vertical_interp(&vgrid_in, &vgrid_out);
     }
-  
-    if(nfiles == 2) {
-      set_mosaic_data_file(ntiles_in, mosaic_in, dir_in, file2_in,  input_file[1]);
-      set_mosaic_data_file(ntiles_out, mosaic_out, dir_out, file2_out, output_file[1]);    
+
+    if (nfiles == 2) {
+      set_mosaic_data_file(ntiles_in, mosaic_in, dir_in, file2_in, input_file[1]);
+      set_mosaic_data_file(ntiles_out, mosaic_out, dir_out, file2_out, output_file[1]);
     }
 
-    for(n=0; n<ntiles_in; n++) file_in[n].fid = mpp_open(file_in[n].name, MPP_READ);
+    //Open the input files. Save the nc formal of the first one.
+    int in_format_0 = -1;
+    for (n = 0; n < ntiles_in; n++) {
+      file_in[n].fid = mpp_open(file_in[n].name, MPP_READ);
+      if(n == 0) in_format_0 = in_format;
+    }
 
     nscalar_orig = nscalar;
     /* filter field with interp_method = "none"  */
     nscalar = 0;
-    for(n=0; n<nscalar_orig; n++) {
+    for (n = 0; n < nscalar_orig; n++) {
       int vid;
 
       vid = mpp_get_varid(file_in[0].fid, scalar_name[n]);
-      if(mpp_var_att_exist(file_in[0].fid, vid, "interp_method")) {
+      if (mpp_var_att_exist(file_in[0].fid, vid, "interp_method")) {
         char remap_method[STRING] = "";
         mpp_get_var_att(file_in[0].fid, vid, "interp_method", remap_method);
-        if(strcmp(remap_method, "none") && strcmp(remap_method, "NONE") && strcmp(remap_method, "None")) {
+        if (strcmp(remap_method, "none") && strcmp(remap_method, "NONE") && strcmp(remap_method, "None")) {
           strcpy(scalar_name_remap[nscalar], scalar_name[n]);
           nscalar++;
         }
-      }
-      else {
+      } else {
         strcpy(scalar_name_remap[nscalar], scalar_name[n]);
-          nscalar++;
+        nscalar++;
       }
     }
 
     /* when there is no scalar and vector to remap, simply return */
-    if(nscalar == 0 && nvector == 0) {
-      if(mpp_pe() == mpp_root_pe()) printf("NOTE from fregrid: no scalar and vector field need to be regridded.\n");
+    if (nscalar == 0 && nvector == 0) {
+      if (mpp_pe() == mpp_root_pe()) printf("NOTE from fregrid: no scalar and vector field need to be regridded.\n");
       mpp_end();
-      return 0;   
+      return 0;
     }
-    
-    if(nscalar > 0) {
-      scalar_in  = (Field_config *)malloc(ntiles_in *sizeof(Field_config));
-      scalar_out = (Field_config *)malloc(ntiles_out *sizeof(Field_config));
+
+    if (nscalar > 0) {
+      scalar_in = (Field_config *)malloc(ntiles_in * sizeof(Field_config));
+      scalar_out = (Field_config *)malloc(ntiles_out * sizeof(Field_config));
     }
-    if(nvector > 0) {
+    if (nvector > 0) {
       mpp_error("fregrid: currently does not support vertical interpolation, contact developer");
-      u_in  = (Field_config *)malloc(ntiles_in *sizeof(Field_config));
-      u_out = (Field_config *)malloc(ntiles_out *sizeof(Field_config));    
-      v_in  = (Field_config *)malloc(ntiles_in *sizeof(Field_config));
-      v_out = (Field_config *)malloc(ntiles_out *sizeof(Field_config));
-    }
-  
-    set_field_struct ( ntiles_in,   scalar_in,   nscalar, scalar_name_remap[0], file_in);
-    set_field_struct ( ntiles_out,  scalar_out,  nscalar, scalar_name_remap[0], file_out);
-    set_field_struct ( ntiles_in,   u_in,        nvector, u_name[0], file_in);
-    set_field_struct ( ntiles_out,  u_out,       nvector, u_name[0], file_out);
-    if(nfiles == 1) {
-      set_field_struct ( ntiles_in,   v_in,        nvector, v_name[0], file_in);
-      set_field_struct ( ntiles_out,  v_out,       nvector, v_name[0], file_out);
-    }
-    else {
-      set_field_struct ( ntiles_in,   v_in,        nvector, v_name[0], file2_in);
-      set_field_struct ( ntiles_out,  v_out,       nvector, v_name[0], file2_out);
+      u_in = (Field_config *)malloc(ntiles_in * sizeof(Field_config));
+      u_out = (Field_config *)malloc(ntiles_out * sizeof(Field_config));
+      v_in = (Field_config *)malloc(ntiles_in * sizeof(Field_config));
+      v_out = (Field_config *)malloc(ntiles_out * sizeof(Field_config));
     }
 
-    get_input_metadata(ntiles_in, nfiles, file_in, file2_in, scalar_in, u_in, v_in, grid_in,
-		       kbegin, kend, lbegin, lend, opcode, associated_file_dir);
+    set_field_struct(ntiles_in, scalar_in, nscalar, scalar_name_remap[0], file_in);
+    set_field_struct(ntiles_out, scalar_out, nscalar, scalar_name_remap[0], file_out);
+    set_field_struct(ntiles_in, u_in, nvector, u_name[0], file_in);
+    set_field_struct(ntiles_out, u_out, nvector, u_name[0], file_out);
+    if (nfiles == 1) {
+      set_field_struct(ntiles_in, v_in, nvector, v_name[0], file_in);
+      set_field_struct(ntiles_out, v_out, nvector, v_name[0], file_out);
+    } else {
+      set_field_struct(ntiles_in, v_in, nvector, v_name[0], file2_in);
+      set_field_struct(ntiles_out, v_out, nvector, v_name[0], file2_out);
+    }
 
-    set_weight_inf( ntiles_in, grid_in, weight_file, weight_field, file_in->has_cell_measure_att);
+    get_input_metadata(ntiles_in, nfiles, file_in, file2_in, scalar_in, u_in, v_in, grid_in, kbegin, kend, lbegin, lend,
+                       opcode, associated_file_dir);
 
-    set_in_format(format);
-    
-    set_output_metadata(ntiles_in, nfiles, file_in, file2_in, scalar_in, u_in, v_in,
-			ntiles_out, file_out, file2_out, scalar_out, u_out, v_out, grid_out, &vgrid_out, history, tagname, opcode,
-			deflation, shuffle);
+    set_weight_inf(ntiles_in, grid_in, weight_file, weight_field, file_in->has_cell_measure_att);
 
-    if(debug) print_mem_usage("After set_output_metadata");
-    /* when the interp_method specified through command line is CONSERVE_ORDER1, but the interp_method in the source file
-       field attribute is CONSERVE_ORDER2, need to modify the interp_method value */
-    if(opcode & CONSERVE_ORDER1) {
-      for(l=0; l<nscalar; l++) {
-	if(scalar_out->var[l].interp_method == CONSERVE_ORDER2) {
-	  if(mpp_pe() == mpp_root_pe())printf("NOTE from fregrid: even though the interp_method specified through command line is "
-					      "conserve_order1, the interp_method is reset to conserve_order2 because some fields in "
-					      "the source data have interp_method attribute value conserve_order2");
-	  opcode = opcode & ~CONSERVE_ORDER1;
-	  opcode |= CONSERVE_ORDER2;
-	  break;
-	}
+    //If the netcdf format was specified aas an input arguemnt, use that format. Otherwise
+    // use the format from the forst ( tile 0) input file.
+    if(format != NULL) {
+      set_in_format(format);
+    }else if (in_format_0 >= 0){
+      reset_in_format( in_format_0);
+    }else{
+      printf("WARNING: fregrid could not set in_format");
+    }
+
+    set_output_metadata(ntiles_in, nfiles, file_in, file2_in, scalar_in, u_in, v_in, ntiles_out, file_out, file2_out,
+                        scalar_out, u_out, v_out, grid_out, &vgrid_out, history, tagname, opcode, deflation, shuffle);
+
+    if (debug) print_mem_usage("After set_output_metadata");
+    /* when the interp_method specified through command line is CONSERVE_ORDER1, but the interp_method in the source
+       file field attribute is CONSERVE_ORDER2, need to modify the interp_method value */
+    if (opcode & CONSERVE_ORDER1) {
+      for (l = 0; l < nscalar; l++) {
+        if (scalar_out->var[l].interp_method == CONSERVE_ORDER2) {
+          if (mpp_pe() == mpp_root_pe())
+            printf(
+                "NOTE from fregrid: even though the interp_method specified through command line is "
+                "conserve_order1, the interp_method is reset to conserve_order2 because some fields in "
+                "the source data have interp_method attribute value conserve_order2");
+          opcode = opcode & ~CONSERVE_ORDER1;
+          opcode |= CONSERVE_ORDER2;
+          break;
+        }
       }
     }
-    if(opcode & CONSERVE_ORDER1) {
-      for(l=0; l<nvector; l++) {
-	if(u_out->var[l].interp_method == CONSERVE_ORDER2) {
-	  if(mpp_pe() == mpp_root_pe())printf("NOTE from fregrid: even though the interp_method specified through command line is "
-					      "conserve_order1, the interp_method is reset to conserve_order2 because some fields in "
-					      "the source data have interp_method attribute value conserve_order2");
-	  opcode = opcode & ~CONSERVE_ORDER1;
-	  opcode |= CONSERVE_ORDER2;
-	  break;
-	}
+    if (opcode & CONSERVE_ORDER1) {
+      for (l = 0; l < nvector; l++) {
+        if (u_out->var[l].interp_method == CONSERVE_ORDER2) {
+          if (mpp_pe() == mpp_root_pe())
+            printf(
+                "NOTE from fregrid: even though the interp_method specified through command line is "
+                "conserve_order1, the interp_method is reset to conserve_order2 because some fields in "
+                "the source data have interp_method attribute value conserve_order2");
+          opcode = opcode & ~CONSERVE_ORDER1;
+          opcode |= CONSERVE_ORDER2;
+          break;
+        }
       }
-    }    
+    }
   }
 
   /* preparing for the interpolation, if remapping information exist, read it from remap_file,
      otherwise create the remapping information and write it to remap_file
   */
 
-  if(debug) time_start = clock();
-  if( opcode & BILINEAR ) {  /* bilinear interpolation from cubic to lalon */
+  if (debug) time_start = clock();
+  if (opcode & BILINEAR) { /* bilinear interpolation from cubic to lalon */
     double dlon_in, dlat_in;
     double lonbegin_in, latbegin_in;
     /* when dlon_in is 0, bilinear_interp will use the default 2*M_PI */
-    if(fabs(lonend-lonbegin-360) < EPSLN10)
-      dlon_in = M_PI+M_PI;
+    if (fabs(lonend - lonbegin - 360) < EPSLN10)
+      dlon_in = M_PI + M_PI;
     else
-      dlon_in = (lonend-lonbegin)*D2R;
-    if(fabs(latend-latbegin-180) < EPSLN10)
+      dlon_in = (lonend - lonbegin) * D2R;
+    if (fabs(latend - latbegin - 180) < EPSLN10)
       dlat_in = M_PI;
     else
-      dlat_in = (latend-latbegin)*D2R;
-    if(fabs(lonbegin) < EPSLN10)
+      dlat_in = (latend - latbegin) * D2R;
+    if (fabs(lonbegin) < EPSLN10)
       lonbegin_in = 0.0;
     else
-      lonbegin_in = lonbegin*D2R;
-    if(fabs(latbegin+90) < EPSLN10)
-      latbegin_in = -0.5*M_PI;
+      lonbegin_in = lonbegin * D2R;
+    if (fabs(latbegin + 90) < EPSLN10)
+      latbegin_in = -0.5 * M_PI;
     else
-      latbegin_in = latbegin*D2R;
-    
-    setup_bilinear_interp(ntiles_in, grid_in, ntiles_out, grid_out, interp, opcode, dlon_in, dlat_in, lonbegin_in, latbegin_in );
+      latbegin_in = latbegin * D2R;
+
+    setup_bilinear_interp(ntiles_in, grid_in, ntiles_out, grid_out, interp, opcode, dlon_in, dlat_in, lonbegin_in,
+                          latbegin_in);
+  } else
+    setup_conserve_interp(ntiles_in, grid_in, ntiles_out, grid_out, interp, opcode);
+  if (debug) {
+    time_end = clock();
+    time_setup_interp = 1.0 * (time_end - time_start) / CLOCKS_PER_SEC;
+    print_mem_usage("After setup interp");
   }
-   else
-     setup_conserve_interp(ntiles_in, grid_in, ntiles_out, grid_out, interp, opcode);
-   if(debug) {
-     time_end = clock();
-     time_setup_interp = 1.0*(time_end - time_start)/CLOCKS_PER_SEC;
-     print_mem_usage("After setup interp");
-   }
-   if(debug) {
-      print_time("get_input_grid", time_get_in_grid);
-      print_time("get_output_grid", time_get_out_grid);
-      print_time("setup_interp", time_setup_interp);
-   }
-   if(save_weight_only) {
-     if(mpp_pe() == mpp_root_pe() ) {
-       printf("NOTE: Successfully running fregrid and the following files which store weight information are generated.\n");
-       for(n=0; n<ntiles_out; n++) {
-	 printf("****%s\n", interp[n].remap_file);
-       }
-     }
-     mpp_end();
-     return 0;     
-   }
-  
-   if(nscalar > 0) {
-     get_field_attribute(ntiles_in, scalar_in);
-     copy_field_attribute(ntiles_out, scalar_in, scalar_out);
-   }
-   
-   if(nvector > 0) {
-     get_field_attribute(ntiles_in, u_in);
-     get_field_attribute(ntiles_in, v_in);
-     copy_field_attribute(ntiles_out, u_in, u_out);
-     copy_field_attribute(ntiles_out, v_in, v_out);
-   }
+  if (debug) {
+    print_time("get_input_grid", time_get_in_grid);
+    print_time("get_output_grid", time_get_out_grid);
+    print_time("setup_interp", time_setup_interp);
+  }
+  if (save_weight_only) {
+    if (mpp_pe() == mpp_root_pe()) {
+      printf(
+          "NOTE: Successfully running fregrid and the following files which store weight information are generated.\n");
+      for (n = 0; n < ntiles_out; n++) {
+        printf("****%s\n", interp[n].remap_file);
+      }
+    }
+    mpp_end();
+    return 0;
+  }
 
+  if (nscalar > 0) {
+    get_field_attribute(ntiles_in, scalar_in);
+    copy_field_attribute(ntiles_out, scalar_in, scalar_out);
+  }
 
-  
-   /* set time step to 1, only test scalar field now, nz need to be 1 */
-   if(test_case) {
-     if(nscalar != 1 || nvector != 0) mpp_error("fregrid: when test_case is specified, nscalar must be 1 and nvector must be 0");
-     if(scalar_in->var->nz != 1) mpp_error("fregrid: when test_case is specified, number of vertical level must be 1");
-     file_in->nt = 1;
-     file_out->nt = 1;
-   }
-   
+  if (nvector > 0) {
+    get_field_attribute(ntiles_in, u_in);
+    get_field_attribute(ntiles_in, v_in);
+    copy_field_attribute(ntiles_out, u_in, u_out);
+    copy_field_attribute(ntiles_out, v_in, v_out);
+  }
+
+  /* set time step to 1, only test scalar field now, nz need to be 1 */
+  if (test_case) {
+    if (nscalar != 1 || nvector != 0)
+      mpp_error("fregrid: when test_case is specified, nscalar must be 1 and nvector must be 0");
+    if (scalar_in->var->nz != 1) mpp_error("fregrid: when test_case is specified, number of vertical level must be 1");
+    file_in->nt = 1;
+    file_out->nt = 1;
+  }
+
   /* Then doing the regridding */
-  for(m=0; m<file_in->nt; m++) {
+  for (m = 0; m < file_in->nt; m++) {
     int memsize, level_z, level_n, level_t;
 
     write_output_time(ntiles_out, file_out, m);
-    if(nfiles > 1) write_output_time(ntiles_out, file2_out, m);
-    
+    if (nfiles > 1) write_output_time(ntiles_out, file2_out, m);
+
     /* first interp scalar variable */
-    for(l=0; l<nscalar; l++) {
-      if( !scalar_in->var[l].has_taxis && m>0) continue;
-      if( !scalar_in->var[l].do_regrid ) continue;
+    for (l = 0; l < nscalar; l++) {
+      if (!scalar_in->var[l].has_taxis && m > 0) continue;
+      if (!scalar_in->var[l].do_regrid) continue;
       level_t = m + scalar_in->var[l].lstart;
       /*--- to reduce memory usage, we are only do remapping for on horizontal level one time */
-      for(level_n =0; level_n < scalar_in->var[l].nn; level_n++) {
-	if(extrapolate) {
-	  get_input_data(ntiles_in, scalar_in, grid_in, bound_T, l, -1, level_n, level_t, extrapolate, stop_crit);
-	  allocate_field_data(ntiles_out, scalar_out, grid_out, scalar_in->var[l].nz);
-	  if( opcode & BILINEAR ) 
-	    do_scalar_bilinear_interp(interp, l, ntiles_in, grid_in, grid_out, scalar_in, scalar_out, finer_step, fill_missing);
-	  else
-	    do_scalar_conserve_interp(interp, l, ntiles_in, grid_in, ntiles_out, grid_out, scalar_in, scalar_out, opcode, scalar_in->var[l].nz);
-          if(vertical_interp) do_vertical_interp(&vgrid_in, &vgrid_out, grid_out, scalar_out, l);
-	  write_field_data(ntiles_out, scalar_out, grid_out, l, -1, level_n, m);
-	  if(scalar_out->var[l].interp_method == CONSERVE_ORDER2) {
-	    for(n=0; n<ntiles_in; n++) {
-	      free(scalar_in[n].grad_x);
-	      free(scalar_in[n].grad_y);
-	    }
-	  }
-	  for(n=0; n<ntiles_in; n++) free(scalar_in[n].data);
-	  for(n=0; n<ntiles_out; n++) free(scalar_out[n].data);
-	}
-	else {
-	  for(level_z=scalar_in->var[l].kstart; level_z <= scalar_in->var[l].kend; level_z++)
-	    {	    
-              if(debug) time_start = clock();
-              if(test_case)
-		get_test_input_data(test_case, test_param, ntiles_in, scalar_in, grid_in, bound_T, opcode);
-	      else
-		get_input_data(ntiles_in, scalar_in, grid_in, bound_T, l, level_z, level_n, level_t, extrapolate, stop_crit);
-              if(debug) {
-	        time_end = clock();
-		time_get_input += 1.0*(time_end - time_start)/CLOCKS_PER_SEC;
-	      }
+      for (level_n = 0; level_n < scalar_in->var[l].nn; level_n++) {
+        if (extrapolate) {
+          get_input_data(ntiles_in, scalar_in, grid_in, bound_T, l, -1, level_n, level_t, extrapolate, stop_crit);
+          allocate_field_data(ntiles_out, scalar_out, grid_out, scalar_in->var[l].nz);
+          if (opcode & BILINEAR)
+            do_scalar_bilinear_interp(interp, l, ntiles_in, grid_in, grid_out, scalar_in, scalar_out, finer_step,
+                                      fill_missing);
+          else
+            do_scalar_conserve_interp(interp, l, ntiles_in, grid_in, ntiles_out, grid_out, scalar_in, scalar_out,
+                                      opcode, scalar_in->var[l].nz);
+          if (vertical_interp) do_vertical_interp(&vgrid_in, &vgrid_out, grid_out, scalar_out, l);
+          write_field_data(ntiles_out, scalar_out, grid_out, l, -1, level_n, m);
+          if (scalar_out->var[l].interp_method == CONSERVE_ORDER2) {
+            for (n = 0; n < ntiles_in; n++) {
+              free(scalar_in[n].grad_x);
+              free(scalar_in[n].grad_y);
+            }
+          }
+          for (n = 0; n < ntiles_in; n++) free(scalar_in[n].data);
+          for (n = 0; n < ntiles_out; n++) free(scalar_out[n].data);
+        } else {
+          for (level_z = scalar_in->var[l].kstart; level_z <= scalar_in->var[l].kend; level_z++) {
+            if (debug) time_start = clock();
+            if (test_case)
+              get_test_input_data(test_case, test_param, ntiles_in, scalar_in, grid_in, bound_T, opcode);
+            else
+              get_input_data(ntiles_in, scalar_in, grid_in, bound_T, l, level_z, level_n, level_t, extrapolate,
+                             stop_crit);
+            if (debug) {
+              time_end = clock();
+              time_get_input += 1.0 * (time_end - time_start) / CLOCKS_PER_SEC;
+            }
 
-	      allocate_field_data(ntiles_out, scalar_out, grid_out, 1);
-	      if(debug) time_start = clock();
-	      if( opcode & BILINEAR ) 
-		do_scalar_bilinear_interp(interp, l, ntiles_in, grid_in, grid_out, scalar_in, scalar_out, finer_step, fill_missing);
-	      else
-		do_scalar_conserve_interp(interp, l, ntiles_in, grid_in, ntiles_out, grid_out, scalar_in, scalar_out, opcode,1);
-              if(debug) {
-		time_end = clock();
-		time_do_interp += 1.0*(time_end - time_start)/CLOCKS_PER_SEC;
-	      }
+            allocate_field_data(ntiles_out, scalar_out, grid_out, 1);
+            if (debug) time_start = clock();
+            if (opcode & BILINEAR)
+              do_scalar_bilinear_interp(interp, l, ntiles_in, grid_in, grid_out, scalar_in, scalar_out, finer_step,
+                                        fill_missing);
+            else
+              do_scalar_conserve_interp(interp, l, ntiles_in, grid_in, ntiles_out, grid_out, scalar_in, scalar_out,
+                                        opcode, 1);
+            if (debug) {
+              time_end = clock();
+              time_do_interp += 1.0 * (time_end - time_start) / CLOCKS_PER_SEC;
+            }
 
-	      if(debug) time_start = clock();
-	      write_field_data(ntiles_out, scalar_out, grid_out, l, level_z, level_n, m);
-	      if(debug) {
-		time_end = clock();
-	        time_write += 1.0*(time_end - time_start)/CLOCKS_PER_SEC;
-	      }
-	      if(scalar_out->var[l].interp_method == CONSERVE_ORDER2) {
-		for(n=0; n<ntiles_in; n++) {
-		  free(scalar_in[n].grad_x);
-		  free(scalar_in[n].grad_y);
-		  free(scalar_in[n].grad_mask);
-		}
-	      }
-	      for(n=0; n<ntiles_in; n++) free(scalar_in[n].data);
-	      for(n=0; n<ntiles_out; n++) free(scalar_out[n].data);
-	    }
-	}
+            if (debug) time_start = clock();
+            write_field_data(ntiles_out, scalar_out, grid_out, l, level_z, level_n, m);
+            if (debug) {
+              time_end = clock();
+              time_write += 1.0 * (time_end - time_start) / CLOCKS_PER_SEC;
+            }
+            if (scalar_out->var[l].interp_method == CONSERVE_ORDER2) {
+              for (n = 0; n < ntiles_in; n++) {
+                free(scalar_in[n].grad_x);
+                free(scalar_in[n].grad_y);
+                free(scalar_in[n].grad_mask);
+              }
+            }
+            for (n = 0; n < ntiles_in; n++) free(scalar_in[n].data);
+            for (n = 0; n < ntiles_out; n++) free(scalar_out[n].data);
+          }
+        }
       }
     }
-   if(debug) print_mem_usage("After do interp");
+    if (debug) print_mem_usage("After do interp");
     /* then interp vector field */
-    for(l=0; l<nvector; l++) {
-      if( !u_in[n].var[l].has_taxis && m>0) continue;
+    for (l = 0; l < nvector; l++) {
+      if (!u_in[n].var[l].has_taxis && m > 0) continue;
       level_t = m + u_in->var[l].lstart;
       get_input_data(ntiles_in, u_in, grid_in, bound_T, l, level_z, level_n, level_t, extrapolate, stop_crit);
       get_input_data(ntiles_in, v_in, grid_in, bound_T, l, level_z, level_n, level_t, extrapolate, stop_crit);
       allocate_field_data(ntiles_out, u_out, grid_out, u_in[n].var[l].nz);
       allocate_field_data(ntiles_out, v_out, grid_out, u_in[n].var[l].nz);
-      if( opcode & BILINEAR )
-	do_vector_bilinear_interp(interp, l, ntiles_in, grid_in, ntiles_out, grid_out, u_in, v_in, u_out, v_out, finer_step, fill_missing);
+      if (opcode & BILINEAR)
+        do_vector_bilinear_interp(interp, l, ntiles_in, grid_in, ntiles_out, grid_out, u_in, v_in, u_out, v_out,
+                                  finer_step, fill_missing);
       else
-	do_vector_conserve_interp(interp, l, ntiles_in, grid_in, ntiles_out, grid_out, u_in, v_in, u_out, v_out, opcode);
-      
+        do_vector_conserve_interp(interp, l, ntiles_in, grid_in, ntiles_out, grid_out, u_in, v_in, u_out, v_out,
+                                  opcode);
+
       write_field_data(ntiles_out, u_out, grid_out, l, level_z, level_n, m);
       write_field_data(ntiles_out, v_out, grid_out, l, level_z, level_n, m);
-      for(n=0; n<ntiles_in; n++) {
-	free(u_in[n].data);
-	free(v_in[n].data);
+      for (n = 0; n < ntiles_in; n++) {
+        free(u_in[n].data);
+        free(v_in[n].data);
       }
-      for(n=0; n<ntiles_out; n++) {
-	free(u_out[n].data);
-	free(v_out[n].data);
-      }      
+      for (n = 0; n < ntiles_out; n++) {
+        free(u_out[n].data);
+        free(v_out[n].data);
+      }
     }
   }
 
-  if(debug) {
+  if (debug) {
     print_time("get_input", time_get_input);
     print_time("do_interp", time_do_interp);
     print_time("write_data", time_write);
   }
-  
-  if(mpp_pe() == mpp_root_pe() ) {
+
+  if (mpp_pe() == mpp_root_pe()) {
     printf("Successfully running fregrid and the following output file are generated.\n");
-    for(n=0; n<ntiles_out; n++) {
+    for (n = 0; n < ntiles_out; n++) {
       mpp_close(file_out[n].fid);
       printf("****%s\n", file_out[n].name);
-      if( nfiles > 1 ) {
-	mpp_close(file2_out[n].fid);
-	printf("****%s\n", file2_out[n].name);
+      if (nfiles > 1) {
+        mpp_close(file2_out[n].fid);
+        printf("****%s\n", file2_out[n].name);
       }
     }
   }
-      
+
   mpp_end();
   return 0;
-  
-} /* end of main */
-  
 
-  
-  
+} /* end of main */

--- a/tools/libfrencutils/mpp_io.c
+++ b/tools/libfrencutils/mpp_io.c
@@ -17,18 +17,20 @@
  * License along with FRE-NCTools.  If not, see
  * <http://www.gnu.org/licenses/>.
  **********************************************************************/
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdarg.h>
-#include <netcdf.h>
-#include "mpp.h"
-#include "mpp_domain.h"
 #include "mpp_io.h"
 
-#define  MAXFILE 200
-#define  MAXVAR  1024
-#define  STRING 255
+#include <netcdf.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mpp.h"
+#include "mpp_domain.h"
+
+#define MAXFILE 200
+#define MAXVAR 1024
+#define STRING 255
 
 typedef struct {
   int fldid;
@@ -37,33 +39,31 @@ typedef struct {
 } VarType;
 
 typedef struct {
-  int  ncid;
+  int ncid;
   char name[512];
-  int  action;  /* indicate the action, MPP_WRITE or MPP_READ */
-  int  status;  /* indicate if the file is opened or closed */
-  int  nvar;
+  int action; /* indicate the action, MPP_WRITE or MPP_READ */
+  int status; /* indicate if the file is opened or closed */
+  int nvar;
   VarType *var;
 } FileType;
 
 FileType files[MAXFILE];
-int      nfiles = 0;
+int nfiles = 0;
 
-int      in_format = NC_FORMAT_NETCDF4_CLASSIC;
+int in_format = NC_FORMAT_NETCDF4_CLASSIC;
 
 /*********************************************************************
     void netcdf_error( int status )
     status is the returning value of netcdf call. this routine will
     handle the error when status is not NC_NOERR.
 ********************************************************************/
-void netcdf_error(const char *msg, int status )
-{
+void netcdf_error(const char *msg, int status) {
   char errmsg[512];
 
-  sprintf( errmsg, "%s: %s", msg, nc_strerror(status) );
+  sprintf(errmsg, "%s: %s", msg, nc_strerror(status));
   mpp_error(errmsg);
 
 }; /* netcdf_error */
-
 
 /*************************************************************
  int mpp_open(char *filename, int action)
@@ -78,163 +78,164 @@ void netcdf_error(const char *msg, int status )
 
 int mpp_open(const char *file, int action) {
   char curfile[STRING];
-  char errmsg[512];  
+  char errmsg[512];
   int ncid, status, istat, n, fid;
   static int first_call = 1;
-  static size_t blksz=1048576;
+  static size_t blksz = 1048576;
 
   /* read the blksz from environment variable for the first_call */
-  if(first_call) {
+  if (first_call) {
     char *blkstr;
     int len;
     first_call = 0;
-    blkstr=getenv ("NC_BLKSZ");
-    if(blkstr) {
-      len=strlen(blkstr);
+    blkstr = getenv("NC_BLKSZ");
+    if (blkstr) {
+      len = strlen(blkstr);
       /* check to make sure each character is either number of 'K' or 'M' */
-      for(n=0; n<len; n++) {
-	if( n == len-1 ) { /* the last character might be K or M */
-	  if( (blkstr[n]  > '9' || blkstr[n] < '0') && blkstr[n] != 'K' &&  blkstr[n] != 'M'  ) {
-	    sprintf( errmsg, "mpp_io(mpp_open): the last charactor of environment variable NC_BLKSZ = %s "
-		     "should be digit, 'K' or 'M'", blkstr);
-	    mpp_error(errmsg);
-	  }
-	}
-	else if( blkstr[n] > '9' || blkstr[n] < '0' ) {
-	    sprintf( errmsg, "mpp_io(mpp_open): environment variable NC_BLKSZ = %s "
-		     "should only contain digit except the last character", blkstr);
-	    printf("error 2 = %s\n", errmsg);
-	    mpp_error(errmsg);
-	}
+      for (n = 0; n < len; n++) {
+        if (n == len - 1) { /* the last character might be K or M */
+          if ((blkstr[n] > '9' || blkstr[n] < '0') && blkstr[n] != 'K' && blkstr[n] != 'M') {
+            sprintf(errmsg,
+                    "mpp_io(mpp_open): the last charactor of environment variable NC_BLKSZ = %s "
+                    "should be digit, 'K' or 'M'",
+                    blkstr);
+            mpp_error(errmsg);
+          }
+        } else if (blkstr[n] > '9' || blkstr[n] < '0') {
+          sprintf(errmsg,
+                  "mpp_io(mpp_open): environment variable NC_BLKSZ = %s "
+                  "should only contain digit except the last character",
+                  blkstr);
+          printf("error 2 = %s\n", errmsg);
+          mpp_error(errmsg);
+        }
       }
       blksz = atoi(blkstr);
-      if( blkstr[len-1] == 'K' )
-	blksz *= 1024;
-      else if( blkstr[len-1] == 'M' )
-        blksz *= (1024*1024);
+      if (blkstr[len - 1] == 'K')
+        blksz *= 1024;
+      else if (blkstr[len - 1] == 'M')
+        blksz *= (1024 * 1024);
     }
+  }
 
-  }      
-  
   /* write only from root pe. */
-  if(action != MPP_READ && mpp_pe() != mpp_root_pe() ) return -1;
+  if (action != MPP_READ && mpp_pe() != mpp_root_pe()) return -1;
   /*if file is not ended with .nc add .nc at the end. */
   strcpy(curfile, file);
-  if(strstr(curfile, ".nc") == NULL) strcat(curfile,".nc");
+  if (strstr(curfile, ".nc") == NULL) strcat(curfile, ".nc");
 
   /* look through currently files to make sure the file is not in the list*/
   fid = -1;
-  for(n=0; n<nfiles; n++) {
-    if(!strcmp(files[n].name, file) && files[n].action == action) {
+  for (n = 0; n < nfiles; n++) {
+    if (!strcmp(files[n].name, file) && files[n].action == action) {
       fid = n;
       break;
     }
   }
-  if(fid > -1) {
-    if(files[n].action == MPP_WRITE) {
-      sprintf( errmsg, "mpp_io(mpp_open): %s is already created for write", file);
+  if (fid > -1) {
+    if (files[n].action == MPP_WRITE) {
+      sprintf(errmsg, "mpp_io(mpp_open): %s is already created for write", file);
       mpp_error(errmsg);
     }
-    if(files[n].status) {
-      sprintf( errmsg, "mpp_io(mpp_open): %s is already opened", file);
+    if (files[n].status) {
+      sprintf(errmsg, "mpp_io(mpp_open): %s is already opened", file);
       mpp_error(errmsg);
     }
-  }
-  else {
+  } else {
     fid = nfiles;
     nfiles++;
-    if(nfiles > MAXFILE) mpp_error("mpp_io(mpp_open): nfiles is larger than MAXFILE, increase MAXFILE");
+    if (nfiles > MAXFILE) mpp_error("mpp_io(mpp_open): nfiles is larger than MAXFILE, increase MAXFILE");
     strcpy(files[fid].name, file);
     files[fid].nvar = 0;
-    files[fid].var = (VarType *)malloc(MAXVAR*sizeof(VarType));
+    files[fid].var = (VarType *)malloc(MAXVAR * sizeof(VarType));
   }
   switch (action) {
-  case MPP_WRITE:
+    case MPP_WRITE:
 #ifdef use_netCDF3
 #ifdef NC_64BIT_OFFSET
-    status = nc_create(curfile, NC_64BIT_OFFSET, &ncid);
+      status = nc_create(curfile, NC_64BIT_OFFSET, &ncid);
 #else
-    status = nc_create(curfile, NC_WRITE, &ncid);
+      status = nc_create(curfile, NC_WRITE, &ncid);
 #endif
 #elif use_netCDF4
-       status = nc__create(curfile, NC_NETCDF4, 0, &blksz, &ncid);
+      status = nc__create(curfile, NC_NETCDF4, 0, &blksz, &ncid);
 #else
-    switch (in_format) {
-      case NC_FORMAT_NETCDF4:
-        status = nc__create(curfile, NC_NETCDF4, 0, &blksz, &ncid);
-        break;
-      case NC_FORMAT_NETCDF4_CLASSIC:
-        status = nc__create(curfile, NC_NETCDF4 | NC_CLASSIC_MODEL, 0, &blksz, &ncid);
-        break;
-      case NC_FORMAT_64BIT:
-        status = nc__create(curfile, NC_CLOBBER | NC_64BIT_OFFSET, 0, &blksz, &ncid);
-        break;
-      case NC_FORMAT_CLASSIC:
-        status = nc__create(curfile, NC_CLOBBER | NC_CLASSIC_MODEL, 0, &blksz, &ncid);
-        break;
-      default:
-        sprintf(errmsg, "mpp_io(mpp_open): Unknown netCDF format");
-        mpp_error(errmsg);
-    }
+      switch (in_format) {
+        case NC_FORMAT_NETCDF4:
+          status = nc__create(curfile, NC_NETCDF4, 0, &blksz, &ncid);
+          break;
+        case NC_FORMAT_NETCDF4_CLASSIC:
+          status = nc__create(curfile, NC_NETCDF4 | NC_CLASSIC_MODEL, 0, &blksz, &ncid);
+          break;
+        case NC_FORMAT_64BIT:
+          status = nc__create(curfile, NC_CLOBBER | NC_64BIT_OFFSET, 0, &blksz, &ncid);
+          break;
+        case NC_FORMAT_CLASSIC:
+          status = nc__create(curfile, NC_CLOBBER | NC_CLASSIC_MODEL, 0, &blksz, &ncid);
+          break;
+        default:
+          sprintf(errmsg, "mpp_io(mpp_open): Unknown netCDF format");
+          mpp_error(errmsg);
+      }
 #endif
-    break;
-  case MPP_APPEND:
-    status = nc_open(curfile, NC_WRITE, &ncid);
-    break;
-  case MPP_READ:
-    status = nc_open(curfile,NC_NOWRITE, &ncid);
+      break;
+    case MPP_APPEND:
+      status = nc_open(curfile, NC_WRITE, &ncid);
+      break;
+    case MPP_READ:
+      status = nc_open(curfile, NC_NOWRITE, &ncid);
 #ifndef use_netCDF3
-    istat = nc_inq_format(ncid,&in_format);
+      istat = nc_inq_format(ncid, &in_format);
 #endif
-    break;
-  default:
-    sprintf(errmsg, "mpp_io(mpp_open): the action should be MPP_WRITE or MPP_READ when opening file %s", file);
-    mpp_error(errmsg);
+      break;
+    default:
+      sprintf(errmsg, "mpp_io(mpp_open): the action should be MPP_WRITE or MPP_READ when opening file %s", file);
+      mpp_error(errmsg);
   }
-  
-  if(status != NC_NOERR) {
+
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_open): error in opening file %s", file);
     netcdf_error(errmsg, status);
   }
 
-  files[fid].ncid   = ncid;
+  files[fid].ncid = ncid;
   files[fid].status = 1;
   files[fid].action = action;
-  
+
   return fid;
 }
 
 /* close the file */
-void mpp_close(int fid)
-{
+void mpp_close(int fid) {
   int status;
   char errmsg[512];
 
-  if(fid == -1 && mpp_pe() != mpp_root_pe() ) return;
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_close): invalid id number, id should be "
-				    "a nonnegative integer that less than nfiles");
-  
+  if (fid == -1 && mpp_pe() != mpp_root_pe()) return;
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_close): invalid id number, id should be "
+        "a nonnegative integer that less than nfiles");
+
   status = nc_close(files[fid].ncid);
-  if(status != NC_NOERR) {
-    sprintf( errmsg, "mpp_io(mpp_close): error in closing files %s ", files[fid].name);
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_close): error in closing files %s ", files[fid].name);
     netcdf_error(errmsg, status);
   }
   files[fid].ncid = 0;
   files[fid].status = 0;
-  
 }
 
-
-int mpp_get_nvars(int fid)
-{
+int mpp_get_nvars(int fid) {
   int nvars, status;
   char errmsg[512];
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_nvars): invalid id number, id should be "
-				    "a nonnegative integer that less than nfiles"); 
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_nvars): invalid id number, id should be "
+        "a nonnegative integer that less than nfiles");
   status = nc_inq_nvars(files[fid].ncid, &nvars);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_nvars): error in get nvars from file %s", files[fid].name);
     netcdf_error(errmsg, status);
   }
@@ -242,49 +243,46 @@ int mpp_get_nvars(int fid)
   return nvars;
 }
 
-void mpp_get_varname(int fid, int varid, char *name)
-{
-
-  int  status;
+void mpp_get_varname(int fid, int varid, char *name) {
+  int status;
   char errmsg[512];
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_varname): invalid id number, id should be "
-				    "a nonnegative integer that less than nfiles"); 
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_varname): invalid id number, id should be "
+        "a nonnegative integer that less than nfiles");
   status = nc_inq_varname(files[fid].ncid, varid, name);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_varname): error in get varname from file %s", files[fid].name);
     netcdf_error(errmsg, status);
-  }  
- 
+  }
 }
 
-int mpp_get_record_name(int fid, char *name)
-{
+int mpp_get_record_name(int fid, char *name) {
   int dimid, status;
   char errmsg[512];
   int record_exist;
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_record_name): invalid id number, id should be "
-				    "a nonnegative integer that less than nfiles");    
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_record_name): invalid id number, id should be "
+        "a nonnegative integer that less than nfiles");
   status = nc_inq_unlimdim(files[fid].ncid, &dimid);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_record_name): error in get record id from file %s", files[fid].name);
     netcdf_error(errmsg, status);
-  }  
-  if(dimid >=0) {
+  }
+  if (dimid >= 0) {
     record_exist = 1;
     status = nc_inq_dimname(files[fid].ncid, dimid, name);
-    if(status != NC_NOERR) {
+    if (status != NC_NOERR) {
       sprintf(errmsg, "mpp_io(mpp_get_record_name): error in get record name from file %s", files[fid].name);
       netcdf_error(errmsg, status);
     }
-  }
-  else {
+  } else {
     record_exist = 0;
   }
   return record_exist;
 }
-
-  
 
 /*******************************************************************************/
 /*                                                                             */
@@ -294,232 +292,249 @@ int mpp_get_record_name(int fid, char *name)
 
 /*********************************************************************
   int mpp_get_dimid(int fid, const char *dimname)
-  get the id of the dimname from file with fid, 
+  get the id of the dimname from file with fid,
 *********************************************************************/
-int mpp_get_dimid(int fid, const char *dimname)
-{
+int mpp_get_dimid(int fid, const char *dimname) {
   int status, dimid;
   char errmsg[512];
-  
+
   /* First look through existing variables to see
      if the fldid of varname is already retrieved. */
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_dimid): invalid id number, id should be "
-				    "a nonnegative integer that less than nfiles");
-  
-  status =  nc_inq_dimid(files[fid].ncid, dimname, &dimid);
-  if(status != NC_NOERR) {
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_dimid): invalid id number, id should be "
+        "a nonnegative integer that less than nfiles");
+
+  status = nc_inq_dimid(files[fid].ncid, dimname, &dimid);
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_dimid): error in get dimension id of %s from file %s", dimname, files[fid].name);
     netcdf_error(errmsg, status);
   }
 
   return dimid;
 
-};/* mpp_get_dimid */
-
+}; /* mpp_get_dimid */
 
 /*********************************************************************
   int mpp_get_varid(int fid, const char *varname)
   get the id of the varname from file with fid, the id will be the index
   in files[fid].var.
 *********************************************************************/
-int mpp_get_varid(int fid, const char *varname)
-{
+int mpp_get_varid(int fid, const char *varname) {
   int status, fldid, vid, n;
   char errmsg[512];
-  
+
   /* First look through existing variables to see
      if the fldid of varname is already retrieved. */
-  if(files[fid].action != MPP_READ  && mpp_pe() != mpp_root_pe() ) return -1;
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_varid): invalid id number, id should be "
-				    "a nonnegative integer that less than nfiles");
-  
-  for(n=0; n<files[fid].nvar; n++) {
-    if( !strcmp(files[fid].var[n].name, varname) ) return n;
+  if (files[fid].action != MPP_READ && mpp_pe() != mpp_root_pe()) return -1;
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_varid): invalid id number, id should be "
+        "a nonnegative integer that less than nfiles");
+
+  for (n = 0; n < files[fid].nvar; n++) {
+    if (!strcmp(files[fid].var[n].name, varname)) return n;
   }
 
   vid = files[fid].nvar;
   files[fid].nvar++;
-  if(files[fid].nvar > MAXVAR ) mpp_error("mpp_io(mpp_get_varid): nvar is larger than MAXVAR, increase MAXVAR");
-  
-  status =  nc_inq_varid(files[fid].ncid, varname, &fldid);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_varid): error in get field_id of variable %s from file %s", varname, files[fid].name);
+  if (files[fid].nvar > MAXVAR) mpp_error("mpp_io(mpp_get_varid): nvar is larger than MAXVAR, increase MAXVAR");
+
+  status = nc_inq_varid(files[fid].ncid, varname, &fldid);
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_varid): error in get field_id of variable %s from file %s", varname,
+            files[fid].name);
     netcdf_error(errmsg, status);
   }
 
   status = nc_inq_vartype(files[fid].ncid, fldid, &(files[fid].var[vid].type));
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_varid): Error in getting type of of field %s in file %s ",
-	    files[fid].var[vid].name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_varid): Error in getting type of of field %s in file %s ", files[fid].var[vid].name,
+            files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
+
   files[fid].var[vid].fldid = fldid;
   strcpy(files[fid].var[vid].name, varname);
   return vid;
 
-};/* mpp_get_varid */
+}; /* mpp_get_varid */
 
 /********************************************************************
   int mpp_get_dimlen(char* file, char *name)
   Get the dimension.
  *******************************************************************/
-int mpp_get_dimlen(int fid, const char *name)
-{
+int mpp_get_dimlen(int fid, const char *name) {
   int ncid, dimid, status, len;
   size_t size;
   char errmsg[512];
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_dimlen): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_dimlen): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
   ncid = files[fid].ncid;
   status = nc_inq_dimid(ncid, name, &dimid);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_dimlen): error in inquiring dimid of %s from file %s", name, files[fid].name);
     netcdf_error(errmsg, status);
   }
   status = nc_inq_dimlen(ncid, dimid, &size);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_dimlen): error in inquiring dimlen of %s from file %s", name, files[fid].name);
     netcdf_error(errmsg, status);
   }
   len = size;
   return len;
-  
+
 }; /* mpp_get_dimlen */
 
 /*********************************************************************
   void mpp_get_var_value(int fid, int vid, void *data)
   read part of var data, the part is defined by start and nread.
 *********************************************************************/
-void mpp_get_var_value(int fid, int vid, void *data)
-{
+void mpp_get_var_value(int fid, int vid, void *data) {
   int status;
   int *data_i4;
   short *data_i2;
   float *data_r4;
   char errmsg[512];
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_value_block): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_value_block): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
 
-  switch(files[fid].var[vid].type) {
-  case NC_DOUBLE:case NC_FLOAT:
-    status = nc_get_var_double(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break;
-  case NC_INT:
-    status = nc_get_var_int(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break;
-  case NC_SHORT:
-    status = nc_get_var_short(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break;    
-  case NC_CHAR:
-    status = nc_get_var_text(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break; 
-  default:
-    sprintf(errmsg, "mpp_io(mpp_get_var_value): field %s in file %s has an invalid type, "
-	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
-	    files[fid].var[vid].name, files[fid].name );
-    mpp_error(errmsg);
-  }    
-  if(status != NC_NOERR) {
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_value_block): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_get_var_value_block): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
+
+  switch (files[fid].var[vid].type) {
+    case NC_DOUBLE:
+    case NC_FLOAT:
+      status = nc_get_var_double(files[fid].ncid, files[fid].var[vid].fldid, data);
+      break;
+    case NC_INT:
+      status = nc_get_var_int(files[fid].ncid, files[fid].var[vid].fldid, data);
+      break;
+    case NC_SHORT:
+      status = nc_get_var_short(files[fid].ncid, files[fid].var[vid].fldid, data);
+      break;
+    case NC_CHAR:
+      status = nc_get_var_text(files[fid].ncid, files[fid].var[vid].fldid, data);
+      break;
+    default:
+      sprintf(errmsg,
+              "mpp_io(mpp_get_var_value): field %s in file %s has an invalid type, "
+              "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
+              files[fid].var[vid].name, files[fid].name);
+      mpp_error(errmsg);
+  }
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_value): Error in getting value of variable %s from file %s",
-	    files[fid].var[vid].name, files[fid].name );
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_get_var_value */
 
 /*********************************************************************
   void mpp_get_var_value_block(int fid, int vid, const size_t *start, const size_t *nread, void *data)
   read part of var data, the part is defined by start and nread.
 *********************************************************************/
-void mpp_get_var_value_block(int fid, int vid, const size_t *start, const size_t *nread, void *data)
-{
+void mpp_get_var_value_block(int fid, int vid, const size_t *start, const size_t *nread, void *data) {
   int status;
   char errmsg[512];
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_value_block): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_value_block): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
 
-  switch(files[fid].var[vid].type) {
-  case NC_DOUBLE:case NC_FLOAT:
-    status = nc_get_vara_double(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
-    break;
-  case NC_INT:
-    status = nc_get_vara_int(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
-    break;
-  case NC_SHORT:
-    status = nc_get_vara_short(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
-    break;  
-  case NC_CHAR:
-    status = nc_get_vara_text(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
-    break; 
-  default:
-    sprintf(errmsg, "mpp_io(mpp_get_var_value_block): field %s in file %s has an invalid type, "
-	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
-	    files[fid].var[vid].name, files[fid].name );
-    mpp_error(errmsg);
-  }    
-  if(status != NC_NOERR) {
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_value_block): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_get_var_value_block): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
+
+  switch (files[fid].var[vid].type) {
+    case NC_DOUBLE:
+    case NC_FLOAT:
+      status = nc_get_vara_double(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
+      break;
+    case NC_INT:
+      status = nc_get_vara_int(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
+      break;
+    case NC_SHORT:
+      status = nc_get_vara_short(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
+      break;
+    case NC_CHAR:
+      status = nc_get_vara_text(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
+      break;
+    default:
+      sprintf(errmsg,
+              "mpp_io(mpp_get_var_value_block): field %s in file %s has an invalid type, "
+              "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
+              files[fid].var[vid].name, files[fid].name);
+      mpp_error(errmsg);
+  }
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_value_block): Error in getting value of variable %s from file %s",
-	    files[fid].var[vid].name, files[fid].name );
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_get_var_value_block */
 
 /*******************************************************************
  void mpp_get_var_att(int fid, int vid, const char *name, void *val)
  get the attribute value of vid from file fid.
  ******************************************************************/
-void mpp_get_var_att(int fid, int vid, const char *name, void *val)
-{
+void mpp_get_var_att(int fid, int vid, const char *name, void *val) {
   int status;
   char errmsg[512];
   nc_type type;
 
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_att): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_att): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_att): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_get_var_att): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
 
   status = nc_inq_atttype(files[fid].ncid, files[fid].var[vid].fldid, name, &type);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting type of attribute %s of field %s in file %s ",
-	    name, files[fid].var[vid].name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting type of attribute %s of field %s in file %s ", name,
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
-  switch(type) {
-  case NC_DOUBLE:case NC_FLOAT:
-    status = nc_get_att_double(files[fid].ncid, files[fid].var[vid].fldid, name, val);
-    break;
-  case NC_INT:
-    status = nc_get_att_int(files[fid].ncid, files[fid].var[vid].fldid, name, val);
-    break;      
-  case NC_SHORT:
-    status = nc_get_att_short(files[fid].ncid, files[fid].var[vid].fldid, name, val);
-    break;
-  case NC_CHAR:
-    status = nc_get_att_text(files[fid].ncid, files[fid].var[vid].fldid, name, val);
-    break;    
-  default:
-    sprintf(errmsg, "mpp_io(mpp_get_var_att): attribute %s of field %s in file %s has an invalid type, "
-	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
-	    name, files[fid].var[vid].name, files[fid].name );
-    mpp_error(errmsg);
+
+  switch (type) {
+    case NC_DOUBLE:
+    case NC_FLOAT:
+      status = nc_get_att_double(files[fid].ncid, files[fid].var[vid].fldid, name, val);
+      break;
+    case NC_INT:
+      status = nc_get_att_int(files[fid].ncid, files[fid].var[vid].fldid, name, val);
+      break;
+    case NC_SHORT:
+      status = nc_get_att_short(files[fid].ncid, files[fid].var[vid].fldid, name, val);
+      break;
+    case NC_CHAR:
+      status = nc_get_att_text(files[fid].ncid, files[fid].var[vid].fldid, name, val);
+      break;
+    default:
+      sprintf(errmsg,
+              "mpp_io(mpp_get_var_att): attribute %s of field %s in file %s has an invalid type, "
+              "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
+              name, files[fid].var[vid].name, files[fid].name);
+      mpp_error(errmsg);
   }
-  
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting value of attribute %s of variable %s from file %s",
-	    name, files[fid].var[vid].name, files[fid].name );
+
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting value of attribute %s of variable %s from file %s", name,
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
 }
@@ -528,48 +543,53 @@ void mpp_get_var_att(int fid, int vid, const char *name, void *val)
  void mpp_get_var_att_double(int fid, int vid, const char *name, double *val)
  get the attribute value of vid from file fid.
  ******************************************************************/
-void mpp_get_var_att_double(int fid, int vid, const char *name, double *val)
-{
+void mpp_get_var_att_double(int fid, int vid, const char *name, double *val) {
   int status;
   char errmsg[512];
   nc_type type;
   short sval;
-  int   ival;
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_att): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_att): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
+  int ival;
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_att): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_get_var_att): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
 
   status = nc_inq_atttype(files[fid].ncid, files[fid].var[vid].fldid, name, &type);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting type of attribute %s of field %s in file %s ",
-	    name, files[fid].var[vid].name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting type of attribute %s of field %s in file %s ", name,
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
-  switch(type) {
-  case NC_DOUBLE:case NC_FLOAT:
-    status = nc_get_att_double(files[fid].ncid, files[fid].var[vid].fldid, name, val);
-    break;
-  case NC_INT:
-    status = nc_get_att_int(files[fid].ncid, files[fid].var[vid].fldid, name, &ival);
-    *val = ival;
-    break;      
-  case NC_SHORT:
-    status = nc_get_att_short(files[fid].ncid, files[fid].var[vid].fldid, name, &sval);
-    *val = sval;
-    break;
-  default:
-    sprintf(errmsg, "mpp_io(mpp_get_var_att): attribute %s of field %s in file %s has an invalid type, "
-	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
-	    name, files[fid].var[vid].name, files[fid].name );
-    mpp_error(errmsg);
+
+  switch (type) {
+    case NC_DOUBLE:
+    case NC_FLOAT:
+      status = nc_get_att_double(files[fid].ncid, files[fid].var[vid].fldid, name, val);
+      break;
+    case NC_INT:
+      status = nc_get_att_int(files[fid].ncid, files[fid].var[vid].fldid, name, &ival);
+      *val = ival;
+      break;
+    case NC_SHORT:
+      status = nc_get_att_short(files[fid].ncid, files[fid].var[vid].fldid, name, &sval);
+      *val = sval;
+      break;
+    default:
+      sprintf(errmsg,
+              "mpp_io(mpp_get_var_att): attribute %s of field %s in file %s has an invalid type, "
+              "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
+              name, files[fid].var[vid].name, files[fid].name);
+      mpp_error(errmsg);
   }
-  
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting value of attribute %s of variable %s from file %s",
-	    name, files[fid].var[vid].name, files[fid].name );
+
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting value of attribute %s of variable %s from file %s", name,
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
 }
@@ -578,78 +598,83 @@ void mpp_get_var_att_double(int fid, int vid, const char *name, double *val)
  void mpp_get_global_att(int fid, const char *name, void *val)
  get the global attribute from file fid.
  ******************************************************************/
-void mpp_get_global_att(int fid, const char *name, void *val)
-{
+void mpp_get_global_att(int fid, const char *name, void *val) {
   int status;
   char errmsg[512], attval[4096];
   nc_type type;
   size_t attlen;
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_global_att): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_global_att): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
   status = nc_inq_atttype(files[fid].ncid, NC_GLOBAL, name, &type);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_global_att): Error in getting type of global attribute %s in file %s ",
-	    name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_global_att): Error in getting type of global attribute %s in file %s ", name,
+            files[fid].name);
     netcdf_error(errmsg, status);
   }
 
-  
-  switch(type) {
-  case NC_DOUBLE:case NC_FLOAT:
-    status = nc_get_att_double(files[fid].ncid, NC_GLOBAL, name, val);
-    break;
-  case NC_INT:
-    status = nc_get_att_int(files[fid].ncid, NC_GLOBAL, name, val);
-    break;
-  case NC_SHORT:
-    status = nc_get_att_short(files[fid].ncid, NC_GLOBAL, name, val);
-    break;  
-  case NC_CHAR:
-    status = nc_inq_attlen(files[fid].ncid, NC_GLOBAL, name, &attlen);
-    if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_get_global_att): Error in getting length of global attribute %s from file %s",
-	      name, files[fid].name );
-      netcdf_error(errmsg, status);
-    }
-    status = nc_get_att_text(files[fid].ncid, NC_GLOBAL, name, attval);
-    attval[attlen] = '\0';
-    strncpy(val, attval, attlen+1);
-    break;  
-  default:
-    sprintf(errmsg, "mpp_io(mpp_get_global_att): global attribute %s in file %s has an invalid type, "
-	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR", name, files[fid].name );
-    mpp_error(errmsg);
-  }
-  
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_global_att): Error in getting value of global attribute %s from file %s",
-	    name, files[fid].name );
-    netcdf_error(errmsg, status);
+  switch (type) {
+    case NC_DOUBLE:
+    case NC_FLOAT:
+      status = nc_get_att_double(files[fid].ncid, NC_GLOBAL, name, val);
+      break;
+    case NC_INT:
+      status = nc_get_att_int(files[fid].ncid, NC_GLOBAL, name, val);
+      break;
+    case NC_SHORT:
+      status = nc_get_att_short(files[fid].ncid, NC_GLOBAL, name, val);
+      break;
+    case NC_CHAR:
+      status = nc_inq_attlen(files[fid].ncid, NC_GLOBAL, name, &attlen);
+      if (status != NC_NOERR) {
+        sprintf(errmsg, "mpp_io(mpp_get_global_att): Error in getting length of global attribute %s from file %s", name,
+                files[fid].name);
+        netcdf_error(errmsg, status);
+      }
+      status = nc_get_att_text(files[fid].ncid, NC_GLOBAL, name, attval);
+      attval[attlen] = '\0';
+      strncpy(val, attval, attlen + 1);
+      break;
+    default:
+      sprintf(errmsg,
+              "mpp_io(mpp_get_global_att): global attribute %s in file %s has an invalid type, "
+              "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
+              name, files[fid].name);
+      mpp_error(errmsg);
   }
 
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_global_att): Error in getting value of global attribute %s from file %s", name,
+            files[fid].name);
+    netcdf_error(errmsg, status);
+  }
 }
 
 /********************************************************************
   int mpp_get_var_ndim(int fid, int vid)
 ********************************************************************/
-int mpp_get_var_ndim(int fid, int vid)
-{
+int mpp_get_var_ndim(int fid, int vid) {
   int status, ndim;
   char errmsg[512];
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_ndim): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_ndim): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
-  
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_ndim): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_get_var_ndim): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
+
   status = nc_inq_varndims(files[fid].ncid, files[fid].var[vid].fldid, &ndim);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_var_ndim): Error in getting ndims of var %s from file %s",
-	    files[fid].var[vid].name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_var_ndim): Error in getting ndims of var %s from file %s", files[fid].var[vid].name,
+            files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
+
   return ndim;
 }
 
@@ -657,94 +682,102 @@ int mpp_get_var_ndim(int fid, int vid)
   nc_type mpp_get_var_type(int fid, int vid)
   get var type
 ********************************************************************/
-nc_type mpp_get_var_type(int fid, int vid)
-{
+nc_type mpp_get_var_type(int fid, int vid) {
   char errmsg[512];
-  
+
   nc_type vartype;
   int status;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_ndim): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_ndim): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
-  
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_ndim): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_get_var_ndim): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
+
   status = nc_inq_vartype(files[fid].ncid, files[fid].var[vid].fldid, &vartype);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_var_type): Error in getting type of var %s from file %s",
-	    files[fid].var[vid].name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_var_type): Error in getting type of var %s from file %s", files[fid].var[vid].name,
+            files[fid].name);
     netcdf_error(errmsg, status);
   }
 
   return vartype;
 }
 
-
 /*********************************************************************
 void mpp_get_var_dimname(int fid, int vid, int i, char *name)
 For each dimension we are assuming there is a 1-d field have the same name as the dimension.
 *********************************************************************/
-void mpp_get_var_dimname(int fid, int vid, int ind, char *name)
-{
+void mpp_get_var_dimname(int fid, int vid, int ind, char *name) {
   int status, ncid, fldid, ndims, dims[4];
   char errmsg[512];
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_dimname): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_dimname): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_dimname): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_get_var_dimname): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
   ncid = files[fid].ncid;
   fldid = files[fid].var[vid].fldid;
-  
+
   status = nc_inq_varndims(ncid, fldid, &ndims);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var2D_dimname): Error in getting ndims of var %s from file %s",
-	    files[fid].var[vid].name, files[fid].name );
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
 
-  if(ind < 0 || ind >= ndims) mpp_error("mpp_io(mpp_get_var_dimname): invalid ind value, ind should be between 0 and ndim-1");
-  
-  status = nc_inq_vardimid(ncid,fldid,dims);
-  if(status != NC_NOERR) {
+  if (ind < 0 || ind >= ndims)
+    mpp_error("mpp_io(mpp_get_var_dimname): invalid ind value, ind should be between 0 and ndim-1");
+
+  status = nc_inq_vardimid(ncid, fldid, dims);
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var2D_dimname): Error in getting dimid of var %s from file %s",
-	    files[fid].var[vid].name, files[fid].name );
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
   status = nc_inq_dimname(ncid, dims[ind], name);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_get_var2D_dimname): Error in getting %d dimension name of var %s from file %s",
-	    ind, files[fid].var[vid].name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_get_var2D_dimname): Error in getting %d dimension name of var %s from file %s", ind,
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
 
 }; /* mpp_get_var_dimname */
 
-
 /***************************************************************************
   char mpp_get_var_cart(int fid, int vid)
   get the cart of the dimension variable
   *************************************************************************/
-char mpp_get_var_cart(int fid, int vid)
-{
+char mpp_get_var_cart(int fid, int vid) {
   char cart;
   int ncid, fldid, status;
   char errmsg[512];
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_cart): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles"); 
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_cart): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_cart): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_get_var_cart): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
   cart = 'N';
 
   ncid = files[fid].ncid;
   fldid = files[fid].var[vid].fldid;
   status = nc_get_att_text(ncid, fldid, "cartesian_axis", &cart);
-  if(status != NC_NOERR)status = nc_get_att_text(ncid, fldid, "axis", &cart);
+  if (status != NC_NOERR) status = nc_get_att_text(ncid, fldid, "axis", &cart);
   /*
   if(status != NC_NOERR){
     sprintf(errmsg, "mpp_io(mpp_get_var_cart): Error in getting attribute cartesian_axis/axis of "
-	    "dimension variable %s from file %s", files[fid].var[vid].name, files[fid].name );
+            "dimension variable %s from file %s", files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
   */
@@ -754,88 +787,95 @@ char mpp_get_var_cart(int fid, int vid)
 /***************************************************************************
  void mpp_get_var_bndname(int fid, int vid, char *bndname)
  Get the bound name of dimension variable if it exist, otherwise the value will be 'none'
- for time axis, the bounds may be 'climatology' 
+ for time axis, the bounds may be 'climatology'
  **************************************************************************/
-void mpp_get_var_bndname(int fid, int vid, char *bndname)
-{
+void mpp_get_var_bndname(int fid, int vid, char *bndname) {
   int ncid, fldid, status;
   char errmsg[512], name[32];
   size_t siz;
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_cart): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles"); 
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_cart): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_cart): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_get_var_cart): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
   ncid = files[fid].ncid;
-  fldid = files[fid].var[vid].fldid;  
+  fldid = files[fid].var[vid].fldid;
   strcpy(name, "climatology");
   status = nc_inq_attlen(ncid, fldid, name, &siz);
-  if(status != NC_NOERR){
+  if (status != NC_NOERR) {
     strcpy(name, "bounds");
     status = nc_inq_attlen(ncid, fldid, name, &siz);
   }
-  if(status != NC_NOERR){
+  if (status != NC_NOERR) {
     strcpy(name, "edges");
     status = nc_inq_attlen(ncid, fldid, name, &siz);
   }
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     strcpy(bndname, "none");
-  }
-  else {
+  } else {
     status = nc_get_att_text(ncid, fldid, name, bndname);
     bndname[siz] = '\0';
-    if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_get_var_bndname): Error in getting attribute %s of "
-	      "dimension variable %s from file %s", name, files[fid].var[vid].name, files[fid].name );
+    if (status != NC_NOERR) {
+      sprintf(errmsg,
+              "mpp_io(mpp_get_var_bndname): Error in getting attribute %s of "
+              "dimension variable %s from file %s",
+              name, files[fid].var[vid].name, files[fid].name);
       netcdf_error(errmsg, status);
     }
-  }  
+  }
 }
 
 /***************************************************************************
   int mpp_var_att_exist(int fid, int vid, const char *att)
   check the field var has the attribute "att" or not.
 ***************************************************************************/
-int mpp_var_att_exist(int fid, int vid, const char *att)
-{
-  int    status;
+int mpp_var_att_exist(int fid, int vid, const char *att) {
+  int status;
   size_t attlen;
   nc_type atttype;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_var_att_exist): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_var_att_exist): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
-  
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_var_att_exist): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_var_att_exist): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
+
   status = nc_inq_att(files[fid].ncid, files[fid].var[vid].fldid, att, &atttype, &attlen);
-  if(status == NC_NOERR) 
+  if (status == NC_NOERR)
     return 1;
   else
     return 0;
-  
+
 }; /* mpp_att_exist */
 
 /***************************************************************************
   int mpp_global_att_exist(int fid, const char *att)
   check  has the global attribute "att" or not.
 ***************************************************************************/
-int mpp_global_att_exist(int fid, const char *att)
-{
-  int    status;
+int mpp_global_att_exist(int fid, const char *att) {
+  int status;
   size_t attlen;
   nc_type atttype;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_global_att_exist): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_global_att_exist): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+
   status = nc_inq_att(files[fid].ncid, NC_GLOBAL, att, &atttype, &attlen);
-  if(status == NC_NOERR) 
+  if (status == NC_NOERR)
     return 1;
   else
     return 0;
-  
-}; /* mpp_att_exist */
 
+}; /* mpp_att_exist */
 
 /*******************************************************************************/
 /*                                                                             */
@@ -845,20 +885,21 @@ int mpp_global_att_exist(int fid, const char *att)
 
 /********************************************************************
  int mpp_def_dim(int fid, char* name, int size)
- define dimension. 
+ define dimension.
 ********************************************************************/
-int mpp_def_dim(int fid, const char* name, int size) {
+int mpp_def_dim(int fid, const char *name, int size) {
   int dimid, status;
   char errmsg[512];
-  
-  if( mpp_pe() != mpp_root_pe() ) return 0;
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_dim): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  
+
+  if (mpp_pe() != mpp_root_pe()) return 0;
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_def_dim): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+
   status = nc_def_dim(files[fid].ncid, name, size, &dimid);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_def_dim): Error in defining dimension %s of file %s",
-	    name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_def_dim): Error in defining dimension %s of file %s", name, files[fid].name);
     netcdf_error(errmsg, status);
   }
   return dimid;
@@ -868,40 +909,41 @@ int mpp_def_dim(int fid, const char* name, int size) {
  int mpp_def_var(nt fid, const char* name, int type, int ndim, int *dims, int natts ... )
  define metadata of field.
 ********************************************************************/
-int mpp_def_var(int fid, const char* name, nc_type type, int ndim, const int *dims, int natts, ...) {
+int mpp_def_var(int fid, const char *name, nc_type type, int ndim, const int *dims, int natts, ...) {
   int fldid, status, i, vid, ncid;
   va_list ap;
   char errmsg[512];
-  
-  if( mpp_pe() != mpp_root_pe() ) return 0;
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_var): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
+
+  if (mpp_pe() != mpp_root_pe()) return 0;
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_def_var): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
 
   ncid = files[fid].ncid;
   status = nc_def_var(ncid, name, type, ndim, dims, &fldid);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_def_var): Error in defining var %s of file %s",
-	    name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_def_var): Error in defining var %s of file %s", name, files[fid].name);
     netcdf_error(errmsg, status);
   }
   vid = files[fid].nvar;
   files[fid].nvar++;
-  if(files[fid].nvar > MAXVAR ) mpp_error("mpp_io(mpp_def_var): nvar is larger than MAXVAR, increase MAXVAR");  
+  if (files[fid].nvar > MAXVAR) mpp_error("mpp_io(mpp_def_var): nvar is larger than MAXVAR, increase MAXVAR");
   files[fid].var[vid].fldid = fldid;
   files[fid].var[vid].type = type;
   strcpy(files[fid].var[vid].name, name);
-  
+
   va_start(ap, natts);
-  for( i=0; i<natts; i++) {
-    char* attname = va_arg(ap, char*);
-    char* attval = va_arg(ap, char*);
-    if( attname == NULL || attval == NULL) {
+  for (i = 0; i < natts; i++) {
+    char *attname = va_arg(ap, char *);
+    char *attval = va_arg(ap, char *);
+    if (attname == NULL || attval == NULL) {
       mpp_error("mpp_io: attribute name and attribute value not defined suitably, check the arguments list.");
     }
-    status = nc_put_att_text(ncid,fldid,attname,strlen(attval),attval);
-    if(status != NC_NOERR ) {
-      sprintf(errmsg, "mpp_io(mpp_def_var): Error in put attribute %s of var %s of file %s",
-	      attname, name, files[fid].name );
+    status = nc_put_att_text(ncid, fldid, attname, strlen(attval), attval);
+    if (status != NC_NOERR) {
+      sprintf(errmsg, "mpp_io(mpp_def_var): Error in put attribute %s of var %s of file %s", attname, name,
+              files[fid].name);
       netcdf_error(errmsg, status);
     }
   }
@@ -909,110 +951,108 @@ int mpp_def_var(int fid, const char* name, nc_type type, int ndim, const int *di
   return vid;
 } /* mpp_define_var */
 
-
-
-
 /*********************************************************************
   void mpp_def_global_att(int fid, const char *name, const char *val)
   write out global attribute
  ********************************************************************/
-void mpp_def_global_att(int fid, const char *name, const char *val)
-{
+void mpp_def_global_att(int fid, const char *name, const char *val) {
   size_t status;
   char errmsg[512];
-  
-  if( mpp_pe() != mpp_root_pe() ) return;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_global_att): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
+  if (mpp_pe() != mpp_root_pe()) return;
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_def_global_att): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
   status = nc_put_att_text(files[fid].ncid, NC_GLOBAL, name, strlen(val), val);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_def_global_att): Error in put glboal attribute %s of file %s",
-	    name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_def_global_att): Error in put glboal attribute %s of file %s", name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
-}; /* mpp_def_global_att */
 
+}; /* mpp_def_global_att */
 
 /*********************************************************************
   void mpp_def_global_att_double(int fid, const char *name, const char *val)
   write out double global attribute
  ********************************************************************/
-void mpp_def_global_att_double(int fid, const char *name, size_t len, const double *val)
-{
+void mpp_def_global_att_double(int fid, const char *name, size_t len, const double *val) {
   size_t status;
   char errmsg[512];
-  
-  if( mpp_pe() != mpp_root_pe() ) return;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_global_att_double): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
+  if (mpp_pe() != mpp_root_pe()) return;
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_def_global_att_double): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
   status = nc_put_att_double(files[fid].ncid, NC_GLOBAL, name, NC_DOUBLE, len, val);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_def_global_att_double): Error in put glboal attribute %s of file %s",
-	    name, files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_def_global_att_double): Error in put glboal attribute %s of file %s", name,
+            files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
-}; /* mpp_def_global_att_double */
 
+}; /* mpp_def_global_att_double */
 
 /**********************************************************************
 void mpp_def_var_att(int fid, int vid, const char *attname, const char *attval)
  define one field attribute
 *********************************************************************/
-void mpp_def_var_att(int fid, int vid, const char *attname, const char *attval)
-{
+void mpp_def_var_att(int fid, int vid, const char *attname, const char *attval) {
   int ncid, fldid, status;
   char errmsg[512];
-  
-  if( mpp_pe() != mpp_root_pe() ) return;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_var_att): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_def_var_att): invalid vid number, vid should be "
-					       "a nonnegative integer that less than nvar");
-  ncid  = files[fid].ncid;
+  if (mpp_pe() != mpp_root_pe()) return;
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_def_var_att): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_def_var_att): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
+  ncid = files[fid].ncid;
   fldid = files[fid].var[vid].fldid;
-  status = nc_put_att_text(ncid,fldid,attname,strlen(attval),attval);
-  if(status != NC_NOERR ) {
-    sprintf(errmsg, "mpp_io(mpp_def_var_att): Error in put attribute %s of var %s of file %s",
-	    attname, files[fid].var[vid].name, files[fid].name );
+  status = nc_put_att_text(ncid, fldid, attname, strlen(attval), attval);
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_def_var_att): Error in put attribute %s of var %s of file %s", attname,
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
+
 } /* mpp_def_var_att */
-
-
 
 /**********************************************************************
 void mpp_def_var_att_double(int fid, int vid, const char *attname, double attval)
  define one field double attribute
 *********************************************************************/
-void mpp_def_var_att_double(int fid, int vid, const char *attname, double attval)
-{
+void mpp_def_var_att_double(int fid, int vid, const char *attname, double attval) {
   int ncid, fldid, status;
   char errmsg[512];
-  
-  if( mpp_pe() != mpp_root_pe() ) return;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_var_att): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_def_var_att): invalid vid number, vid should be "
-					       "a nonnegative integer that less than nvar");
-  ncid  = files[fid].ncid;
+  if (mpp_pe() != mpp_root_pe()) return;
+
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_def_var_att): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_def_var_att): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
+  ncid = files[fid].ncid;
   fldid = files[fid].var[vid].fldid;
-  status = nc_put_att_double(ncid,fldid,attname,NC_DOUBLE,1,&attval);
-  if(status != NC_NOERR ) {
-    sprintf(errmsg, "mpp_io(mpp_def_var_att_double): Error in put attribute %s of var %s of file %s",
-	    attname, files[fid].var[vid].name, files[fid].name );
+  status = nc_put_att_double(ncid, fldid, attname, NC_DOUBLE, 1, &attval);
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_def_var_att_double): Error in put attribute %s of var %s of file %s", attname,
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
+
 } /* mpp_def_var_att_double */
-
-
 
 /**********************************************************************
  * void mpp_set_deflation(fid_in, fid_out, deflation, shuffle)        *
@@ -1022,95 +1062,97 @@ void mpp_def_var_att_double(int fid, int vid, const char *attname, double attval
  * of the input file are applied                                      *
  * ********************************************************************/
 void mpp_set_deflation(int fid_in, int fid_out, int deflation, int shuffle) {
-    // return if deflation set to zero
-    if (deflation == 0) {
-        printf("Not compressing due to option\n");
-        return;
-    }
+  // return if deflation set to zero
+  if (deflation == 0) {
+    printf("Not compressing due to option\n");
+    return;
+  }
 
-    // return if netcdf3
-    int format;
-    char errmsg[512];
-    int status;
-    status = nc_inq_format(files[fid_in].ncid, &format);
+  // return if netcdf3
+  int format;
+  char errmsg[512];
+  int status;
+  status = nc_inq_format(files[fid_in].ncid, &format);
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_set_deflation): Error in getting determining netcdf version");
+    netcdf_error(errmsg, status);
+  }
+  printf("Input: filename=%s, nvar=%i, format=%i\n", files[fid_in].name, files[fid_in].nvar, format);
+  if (format == NC_FORMAT_CLASSIC || format == NC_FORMAT_64BIT) {
+    printf("Not compressing because input file is NetCDF3\n");
+    return;
+  }
+
+  int v, shuffle2, deflate2, deflation2;
+
+  // loop thru vars
+  for (v = 0; v < files[fid_in].nvar; ++v) {
+    // get existing compression settings
+    status = nc_inq_var_deflate(files[fid_in].ncid, files[fid_in].var[v].fldid, &shuffle2, &deflate2, &deflation2);
     if (status != NC_NOERR) {
-        sprintf(errmsg, "mpp_io(mpp_set_deflation): Error in getting determining netcdf version");
-        netcdf_error(errmsg, status);
+      sprintf(errmsg, "mpp_io(mpp_set_deflation): Error in getting deflation level");
+      netcdf_error(errmsg, status);
     }
-    printf("Input: filename=%s, nvar=%i, format=%i\n", files[fid_in].name, files[fid_in].nvar, format);
-    if (format == NC_FORMAT_CLASSIC || format == NC_FORMAT_64BIT) {
-        printf("Not compressing because input file is NetCDF3\n");
-        return;
+    printf("Input: var=%s, shuffle=%i, deflate=%i, deflation=%i\n", files[fid_in].var[v].name, shuffle2, deflate2,
+           deflation2);
+
+    // apply overrides
+    if (deflation == -1) deflation = deflation2;
+    if (shuffle == -1) shuffle = shuffle2;
+
+    // set compression level
+    status = nc_def_var_deflate(files[fid_out].ncid, files[fid_out].var[v].fldid, shuffle, deflation, deflation);
+    if (status != NC_NOERR) {
+      sprintf(errmsg, "mpp_io(mpp_set_deflation): Error in setting deflation level");
+      netcdf_error(errmsg, status);
     }
-
-    int v, shuffle2, deflate2, deflation2;
-
-    // loop thru vars
-    for (v = 0; v < files[fid_in].nvar; ++v) {
-        // get existing compression settings
-        status = nc_inq_var_deflate(files[fid_in].ncid, files[fid_in].var[v].fldid, &shuffle2, &deflate2, &deflation2);
-        if (status != NC_NOERR) {
-            sprintf(errmsg, "mpp_io(mpp_set_deflation): Error in getting deflation level");
-            netcdf_error(errmsg, status);
-        }
-        printf("Input: var=%s, shuffle=%i, deflate=%i, deflation=%i\n", files[fid_in].var[v].name, shuffle2, deflate2, deflation2);
-
-        // apply overrides
-        if (deflation == -1)
-            deflation = deflation2;
-        if (shuffle == -1)
-            shuffle = shuffle2;
-
-        // set compression level
-        status = nc_def_var_deflate(files[fid_out].ncid, files[fid_out].var[v].fldid, shuffle, deflation, deflation);
-        if (status != NC_NOERR) {
-            sprintf(errmsg, "mpp_io(mpp_set_deflation): Error in setting deflation level");
-            netcdf_error(errmsg, status);
-        }
-        printf("Output: var=%s, shuffle=%i, deflation=%i\n", files[fid_in].var[v].name, shuffle, deflation);
-    }
+    printf("Output: var=%s, shuffle=%i, deflation=%i\n", files[fid_in].var[v].name, shuffle, deflation);
+  }
 }
 
 /**********************************************************************
   void mpp_copy_var_att(fid_in, fid_out)
   copy all the field attribute from infile to outfile
 **********************************************************************/
-void mpp_copy_var_att(int fid_in, int vid_in, int fid_out, int vid_out)
-{
+void mpp_copy_var_att(int fid_in, int vid_in, int fid_out, int vid_out) {
   int natt, status, i, ncid_in, ncid_out, fldid_in, fldid_out;
   char name[256];
   char errmsg[512];
 
-  if( mpp_pe() != mpp_root_pe() ) return;
-  
-  if(fid_in<0 || fid_in >=nfiles) mpp_error("mpp_io(mpp_copy_var_att): invalid fid_in number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  if(fid_out<0 || fid_out >=nfiles) mpp_error("mpp_io(mpp_copy_var_att): invalid fid_out number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-        
-  ncid_in   = files[fid_in].ncid;
-  ncid_out  = files[fid_out].ncid;  
-  fldid_in  = files[fid_in].var[vid_in].fldid;
+  if (mpp_pe() != mpp_root_pe()) return;
+
+  if (fid_in < 0 || fid_in >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_copy_var_att): invalid fid_in number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (fid_out < 0 || fid_out >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_copy_var_att): invalid fid_out number, fid should be "
+        "a nonnegative integer that less than nfiles");
+
+  ncid_in = files[fid_in].ncid;
+  ncid_out = files[fid_out].ncid;
+  fldid_in = files[fid_in].var[vid_in].fldid;
   fldid_out = files[fid_out].var[vid_out].fldid;
-  
+
   status = nc_inq_varnatts(ncid_in, fldid_in, &natt);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in inquiring natts of var %s of file %s",
-	    files[fid_in].var[vid_in].name, files[fid_in].name );
+            files[fid_in].var[vid_in].name, files[fid_in].name);
     netcdf_error(errmsg, status);
   }
-  
-  for(i=0; i<natt; i++) {
+
+  for (i = 0; i < natt; i++) {
     status = nc_inq_attname(ncid_in, fldid_in, i, name);
-    if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in inquiring %d attname of var %s of file %s", i, 
-	      files[fid_in].var[vid_in].name, files[fid_in].name );
+    if (status != NC_NOERR) {
+      sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in inquiring %d attname of var %s of file %s", i,
+              files[fid_in].var[vid_in].name, files[fid_in].name);
       netcdf_error(errmsg, status);
     }
     status = nc_copy_att(ncid_in, fldid_in, name, ncid_out, fldid_out);
-    if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in copying att %s of var %s of file %s", name,  
-	      files[fid_in].var[vid_in].name, files[fid_in].name );
+    if (status != NC_NOERR) {
+      sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in copying att %s of var %s of file %s", name,
+              files[fid_in].var[vid_in].name, files[fid_in].name);
       netcdf_error(errmsg, status);
     }
   }
@@ -1121,154 +1163,159 @@ void mpp_copy_var_att(int fid_in, int vid_in, int fid_out, int vid_out)
   void mpp_copy_var(fid_in, vid_in, fid_out)
   copy one field from fid_in to fid_out
 **********************************************************************/
-void mpp_copy_data(int fid_in, int vid_in, int fid_out, int vid_out)
-{
+void mpp_copy_data(int fid_in, int vid_in, int fid_out, int vid_out) {
   int status;
   int ndim, dims[5], i;
   size_t dsize, size;
   char errmsg[512];
-  double *data=NULL;
-  if( mpp_pe() != mpp_root_pe() ) return;
-  
-  if(fid_in<0 || fid_in >=nfiles) mpp_error("mpp_io(mpp_copy_var): invalid fid_in number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  if(fid_out<0 || fid_out >=nfiles) mpp_error("mpp_io(mpp_copy_var): invalid fid_out number, fid should be "
-				      "a nonnegative integer that less than nfiles");
+  double *data = NULL;
+  if (mpp_pe() != mpp_root_pe()) return;
+
+  if (fid_in < 0 || fid_in >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_copy_var): invalid fid_in number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (fid_out < 0 || fid_out >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_copy_var): invalid fid_out number, fid should be "
+        "a nonnegative integer that less than nfiles");
   /*
   ncid_in   = files[fid_in].ncid;
-  ncid_out  = files[fid_out].ncid;  
+  ncid_out  = files[fid_out].ncid;
   fldid_in  = files[fid_in].var[vid_in].fldid;
   fldid_out = files[fid_out].var[vid_out].fldid;
   */
   ndim = mpp_get_var_ndim(fid_in, vid_in);
-  status = nc_inq_vardimid(files[fid_in].ncid, files[fid_in].var[vid_in].fldid,dims);
-  if(status != NC_NOERR) {
+  status = nc_inq_vardimid(files[fid_in].ncid, files[fid_in].var[vid_in].fldid, dims);
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_copy_data): Error in getting dimid of var %s from file %s",
-	    files[fid_in].var[vid_in].name, files[vid_in].name );
+            files[fid_in].var[vid_in].name, files[vid_in].name);
     netcdf_error(errmsg, status);
   }
   dsize = 1;
-  for(i=0; i<ndim; i++) {
+  for (i = 0; i < ndim; i++) {
     status = nc_inq_dimlen(files[fid_in].ncid, dims[i], &size);
-    if(status != NC_NOERR) {
+    if (status != NC_NOERR) {
       sprintf(errmsg, "mpp_io(mpp_copy_data): error in inquiring dimlen from file %s", files[fid_in].name);
       netcdf_error(errmsg, status);
     }
     dsize *= size;
   }
-  
-  data = (void *)malloc(dsize*sizeof(double));
+
+  data = (void *)malloc(dsize * sizeof(double));
 
   mpp_get_var_value(fid_in, vid_in, data);
   mpp_put_var_value(fid_out, vid_out, data);
   free(data);
 }
-  
-int mpp_get_var_natts(int fid, int vid)
-{
+
+int mpp_get_var_natts(int fid, int vid) {
   int natts, ncid, fldid, status;
   char errmsg[512];
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_natts): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-        
-  ncid   = files[fid].ncid;
-  fldid  = files[fid].var[vid].fldid;
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_natts): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+
+  ncid = files[fid].ncid;
+  fldid = files[fid].var[vid].fldid;
   status = nc_inq_varnatts(ncid, fldid, &natts);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_natts): Error in inquiring natts of var %s of file %s",
-	    files[fid].var[vid].name, files[fid].name );
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
 
-   return natts;
-
+  return natts;
 }
 
-void mpp_get_var_attname(int fid, int vid, int i, char *name)
-{
+void mpp_get_var_attname(int fid, int vid, int i, char *name) {
   int ncid, fldid, status;
   char errmsg[512];
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_attname): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  ncid   = files[fid].ncid;
-  fldid  = files[fid].var[vid].fldid;
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_get_var_attname): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  ncid = files[fid].ncid;
+  fldid = files[fid].var[vid].fldid;
 
   status = nc_inq_attname(ncid, fldid, i, name);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_attname): Error in inquiring %d attname of var %s of file %s", i,
-	    files[fid].var[vid].name, files[fid].name );
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-
 }
 
-void mpp_copy_att_by_name(int fid_in, int vid_in, int fid_out, int vid_out, const char *name)
-{
-
+void mpp_copy_att_by_name(int fid_in, int vid_in, int fid_out, int vid_out, const char *name) {
   int status, ncid_in, ncid_out, fldid_in, fldid_out;
   char errmsg[512];
 
-  if( mpp_pe() != mpp_root_pe() ) return;
+  if (mpp_pe() != mpp_root_pe()) return;
 
-  if(fid_in<0 || fid_in >=nfiles) mpp_error("mpp_io(mpp_copy_var_att): invalid fid_in number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  if(fid_out<0 || fid_out >=nfiles) mpp_error("mpp_io(mpp_copy_var_att): invalid fid_out number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  
-  ncid_in   = files[fid_in].ncid;
-  ncid_out  = files[fid_out].ncid;  
-  fldid_in  = files[fid_in].var[vid_in].fldid;
+  if (fid_in < 0 || fid_in >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_copy_var_att): invalid fid_in number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (fid_out < 0 || fid_out >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_copy_var_att): invalid fid_out number, fid should be "
+        "a nonnegative integer that less than nfiles");
+
+  ncid_in = files[fid_in].ncid;
+  ncid_out = files[fid_out].ncid;
+  fldid_in = files[fid_in].var[vid_in].fldid;
   fldid_out = files[fid_out].var[vid_out].fldid;
 
   status = nc_copy_att(ncid_in, fldid_in, name, ncid_out, fldid_out);
-  if(status != NC_NOERR) {
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_copy_att_by_name): Error in copying att %s of var %s of file %s", name,
-	    files[fid_in].var[vid_in].name, files[fid_in].name );
+            files[fid_in].var[vid_in].name, files[fid_in].name);
     netcdf_error(errmsg, status);
   }
-
 }
-  
 
 /**********************************************************************
   void mpp_copy_global_att(fid_in, fid_out)
   copy all the global attribute from infile to outfile
 **********************************************************************/
-void mpp_copy_global_att(int fid_in, int fid_out)
-{
+void mpp_copy_global_att(int fid_in, int fid_out) {
   int natt, status, i, ncid_in, ncid_out;
   char name[256], errmsg[512];
 
-  if( mpp_pe() != mpp_root_pe() ) return;
+  if (mpp_pe() != mpp_root_pe()) return;
 
-  if(fid_in<0 || fid_in >=nfiles) mpp_error("mpp_io(mpp_copy_global_att): invalid fid_in number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  if(fid_out<0 || fid_out >=nfiles) mpp_error("mpp_io(mpp_copy_global_att): invalid fid_out number, fid should be "
-				      "a nonnegative integer that less than nfiles");
+  if (fid_in < 0 || fid_in >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_copy_global_att): invalid fid_in number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (fid_out < 0 || fid_out >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_copy_global_att): invalid fid_out number, fid should be "
+        "a nonnegative integer that less than nfiles");
   ncid_in = files[fid_in].ncid;
   ncid_out = files[fid_out].ncid;
-  
+
   status = nc_inq_varnatts(ncid_in, NC_GLOBAL, &natt);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in inquiring natts(global) of file %s",
-	    files[fid_in].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in inquiring natts(global) of file %s", files[fid_in].name);
     netcdf_error(errmsg, status);
   }
 
-  for(i=0; i<natt; i++) {
+  for (i = 0; i < natt; i++) {
     status = nc_inq_attname(ncid_in, NC_GLOBAL, i, name);
-    if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in inquiring %d global attname of file %s", i, 
-	      files[fid_in].name );
+    if (status != NC_NOERR) {
+      sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in inquiring %d global attname of file %s", i,
+              files[fid_in].name);
       netcdf_error(errmsg, status);
-    }    
+    }
 
     status = nc_copy_att(ncid_in, NC_GLOBAL, name, ncid_out, NC_GLOBAL);
-    if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in copying %d global att %s of file %s", i,  name,  
-	      files[fid_in].name );
+    if (status != NC_NOERR) {
+      sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in copying %d global att %s of file %s", i, name,
+              files[fid_in].name);
       netcdf_error(errmsg, status);
     }
   }
@@ -1280,127 +1327,141 @@ void mpp_copy_global_att(int fid_in, int fid_out)
   write out string-type data
 
  ********************************************************************/
-void mpp_put_var_value(int fid, int vid, const void* data)
-{
+void mpp_put_var_value(int fid, int vid, const void *data) {
   size_t status;
   char errmsg[600];
-  
-  if( mpp_pe() != mpp_root_pe() ) return;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_put_var_value): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_put_var_value): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
+  if (mpp_pe() != mpp_root_pe()) return;
 
-  switch(files[fid].var[vid].type) {
-  case NC_DOUBLE:case NC_FLOAT:
-    status = nc_put_var_double(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break;
-  case NC_INT:
-    status = nc_put_var_int(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break;
-  case NC_SHORT:
-    status = nc_put_var_short(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break;
-  case NC_CHAR:
-    status = nc_put_var_text(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break;    
-  default:
-    sprintf(errmsg, "mpp_io(mpp_put_var_value): field %s in file %s has an invalid type, "
-	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
-	    files[fid].var[vid].name, files[fid].name );
-    mpp_error(errmsg);
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_put_var_value): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_put_var_value): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
+
+  switch (files[fid].var[vid].type) {
+    case NC_DOUBLE:
+    case NC_FLOAT:
+      status = nc_put_var_double(files[fid].ncid, files[fid].var[vid].fldid, data);
+      break;
+    case NC_INT:
+      status = nc_put_var_int(files[fid].ncid, files[fid].var[vid].fldid, data);
+      break;
+    case NC_SHORT:
+      status = nc_put_var_short(files[fid].ncid, files[fid].var[vid].fldid, data);
+      break;
+    case NC_CHAR:
+      status = nc_put_var_text(files[fid].ncid, files[fid].var[vid].fldid, data);
+      break;
+    default:
+      sprintf(errmsg,
+              "mpp_io(mpp_put_var_value): field %s in file %s has an invalid type, "
+              "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
+              files[fid].var[vid].name, files[fid].name);
+      mpp_error(errmsg);
   }
-  
-  if(status != NC_NOERR) {
+
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_put_var_value): Error in putting value of variable %s from file %s",
-	    files[fid].var[vid].name, files[fid].name );
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_put_var_value*/
 
 /*********************************************************************
   void mpp_put_var_value_block(int fid, int vid, const size_t *start, const size_t *nread, void *data)
   read part of var data, the part is defined by start and nread.
 *********************************************************************/
-void mpp_put_var_value_block(int fid, int vid, const size_t *start, const size_t *nwrite, const void *data)
-{
+void mpp_put_var_value_block(int fid, int vid, const size_t *start, const size_t *nwrite, const void *data) {
   int status;
   char errmsg[512];
 
-  if( mpp_pe() != mpp_root_pe() ) return;
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_put_var_value_block): invalid fid number, fid should be "
-				    "a nonnegative integer that less than nfiles");
-  if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_put_var_value_block): invalid vid number, vid should be "
-				    "a nonnegative integer that less than nvar");
+  if (mpp_pe() != mpp_root_pe()) return;
 
-  switch(files[fid].var[vid].type) {
-  case NC_DOUBLE:case NC_FLOAT:
-    status = nc_put_vara_double(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
-    break;
-  case NC_INT:
-    status = nc_put_vara_int(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
-    break;
-  case NC_SHORT:
-    status = nc_put_vara_short(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
-    break;    
-  case NC_CHAR:
-    status = nc_put_vara_text(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
-    break;
-  default:
-    sprintf(errmsg, "mpp_io(mpp_put_var_value_block): field %s in file %s has an invalid type, "
-	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
-	    files[fid].var[vid].name, files[fid].name );
-    mpp_error(errmsg);
-  }    
-  
-  if(status != NC_NOERR) {
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_put_var_value_block): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (vid < 0 || vid >= files[fid].nvar)
+    mpp_error(
+        "mpp_io(mpp_put_var_value_block): invalid vid number, vid should be "
+        "a nonnegative integer that less than nvar");
+
+  switch (files[fid].var[vid].type) {
+    case NC_DOUBLE:
+    case NC_FLOAT:
+      status = nc_put_vara_double(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
+      break;
+    case NC_INT:
+      status = nc_put_vara_int(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
+      break;
+    case NC_SHORT:
+      status = nc_put_vara_short(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
+      break;
+    case NC_CHAR:
+      status = nc_put_vara_text(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
+      break;
+    default:
+      sprintf(errmsg,
+              "mpp_io(mpp_put_var_value_block): field %s in file %s has an invalid type, "
+              "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
+              files[fid].var[vid].name, files[fid].name);
+      mpp_error(errmsg);
+  }
+
+  if (status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_put_var_value_block): Error in putting value of variable %s from file %s",
-	    files[fid].var[vid].name, files[fid].name );
+            files[fid].var[vid].name, files[fid].name);
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_put_var_value_block */
 
 /*********************************************************************
-   void mpp_redef(int fid) 
+   void mpp_redef(int fid)
    redef the meta data of netcdf file with fid.
  *******************************************************************/
 void mpp_redef(int fid) {
   int status;
   char errmsg[512];
-  
-  if( mpp_pe() != mpp_root_pe() ) return;
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_redef): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  
+
+  if (mpp_pe() != mpp_root_pe()) return;
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_redef): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+
   status = nc_redef(files[fid].ncid);
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_redef): Error in redef the meta data of file %s", files[fid].name );
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_redef): Error in redef the meta data of file %s", files[fid].name);
     netcdf_error(errmsg, status);
   }
 } /* mpp_redef */
 
 /*********************************************************************
-   void mpp_end_def(int ncid) 
+   void mpp_end_def(int ncid)
    end the definition of netcdf file with ncid.
  *******************************************************************/
 void mpp_end_def(int fid) {
   int status;
   char errmsg[512];
-  
-  if( mpp_pe() != mpp_root_pe() ) return;
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_end_def): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  if(HEADER_BUFFER_VALUE>0)
+
+  if (mpp_pe() != mpp_root_pe()) return;
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_end_def): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+  if (HEADER_BUFFER_VALUE > 0)
     status = nc__enddef(files[fid].ncid, HEADER_BUFFER_VALUE, 4, 0, 4);
   else
     status = nc_enddef(files[fid].ncid);
-    
-  if(status != NC_NOERR) {
-    sprintf(errmsg, "mpp_io(mpp_end_def): Error in end definition of file %s", files[fid].name );
+
+  if (status != NC_NOERR) {
+    sprintf(errmsg, "mpp_io(mpp_end_def): Error in end definition of file %s", files[fid].name);
     netcdf_error(errmsg, status);
   }
 } /* mpp_end_def */
@@ -1409,111 +1470,118 @@ void mpp_end_def(int fid) {
   int mpp_file_exist(const char *file)
   check to see if file exist or not.
 *******************************************************************************/
-int mpp_file_exist(const char *file)
-{
+int mpp_file_exist(const char *file) {
   int status, ncid;
-  
-  status = nc_open(file,NC_NOWRITE, &ncid);
-  if(status == NC_NOERR) {
+
+  status = nc_open(file, NC_NOWRITE, &ncid);
+  if (status == NC_NOERR) {
     status = nc_close(ncid);
-    if(status != NC_NOERR) netcdf_error("mpp_file_exist(mpp_io):in closing file", status);
+    if (status != NC_NOERR) netcdf_error("mpp_file_exist(mpp_io):in closing file", status);
     return 1;
-  }
-  else
+  } else
     return 0;
 };
 
-int mpp_field_exist(const char *file, const char *field)
-{
+int mpp_field_exist(const char *file, const char *field) {
   int fid, status, varid;
 
   fid = mpp_open(file, MPP_READ);
   status = nc_inq_varid(files[fid].ncid, field, &varid);
   mpp_close(fid);
 
-  if(status == NC_NOERR)
+  if (status == NC_NOERR)
     return 1;
   else
     return 0;
-
 }
 
-int mpp_dim_exist(int fid, const char *dimname)
-{
+int mpp_dim_exist(int fid, const char *dimname) {
   int status, dimid;
-  
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_dim_exist): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
 
-  status = nc_inq_dimid( files[fid].ncid, dimname, &dimid);
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_dim_exist): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
 
-  if(status == NC_NOERR)
+  status = nc_inq_dimid(files[fid].ncid, dimname, &dimid);
+
+  if (status == NC_NOERR)
     return 1;
   else
-    return 0;  
-
+    return 0;
 }
 
-
-int mpp_var_exist(int fid, const char *field)
-{
+int mpp_var_exist(int fid, const char *field) {
   int status, varid;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_var_exist): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles");
-  
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(mpp_var_exist): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
+
   status = nc_inq_varid(files[fid].ncid, field, &varid);
 
-  if(status == NC_NOERR)
+  if (status == NC_NOERR)
     return 1;
   else
     return 0;
+}
 
-} 
-
-
-int get_great_circle_algorithm(int fid)
-{
+int get_great_circle_algorithm(int fid) {
   char attval[256];
   char errmsg[512];
   int great_circle_algorithm = 0;
 
-  if(fid<0 || fid >=nfiles) mpp_error("mpp_io(get_great_circle_algorithm): invalid fid number, fid should be "
-                                        "a nonnegative integer that less than nfiles");
+  if (fid < 0 || fid >= nfiles)
+    mpp_error(
+        "mpp_io(get_great_circle_algorithm): invalid fid number, fid should be "
+        "a nonnegative integer that less than nfiles");
 
-  if(mpp_global_att_exist(fid, "great_circle_algorithm")) {
+  if (mpp_global_att_exist(fid, "great_circle_algorithm")) {
     mpp_get_global_att(fid, "great_circle_algorithm", attval);
 
-    if(!strcmp(attval, "TRUE"))
+    if (!strcmp(attval, "TRUE"))
       great_circle_algorithm = 1;
-    else if(!strcmp(attval, "FALSE"))
+    else if (!strcmp(attval, "FALSE"))
       great_circle_algorithm = 0;
     else {
-      sprintf(errmsg, "mpp_io: global atribute 'great_circle_algorithm' "
-	      "in file %s should have value 'TRUE' or 'FALSE'", files[fid].name);
+      sprintf(errmsg,
+              "mpp_io: global atribute 'great_circle_algorithm' "
+              "in file %s should have value 'TRUE' or 'FALSE'",
+              files[fid].name);
       mpp_error(errmsg);
     }
   }
 
-  return  great_circle_algorithm;
+  return great_circle_algorithm;
 }
 
-void set_in_format(char *format)
-{
+void set_in_format(char *format) {
   char errmsg[128];
 
-
-  if(!format) return;
-  if(!strcmp(format, "netcdf4")) 
+  if (!format) return;
+  if (!strcmp(format, "netcdf4"))
     in_format = NC_FORMAT_NETCDF4;
-  else if(!strcmp(format, "netcdf4_classic")) 
+  else if (!strcmp(format, "netcdf4_classic"))
     in_format = NC_FORMAT_NETCDF4_CLASSIC;
-  else if(!strcmp(format, "64bit_offset")) 
+  else if (!strcmp(format, "64bit_offset"))
     in_format = NC_FORMAT_64BIT;
-  else if(!strcmp(format, "classic"))
+  else if (!strcmp(format, "classic"))
     in_format = NC_FORMAT_CLASSIC;
   else {
-    sprintf(errmsg, "mpp_io(mpp_open): format = %s is not a valid option", format);
+    sprintf(errmsg, "mpp_io(set_in_format): format = %s is not a valid option", format);
     mpp_error(errmsg);
-    }
+  }
+}
+
+void reset_in_format(int format) {
+  char errmsg[128];
+
+  if ((format != NC_FORMAT_NETCDF4) && (format != NC_FORMAT_NETCDF4_CLASSIC) && (format != NC_FORMAT_64BIT) &&
+      (format != NC_FORMAT_CLASSIC)) {
+    sprintf(errmsg, "mpp_io(reset_in_format): format = %d is not a valid format", format);
+    mpp_error(errmsg);
+  } else {
+    in_format = format;
+  }
 }

--- a/tools/libfrencutils/mpp_io.h
+++ b/tools/libfrencutils/mpp_io.h
@@ -20,7 +20,7 @@
 /****************************************************************
                     mpp_io.h
    This headers defines interface to read and write netcdf file. All the data
-will be written out from root pe. 
+will be written out from root pe.
 
    contact: Zhi.Liang@noaa.gov
 
@@ -83,4 +83,5 @@ int mpp_dim_exist(int fid, const char *dimname);
 int get_great_circle_algorithm(int fid);
 void mpp_set_deflation(int fid_in, int fid_out, int deflation, int shuffle);
 void set_in_format(char *format);
+void reset_in_format(int format);
 #endif


### PR DESCRIPTION
Fregrid is modified to more closely work as indicated in its usage instructions. According to the 
instructions: "When format is not specified, will use the format of input_file." Fregrid now temporarily stores the
netcdf format of the input_file file upon opening it,  and if the case where the "format" argument is not specified, it uses
that stored format for the format of the output file. Function reset_in_format was added to mpp_io. 

This PR is related to  GFDL issue ticket #5019381 ("bronx-18: fregrid fails to remap tiled files with netcdf3/netcdf4 cconfusion") and was tested with the data indicated mentioned in that issue.

NOTE: There are some purely automatic formatting (by Visual Code) changes to the files. The actual meaningful changes are in the new versions of fregrid.c lines 283, 834-839 and 899-904. In mpp_io.c, the added lines are 1577-1586.