### PR TITLE
Use input_file format for the output NetCDF file type if the format argument is not specified

### DIFF
--- a/tools/libfrencutils/mpp_io.c
+++ b/tools/libfrencutils/mpp_io.c
@@ -1517,3 +1517,21 @@ void set_in_format(char *format)
     mpp_error(errmsg);
     }
 }
+
+/**
+void reset_in_format(int format) 
+     Checks for validity of "format", prints a warning if needed, otherwise
+     resets the global variable in_format to the input argument "format".
+ **/
+void reset_in_format(int format) {
+  char errmsg[128];
+
+  if ((format != NC_FORMAT_NETCDF4) && (format != NC_FORMAT_NETCDF4_CLASSIC) && (format != NC_FORMAT_64BIT) &&
+      (format != NC_FORMAT_CLASSIC)) {
+    sprintf(errmsg, "mpp_io(reset_in_format): format = %d is not a valid format", format);
+    mpp_error(errmsg);
+  } else {
+    in_format = format;
+  }
+}
+

--- a/tools/libfrencutils/mpp_io.h
+++ b/tools/libfrencutils/mpp_io.h
@@ -20,7 +20,7 @@
 /****************************************************************
                     mpp_io.h
    This headers defines interface to read and write netcdf file. All the data
-will be written out from root pe. 
+will be written out from root pe.
 
    contact: Zhi.Liang@noaa.gov
 
@@ -83,4 +83,5 @@ int mpp_dim_exist(int fid, const char *dimname);
 int get_great_circle_algorithm(int fid);
 void mpp_set_deflation(int fid_in, int fid_out, int deflation, int shuffle);
 void set_in_format(char *format);
+void reset_in_format(int format);
 #endif


### PR DESCRIPTION
Fregrid is modified to more closely work as indicated in its usage instructions. According to the
instructions: "When format is not specified, will use the format of input_file." Fregrid now temporarily stores the
netcdf format of the input_file file upon opening it, and if the case where the "format" argument is not specified, it uses
that stored format for the format of the output file. Function reset_in_format was added to mpp_io.

This PR is related to GFDL issue ticket #5019381 ("bronx-18: fregrid fails to remap tiled files with netcdf3/netcdf4 cconfusion") and was tested with the data indicated mentioned in that issue.

NOTE:: This PR replaces PR 106 because the automatic re-formatting created be Visual Code was too great.
