### PR TITLE
Supergrids from internal FV3 grids.

### DIFF
--- a/tools/make_hgrid/create_hgrid.h
+++ b/tools/make_hgrid/create_hgrid.h
@@ -45,7 +45,7 @@ void create_simple_cartesian_grid( double *xbnds, double *ybnds, int *nlon, int 
 				   double *dx, double *dy, double *area, double *angle_dx);
 
 void create_grid_from_file( char *file, int *nlon, int *nlat, double *x, double *y, double *dx, double *dy,
-           		    double *area, double *angle_dx, int  use_great_circle_algorithm );
+           		    double *area, double *angle_dx, int  use_great_circle_algorithm, int use_angular_midpoint );
 
 void create_spectral_grid( int *nlon, int *nlat, int *isc, int *iec,
 			   int *jsc, int *jec, double *x, double *y, double *dx,

--- a/tools/make_hgrid/make_hgrid.c
+++ b/tools/make_hgrid/make_hgrid.c
@@ -294,6 +294,16 @@ char *usage[] = {
   "   --out_halo #               extra halo size data to be written out. This is    ",
   "                              only works for gnomonic_ed.                        ",
   "                                                                                 ",
+  "   --angular_midpoint         WARNING: This is a deprecated, legacy related      ",
+  "                              option that will be removed.  If specified         ",
+  "                              when grid_type is from_file and the input is a     ",
+  "                              NetCDF file, then the supergrid face midpoint      ",
+  "                              coordinates are simply and independely (the lat    ",
+  "                              independently from the lon) calculated as simple   ",
+  "                              angular midpoints from the model grid coordiantes. ",
+  "                              The default is to use the angles that correspond   ",
+  "                              to the spatial midpoint on the great circle        ",
+  "                              between the model grid points.                     ",
   "   --non_length_angle         When specified, will not output length(dx,dy) and  ",
   "                              angle (angle_dx, angle_dy)                         ",
   "                                                                                 ",
@@ -533,6 +543,7 @@ int main(int argc, char* argv[])
   int    present_target_lon = 0;
   int    present_target_lat = 0;
   int    use_great_circle_algorithm = 0;
+  int    use_angular_midpoint = 0;
   int    output_length_angle = 1;
   unsigned int verbose = 0;
   double simple_dx=0, simple_dy=0;
@@ -593,6 +604,7 @@ int main(int argc, char* argv[])
                                          {"out_halo",        required_argument, NULL, 'K'},
                                          {"do_cube_transform", no_argument,     NULL, 'L'},
                                          {"no_length_angle", no_argument,       NULL, 'M'},
+                                         {"angular_midpoint", no_argument,      NULL, 'N'},
                                          {"help",            no_argument,       NULL, 'h'},
                                          {"verbose",         no_argument,       NULL, 'v'},
 
@@ -729,6 +741,9 @@ int main(int argc, char* argv[])
       break;
     case 'M':
       output_length_angle = 0;
+      break;
+    case 'N':
+      use_angular_midpoint = 1;
       break;
     case 'v':
       verbose = 1;
@@ -1108,7 +1123,7 @@ int main(int argc, char* argv[])
       n2 = n * nx  * nyp;
       n3 = n * nxp * ny;
       n4 = n * nx  * ny;
-      create_grid_from_file(my_grid_file[n], &nx, &ny, x+n1, y+n1, dx+n2, dy+n3, area+n4, angle_dx+n1, use_great_circle_algorithm);
+      create_grid_from_file(my_grid_file[n], &nx, &ny, x+n1, y+n1, dx+n2, dy+n3, area+n4, angle_dx+n1, use_great_circle_algorithm, use_angular_midpoint);
     }
   }
   else if(my_grid_type==SIMPLE_CARTESIAN_GRID)


### PR DESCRIPTION
The PR modifies make_hgrid to correctly make supergrids from internal FV3 grids. Make_hgrid already contained a procedure to
read NetCDF files that contained  the four fields grid_lon, grid_lont, grid_lat, and grid_latt. These fileds would be read, the points (lat and lon coordiantes) would be used as supergrid cell verticies and centroids, and the supergrid cell face midpoints would be calculated from them.
To correctly make this work, these changes were made to make_hgrid  :
a) create_grid_from_file() function was modified so that the angular midpoints (lat and lon) between two points on the sphere (actually, two neighboring cell vertices) are the angles corresponding to the spatial midpoint on the great circle. The old method calculated the mid latitude as a simple 0.5 * (angular sum of neighbor latitudes); and similarly for the longitudes .
b)  make_hgrid() function was modified to correcly allocate space for the supergrid when more than one tile is specified  (in this case where the grid_type is "from_file").

Finally, a legacy flag was added as an "already deprecated" feature  (to be removed in a future PR) to temporarily allow the use of the old/legacy method for calculating midpoints. (the new method is the default method)
