### PR TITLE
ocean_model_grid_generator submodule to NCTools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 # Github actions CI file
 # Ryan Mulhall 2020
 # CI testing for the FRE-NCtools repo, builds and runs unit tests
-# github.com/noaa-gfdl/fre-nctools-container 
+# github.com/noaa-gfdl/fre-nctools-container
 name: FRE-NCtools CI
 on: [push, pull_request]
 jobs:
@@ -19,8 +19,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Configure
-      run: | 
+      run: |
         autoreconf -i configure.ac
         ./configure $MPI $QUAD_P
     - name: Build tools

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/ocean_model_grid_generator"]
+	path = tools/ocean_model_grid_generator
+	url = https://github.com/NOAA-GFDL/ocean_model_grid_generator

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,8 @@ SUBDIRS = postprocessing/combine_restarts \
           tools/simple_hydrog/postp \
           tools/simple_hydrog/lakes \
           tools/simple_hydrog/rmvpr \
-          tools/nc_null_check
+          tools/nc_null_check \
+          tools/ocean_model_grid_generator
 
 if WITH_CHECK_PROGS
 SUBDIRS += t

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ submodules:
 
 ```
 git clone --recursive https://github.com/NOAA-GFDL/FRE-NCtools
-git submodule init
-git submodule update
+git submodule update --init --recursive
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ The tools available in FRE-NCtools are:
 * runoff_regrid -- Regrid land runoff data to the nearest ocean point
 * transfer_to_mosaic_grid -- Convert older style grids to newer mosaic grid
 
+## Cloning and submodules
+The NCTools github repository contains the GFDL ocean_model_grid_generator repository
+as a submodule. After cloning NCTools, it must be initialized and updated for its
+submodules:
+
+```
+git clone --recursive https://github.com/NOAA-GFDL/FRE-NCtools
+git submodule init
+git submodule update
+```
+
 ## Install
 
 FRE-NCtools has a collection of C and Fortran sources.  Within GFDL, FRE-NCtools

--- a/configure.ac
+++ b/configure.ac
@@ -168,5 +168,6 @@ AC_CONFIG_FILES([Makefile
                  tools/simple_hydrog/lakes/Makefile
                  tools/simple_hydrog/rmvpr/Makefile
                  tools/simple_hydrog/libfmslite/Makefile
+                 tools/ocean_model_grid_generator/Makefile
 ])
 AC_OUTPUT

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -57,6 +57,7 @@ TESTS = Test01-check_programs_exist.sh \
         Test25-hydrology.sh \
         Test26-reference_fregrid_gcc.sh \
         Test27-multiple_nests.sh \
+        Test28-om_grid_gen.sh \
         01-make_hgrid.sh \
         01-make_vgrid.sh
 

--- a/t/Test28-input/hash.md5
+++ b/t/Test28-input/hash.md5
@@ -1,0 +1,6 @@
+0ecf1226cda789e225bfa65edadc509c  ocean_hgrid_res4.0.nc
+f49fd3bdbfe4c4764802c591341b1ea2  ocean_hgrid_res1.0.nc
+01d0bfa698d16cec35320c5eaea58a48  ocean_hgrid_res0.5.nc
+cdbe7784f00a0ca8139da4019a961f89  ocean_hgrid_res0.5_equenh.nc
+e105c3f0ca219299015065178c18b998  ocean_hgrid_res0.25.nc
+b382087f5259eaad3fb9a0019eccce43  ocean_hgrid_res0.125.nc

--- a/t/Test28-om_grid_gen.sh
+++ b/t/Test28-om_grid_gen.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+#
+# FRE-NCTools is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FRE-NCTools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FRE-NCTools.  If not, see
+# <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# Test grid for multiple same level and telescoping nests 
+
+@test "Test the ocean_model_grid_generator subproject python app" {
+
+    if [ ! -d "Test28" ] 
+  then
+    mkdir Test28
+  fi
+  
+  cd Test28
+  
+  oggappd=$top_srcdir/tools/ocean_model_grid_generator
+  
+  cp -p $oggappd/ocean_grid_generator.py .
+  cp -p $oggappd/numpypi/numpypi_series.py .
+  cp -p $oggappd/numpypi/ignore_this.py .
+
+  chmod ugo+x *.py
+
+  run python3 ./ocean_grid_generator.py -f ocean_hgrid_res4.0.nc -r 0.25 --even_j --no_changing_meta
+
+  [ -e ocean_hgrid_res4.0.nc ]
+
+  run python3 ./ocean_grid_generator.py -f ocean_hgrid_res1.0.nc -r 1.0  --south_cutoff_row 2 --no_changing_meta
+
+  [ -e ocean_hgrid_res1.0.nc ]
+
+  run python3 ./ocean_grid_generator.py -f ocean_hgrid_res0.5.nc -r 2  --no_changing_meta
+
+  [ -e ocean_hgrid_res0.5.nc ]
+
+  # The app may exit with error "Equator is not going to be a u-point" given the test args:
+  #run python3 ./ocean_grid_generator.py -f ocean_hgrid_res0.5_equenh.nc -r 2 --south_cutoff_row 130
+  #[ -e ocean_hgrid_res0.5_equenh.nc ]
+
+  head -3 $top_srcdir/t/Test28-input/hash.md5 > hash.quick
+
+  md5sum -c hash.quick
+
+  [ "$status" -eq 0 ]
+
+  cd ..
+  rm -rf Test28
+}


### PR DESCRIPTION
This pull request adds the ocean_model_grid_generator project ( https://github.com/NOAA-GFDL/ocean_model_grid_generator ) as a submodule to NCTools.  One key goal is to have the
grid generator appear in as much as possible as just another tool of NCTools. To that end : the
grid generator has its own subdirectory under FRE-NCtools/tools; the grid generator (although it is a python script) 
is installed along with the other NCTools scripts; and unit tests were created within NCTools that are in the same 
directory as all the other NCTools unit tests, and are run by the CI.

There are two issues remaining:
1)  One of the four unit tests is commented out as the expected output is not produced. This is currently under investigation.
2) The coordination between the two repositories is still TBD. With this proposed merge it is partly manual in the sense
 that the NCTools subproject managers would only know of a problematic change in the submodule source repo if either a unit test fails,  or if a submodule source repo developer  informs us of a change. Of course, the submodule source repo is recursively cloned anew and tested every time any CI run is made, but is this enough?
