### PR TITLE
Writing uniform provenance info in netdfs global attributes.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,10 @@ m4_define([git_revision],
   [m4_esyscmd_s([git describe --always --dirty 2> /dev/null || echo "unknown version"])])
 AC_REVISION([$git_revision])
 
+m4_define([git_hashval],
+  [m4_esyscmd_s([git rev-parse HEAD 2> /dev/null || echo "unknown githash"])])
+AC_REVISION([$git_hashval])
+
 AC_CONFIG_SRCDIR([postprocessing/land_utils/combine-ncc.F90])
 AC_CONFIG_MACRO_DIR([m4])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])
@@ -133,6 +137,8 @@ AM_CONDITIONAL([HAVE_TEST25_INPUT], [test -e ${srcdir}/t/Test25-input/grid_spec.
 # Other defs
 AC_DEFINE([GIT_REVISION], "git_revision",
           [Holds the 'git describe' information if configure ran within a git working directory])
+AC_DEFINE([GIT_HEADHASH], "git_hashval",
+          [Holds the 'git rev-parse HEAD' information if configure ran within a git working directory])
 # Output files
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@
 
 # Prelude
 AC_PREREQ([2.63])
-AC_INIT([FRE NC Tools], [18.0.0], [oar.gfdl.help@noaa.gov], [fre-nctools], [https://github.com/NOAA-GFDL/FRE-NCtools])
+AC_INIT([FRE NC Tools], [19.0.1], [oar.gfdl.help@noaa.gov], [fre-nctools], [https://github.com/NOAA-GFDL/FRE-NCtools])
 # Place the git description informatin in the configure script
 m4_define([git_revision],
   [m4_esyscmd_s([git describe --always --dirty 2> /dev/null || echo "unknown version"])])

--- a/tools/cubic_utils/make_remap_file.c
+++ b/tools/cubic_utils/make_remap_file.c
@@ -26,20 +26,20 @@
 
  AUTHOR: Zhi Liang (Zhi.Liang@noaa.gov)
           NOAA Geophysical Fluid Dynamics Lab, Princeton, NJ
- 
+
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2 of the License, or
   (at your option) any later version.
- 
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
- 
+
   For the full text of the GNU General Public License,
   write to: Free Software Foundation, Inc.,
-            675 Mass Ave, Cambridge, MA 02139, USA.  
+            675 Mass Ave, Cambridge, MA 02139, USA.
 -----------------------------------------------------------------------
 */
 #include <stdlib.h>
@@ -94,7 +94,7 @@ char *usage[] = {
   "                              remap_file.                                             ",
   "                                                                                      ",
   "OPTIONAL FLAGS                                                                        ",
-  "                                                                                      ",  
+  "                                                                                      ",
   "--interp_method interp_method specify the remapping algorithm to be used. Default is  ",
   "                              'conserve_order1'. Currently only 'conserve_order1',    ",
   "                              'conserve_order2' remapping scheme are implemented in   ",
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
   int *i_in=NULL, *j_in=NULL, *t_in=NULL;
   int *i_out=NULL, *j_out=NULL;
   int nx_in, ny_in, ni_in, nj_in;
-  int nx_out, ny_out, ni_out, nj_out; 
+  int nx_out, ny_out, ni_out, nj_out;
   int errflg = (argc == 1);
 
   static struct option long_options[] = {
@@ -156,10 +156,10 @@ int main(int argc, char* argv[])
       break;
     case 'r':
       remap_file = optarg;
-      break;    
+      break;
     case 'm':
       strcpy(interp_method, optarg);
-      break;    
+      break;
     case '?':
       errflg++;
       break;
@@ -170,12 +170,12 @@ int main(int argc, char* argv[])
     char **u = usage;
     while (*u) { fprintf(stderr, "%s\n", *u); u++; }
     exit(2);
-  }      
+  }
   /* check the arguments */
   if( !mosaic_in  ) mpp_error("make_remap_file: input_mosaic is not specified");
   if( !mosaic_out ) mpp_error("make_remap_file: output_mosaic is not specified");
   if( !remap_file ) mpp_error("make_remap_file: remap_file is not specified");
-  
+
   remap_method = CONSERVE_ORDER1;
   if( strcmp(interp_method, "conserve_order1") && strcmp(interp_method, "conserve_order2"))
     mpp_error("make_remap_file: interp_method should be conserve_order1 or conserve_order2");
@@ -201,12 +201,12 @@ int main(int argc, char* argv[])
   ntiles_in = mpp_get_dimlen(mid_in, "ntiles");
   mid_out = mpp_open(mosaic_out, MPP_READ);
   ntiles_out = mpp_get_dimlen(mid_out, "ntiles");
-  if( ntiles_out != ntiles_in)  mpp_error("make_remap_file: ntiles_out not equal to ntiles_in"); 
+  if( ntiles_out != ntiles_in)  mpp_error("make_remap_file: ntiles_out not equal to ntiles_in");
 
 
   if(ntiles_in != 6 && remap_method == CONSERVE_ORDER2)
     mpp_error("make_remap_file: only cubic sphere grid supports interp_method = conserve_order2");
-  
+
   /*get the path of input_mosaic and output_mosaic, assume the grid file are in the same directory */
   get_file_path(mosaic_in, dir_in);
   get_file_path(mosaic_out, dir_out);
@@ -222,7 +222,7 @@ int main(int argc, char* argv[])
     else
       strcpy(remap_file_base, remap_file);
   }
-    
+
   /* loop through ntiles to get the input and output grid, also create the remap file */
   for(n=0; n<ntiles_in; n++) {
     char   filename[STRING];
@@ -241,7 +241,7 @@ int main(int argc, char* argv[])
     int id_tile1, id_tile1_cell, id_tile2_cell, id_xgrid_area;
     int id_tile1_dist;
     int out_is_fine;
-    
+
     /**********************************************************************
                          Get input grid
     ***********************************************************************/
@@ -277,7 +277,7 @@ int main(int argc, char* argv[])
     mpp_get_var_value(fid, vid, tmp_in);
     for(j=0; j<njp_in; j++) for(i=0; i<nip_in; i++) {
       y_in[j*nip_in+i] = tmp_in[2*j*nxp_in+2*i]*D2R;
-    }    
+    }
     mpp_close(fid);
 
     /**********************************************************************
@@ -315,7 +315,7 @@ int main(int argc, char* argv[])
     mpp_get_var_value(fid, vid, tmp_out);
     for(j=0; j<njp_out; j++) for(i=0; i<nip_out; i++) {
       y_out[j*nip_out+i] = tmp_out[2*j*nxp_out+2*i]*D2R;
-    }    
+    }
     mpp_close(fid);
     /**********************************************************************
             check the ratio of input and output grid size is integer
@@ -348,7 +348,7 @@ int main(int argc, char* argv[])
     }
     else
       mpp_error("make_remap_file: ratio is not integer");
-    
+
     /**********************************************************************
                   Create remap information, number of exchange grid will
                   equal number of output grid.
@@ -463,7 +463,7 @@ int main(int argc, char* argv[])
 	}
       }
     }
-      
+
 
     if(pos != nxgrid) {
       printf("pos=%d, nxgrid=%d\n", pos, nxgrid);
@@ -472,22 +472,22 @@ int main(int argc, char* argv[])
 
 
     /* write out the remap information */
-    if(ntiles_in > 1) 
+    if(ntiles_in > 1)
       sprintf(my_remap_file, "%s.tile%d.nc", remap_file_base, n+1);
     else
       sprintf(my_remap_file, "%s.nc", remap_file_base);
 
     /*convert from c-index to fortran index */
     for(i=0; i<nxgrid; i++) {
-      t_in[i]++;  
+      t_in[i]++;
       i_in[i]++;
       j_in[i]++;
       i_out[i]++;
       j_out[i]++;
     }
-    
+
     fid = mpp_open(my_remap_file, MPP_WRITE);
-    mpp_def_global_att(fid, "history", history);
+    print_provenance(fid, history);
     dim_string = mpp_def_dim(fid, "string", STRING);
     dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
     dim_two    = mpp_def_dim(fid, "two", 2);
@@ -524,7 +524,7 @@ int main(int argc, char* argv[])
       start[1] = 1;
       mpp_put_var_value_block(fid, id_tile1_dist, start, nwrite, dj_in);
     }
-	  
+
     mpp_close(fid);
   }
 
@@ -549,13 +549,13 @@ int main(int argc, char* argv[])
     free(clon_in);
     free(clat_in);
   }
-    
+
   printf("Successfully running make_remap_file and the following output file are generated.\n");
-      
+
   mpp_end();
   return 0;
-  
-} /* end of main */
-  
 
-  
+} /* end of main */
+
+
+

--- a/tools/fregrid/fregrid_util.c
+++ b/tools/fregrid/fregrid_util.c
@@ -1643,12 +1643,11 @@ void set_output_metadata (int ntiles_in, int nfiles, const File_config *file1_in
       }
 	for(l=0; l<nscalar; l++)scalar_out[n].var[l].type = scalar_in[0].var[l].type;
 
-      if(mpp_pe() == mpp_root_pe()) {
+  if(mpp_pe() == mpp_root_pe()) {
 	int found;
 	file_out[n].fid = mpp_open(file_out[n].name, MPP_WRITE);
 	mpp_copy_global_att(file_in[0].fid, file_out[n].fid);
-	mpp_def_global_att(file_out[n].fid, "history", history);
-	mpp_def_global_att(file_out[n].fid, "code_version", tagname);
+  print_provenance(file_out[n].fid, history);
 	/* check if bnds exist in axis dimensions */
 	found = 0;
 	for(i=0; i<ndim; i++) {

--- a/tools/libfrencutils/mpp_io.c
+++ b/tools/libfrencutils/mpp_io.c
@@ -78,7 +78,7 @@ void netcdf_error(const char *msg, int status )
 
 int mpp_open(const char *file, int action) {
   char curfile[STRING];
-  char errmsg[512];  
+  char errmsg[512];
   int ncid, status, istat, n, fid;
   static int first_call = 1;
   static size_t blksz=1048576;
@@ -114,8 +114,8 @@ int mpp_open(const char *file, int action) {
         blksz *= (1024*1024);
     }
 
-  }      
-  
+  }
+
   /* write only from root pe. */
   if(action != MPP_READ && mpp_pe() != mpp_root_pe() ) return -1;
   /*if file is not ended with .nc add .nc at the end. */
@@ -191,7 +191,7 @@ int mpp_open(const char *file, int action) {
     sprintf(errmsg, "mpp_io(mpp_open): the action should be MPP_WRITE or MPP_READ when opening file %s", file);
     mpp_error(errmsg);
   }
-  
+
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_open): error in opening file %s", file);
     netcdf_error(errmsg, status);
@@ -200,7 +200,7 @@ int mpp_open(const char *file, int action) {
   files[fid].ncid   = ncid;
   files[fid].status = 1;
   files[fid].action = action;
-  
+
   return fid;
 }
 
@@ -211,10 +211,10 @@ void mpp_close(int fid)
   char errmsg[512];
 
   if(fid == -1 && mpp_pe() != mpp_root_pe() ) return;
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_close): invalid id number, id should be "
 				    "a nonnegative integer that less than nfiles");
-  
+
   status = nc_close(files[fid].ncid);
   if(status != NC_NOERR) {
     sprintf( errmsg, "mpp_io(mpp_close): error in closing files %s ", files[fid].name);
@@ -222,7 +222,7 @@ void mpp_close(int fid)
   }
   files[fid].ncid = 0;
   files[fid].status = 0;
-  
+
 }
 
 
@@ -230,9 +230,9 @@ int mpp_get_nvars(int fid)
 {
   int nvars, status;
   char errmsg[512];
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_nvars): invalid id number, id should be "
-				    "a nonnegative integer that less than nfiles"); 
+				    "a nonnegative integer that less than nfiles");
   status = nc_inq_nvars(files[fid].ncid, &nvars);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_nvars): error in get nvars from file %s", files[fid].name);
@@ -247,15 +247,15 @@ void mpp_get_varname(int fid, int varid, char *name)
 
   int  status;
   char errmsg[512];
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_varname): invalid id number, id should be "
-				    "a nonnegative integer that less than nfiles"); 
+				    "a nonnegative integer that less than nfiles");
   status = nc_inq_varname(files[fid].ncid, varid, name);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_varname): error in get varname from file %s", files[fid].name);
     netcdf_error(errmsg, status);
-  }  
- 
+  }
+
 }
 
 int mpp_get_record_name(int fid, char *name)
@@ -264,12 +264,12 @@ int mpp_get_record_name(int fid, char *name)
   char errmsg[512];
   int record_exist;
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_record_name): invalid id number, id should be "
-				    "a nonnegative integer that less than nfiles");    
+				    "a nonnegative integer that less than nfiles");
   status = nc_inq_unlimdim(files[fid].ncid, &dimid);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_record_name): error in get record id from file %s", files[fid].name);
     netcdf_error(errmsg, status);
-  }  
+  }
   if(dimid >=0) {
     record_exist = 1;
     status = nc_inq_dimname(files[fid].ncid, dimid, name);
@@ -284,7 +284,7 @@ int mpp_get_record_name(int fid, char *name)
   return record_exist;
 }
 
-  
+
 
 /*******************************************************************************/
 /*                                                                             */
@@ -294,18 +294,18 @@ int mpp_get_record_name(int fid, char *name)
 
 /*********************************************************************
   int mpp_get_dimid(int fid, const char *dimname)
-  get the id of the dimname from file with fid, 
+  get the id of the dimname from file with fid,
 *********************************************************************/
 int mpp_get_dimid(int fid, const char *dimname)
 {
   int status, dimid;
   char errmsg[512];
-  
+
   /* First look through existing variables to see
      if the fldid of varname is already retrieved. */
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_dimid): invalid id number, id should be "
 				    "a nonnegative integer that less than nfiles");
-  
+
   status =  nc_inq_dimid(files[fid].ncid, dimname, &dimid);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_dimid): error in get dimension id of %s from file %s", dimname, files[fid].name);
@@ -326,14 +326,14 @@ int mpp_get_varid(int fid, const char *varname)
 {
   int status, fldid, vid, n;
   char errmsg[512];
-  
+
   /* First look through existing variables to see
      if the fldid of varname is already retrieved. */
   if(files[fid].action != MPP_READ  && mpp_pe() != mpp_root_pe() ) return -1;
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_varid): invalid id number, id should be "
 				    "a nonnegative integer that less than nfiles");
-  
+
   for(n=0; n<files[fid].nvar; n++) {
     if( !strcmp(files[fid].var[n].name, varname) ) return n;
   }
@@ -341,7 +341,7 @@ int mpp_get_varid(int fid, const char *varname)
   vid = files[fid].nvar;
   files[fid].nvar++;
   if(files[fid].nvar > MAXVAR ) mpp_error("mpp_io(mpp_get_varid): nvar is larger than MAXVAR, increase MAXVAR");
-  
+
   status =  nc_inq_varid(files[fid].ncid, varname, &fldid);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_varid): error in get field_id of variable %s from file %s", varname, files[fid].name);
@@ -354,7 +354,7 @@ int mpp_get_varid(int fid, const char *varname)
 	    files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
   files[fid].var[vid].fldid = fldid;
   strcpy(files[fid].var[vid].name, varname);
   return vid;
@@ -370,7 +370,7 @@ int mpp_get_dimlen(int fid, const char *name)
   int ncid, dimid, status, len;
   size_t size;
   char errmsg[512];
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_dimlen): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
   ncid = files[fid].ncid;
@@ -386,7 +386,7 @@ int mpp_get_dimlen(int fid, const char *name)
   }
   len = size;
   return len;
-  
+
 }; /* mpp_get_dimlen */
 
 /*********************************************************************
@@ -400,7 +400,7 @@ void mpp_get_var_value(int fid, int vid, void *data)
   short *data_i2;
   float *data_r4;
   char errmsg[512];
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_value_block): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_value_block): invalid vid number, vid should be "
@@ -415,22 +415,22 @@ void mpp_get_var_value(int fid, int vid, void *data)
     break;
   case NC_SHORT:
     status = nc_get_var_short(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break;    
+    break;
   case NC_CHAR:
     status = nc_get_var_text(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break; 
+    break;
   default:
     sprintf(errmsg, "mpp_io(mpp_get_var_value): field %s in file %s has an invalid type, "
 	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
 	    files[fid].var[vid].name, files[fid].name );
     mpp_error(errmsg);
-  }    
+  }
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_value): Error in getting value of variable %s from file %s",
 	    files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_get_var_value */
 
 /*********************************************************************
@@ -441,7 +441,7 @@ void mpp_get_var_value_block(int fid, int vid, const size_t *start, const size_t
 {
   int status;
   char errmsg[512];
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_value_block): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_value_block): invalid vid number, vid should be "
@@ -456,22 +456,22 @@ void mpp_get_var_value_block(int fid, int vid, const size_t *start, const size_t
     break;
   case NC_SHORT:
     status = nc_get_vara_short(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
-    break;  
+    break;
   case NC_CHAR:
     status = nc_get_vara_text(files[fid].ncid, files[fid].var[vid].fldid, start, nread, data);
-    break; 
+    break;
   default:
     sprintf(errmsg, "mpp_io(mpp_get_var_value_block): field %s in file %s has an invalid type, "
 	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
 	    files[fid].var[vid].name, files[fid].name );
     mpp_error(errmsg);
-  }    
+  }
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_value_block): Error in getting value of variable %s from file %s",
 	    files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_get_var_value_block */
 
 /*******************************************************************
@@ -484,7 +484,7 @@ void mpp_get_var_att(int fid, int vid, const char *name, void *val)
   char errmsg[512];
   nc_type type;
 
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_att): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_att): invalid vid number, vid should be "
@@ -496,27 +496,27 @@ void mpp_get_var_att(int fid, int vid, const char *name, void *val)
 	    name, files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
   switch(type) {
   case NC_DOUBLE:case NC_FLOAT:
     status = nc_get_att_double(files[fid].ncid, files[fid].var[vid].fldid, name, val);
     break;
   case NC_INT:
     status = nc_get_att_int(files[fid].ncid, files[fid].var[vid].fldid, name, val);
-    break;      
+    break;
   case NC_SHORT:
     status = nc_get_att_short(files[fid].ncid, files[fid].var[vid].fldid, name, val);
     break;
   case NC_CHAR:
     status = nc_get_att_text(files[fid].ncid, files[fid].var[vid].fldid, name, val);
-    break;    
+    break;
   default:
     sprintf(errmsg, "mpp_io(mpp_get_var_att): attribute %s of field %s in file %s has an invalid type, "
 	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
 	    name, files[fid].var[vid].name, files[fid].name );
     mpp_error(errmsg);
   }
-  
+
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting value of attribute %s of variable %s from file %s",
 	    name, files[fid].var[vid].name, files[fid].name );
@@ -535,7 +535,7 @@ void mpp_get_var_att_double(int fid, int vid, const char *name, double *val)
   nc_type type;
   short sval;
   int   ival;
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_att): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_att): invalid vid number, vid should be "
@@ -547,7 +547,7 @@ void mpp_get_var_att_double(int fid, int vid, const char *name, double *val)
 	    name, files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
   switch(type) {
   case NC_DOUBLE:case NC_FLOAT:
     status = nc_get_att_double(files[fid].ncid, files[fid].var[vid].fldid, name, val);
@@ -555,7 +555,7 @@ void mpp_get_var_att_double(int fid, int vid, const char *name, double *val)
   case NC_INT:
     status = nc_get_att_int(files[fid].ncid, files[fid].var[vid].fldid, name, &ival);
     *val = ival;
-    break;      
+    break;
   case NC_SHORT:
     status = nc_get_att_short(files[fid].ncid, files[fid].var[vid].fldid, name, &sval);
     *val = sval;
@@ -566,7 +566,7 @@ void mpp_get_var_att_double(int fid, int vid, const char *name, double *val)
 	    name, files[fid].var[vid].name, files[fid].name );
     mpp_error(errmsg);
   }
-  
+
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_att): Error in getting value of attribute %s of variable %s from file %s",
 	    name, files[fid].var[vid].name, files[fid].name );
@@ -584,7 +584,7 @@ void mpp_get_global_att(int fid, const char *name, void *val)
   char errmsg[512], attval[4096];
   nc_type type;
   size_t attlen;
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_global_att): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
   status = nc_inq_atttype(files[fid].ncid, NC_GLOBAL, name, &type);
@@ -594,7 +594,7 @@ void mpp_get_global_att(int fid, const char *name, void *val)
     netcdf_error(errmsg, status);
   }
 
-  
+
   switch(type) {
   case NC_DOUBLE:case NC_FLOAT:
     status = nc_get_att_double(files[fid].ncid, NC_GLOBAL, name, val);
@@ -604,7 +604,7 @@ void mpp_get_global_att(int fid, const char *name, void *val)
     break;
   case NC_SHORT:
     status = nc_get_att_short(files[fid].ncid, NC_GLOBAL, name, val);
-    break;  
+    break;
   case NC_CHAR:
     status = nc_inq_attlen(files[fid].ncid, NC_GLOBAL, name, &attlen);
     if(status != NC_NOERR) {
@@ -615,13 +615,13 @@ void mpp_get_global_att(int fid, const char *name, void *val)
     status = nc_get_att_text(files[fid].ncid, NC_GLOBAL, name, attval);
     attval[attlen] = '\0';
     strncpy(val, attval, attlen+1);
-    break;  
+    break;
   default:
     sprintf(errmsg, "mpp_io(mpp_get_global_att): global attribute %s in file %s has an invalid type, "
 	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR", name, files[fid].name );
     mpp_error(errmsg);
   }
-  
+
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_global_att): Error in getting value of global attribute %s from file %s",
 	    name, files[fid].name );
@@ -637,19 +637,19 @@ int mpp_get_var_ndim(int fid, int vid)
 {
   int status, ndim;
   char errmsg[512];
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_ndim): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_ndim): invalid vid number, vid should be "
 				    "a nonnegative integer that less than nvar");
-  
+
   status = nc_inq_varndims(files[fid].ncid, files[fid].var[vid].fldid, &ndim);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_ndim): Error in getting ndims of var %s from file %s",
 	    files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
   return ndim;
 }
 
@@ -660,7 +660,7 @@ int mpp_get_var_ndim(int fid, int vid)
 nc_type mpp_get_var_type(int fid, int vid)
 {
   char errmsg[512];
-  
+
   nc_type vartype;
   int status;
 
@@ -668,7 +668,7 @@ nc_type mpp_get_var_type(int fid, int vid)
 				    "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_ndim): invalid vid number, vid should be "
 				    "a nonnegative integer that less than nvar");
-  
+
   status = nc_inq_vartype(files[fid].ncid, files[fid].var[vid].fldid, &vartype);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var_type): Error in getting type of var %s from file %s",
@@ -688,14 +688,14 @@ void mpp_get_var_dimname(int fid, int vid, int ind, char *name)
 {
   int status, ncid, fldid, ndims, dims[4];
   char errmsg[512];
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_dimname): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_dimname): invalid vid number, vid should be "
 				    "a nonnegative integer that less than nvar");
   ncid = files[fid].ncid;
   fldid = files[fid].var[vid].fldid;
-  
+
   status = nc_inq_varndims(ncid, fldid, &ndims);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var2D_dimname): Error in getting ndims of var %s from file %s",
@@ -704,7 +704,7 @@ void mpp_get_var_dimname(int fid, int vid, int ind, char *name)
   }
 
   if(ind < 0 || ind >= ndims) mpp_error("mpp_io(mpp_get_var_dimname): invalid ind value, ind should be between 0 and ndim-1");
-  
+
   status = nc_inq_vardimid(ncid,fldid,dims);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_get_var2D_dimname): Error in getting dimid of var %s from file %s",
@@ -730,9 +730,9 @@ char mpp_get_var_cart(int fid, int vid)
   char cart;
   int ncid, fldid, status;
   char errmsg[512];
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_cart): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles"); 
+				      "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_cart): invalid vid number, vid should be "
 				    "a nonnegative integer that less than nvar");
   cart = 'N';
@@ -754,20 +754,20 @@ char mpp_get_var_cart(int fid, int vid)
 /***************************************************************************
  void mpp_get_var_bndname(int fid, int vid, char *bndname)
  Get the bound name of dimension variable if it exist, otherwise the value will be 'none'
- for time axis, the bounds may be 'climatology' 
+ for time axis, the bounds may be 'climatology'
  **************************************************************************/
 void mpp_get_var_bndname(int fid, int vid, char *bndname)
 {
   int ncid, fldid, status;
   char errmsg[512], name[32];
   size_t siz;
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_cart): invalid fid number, fid should be "
-				      "a nonnegative integer that less than nfiles"); 
+				      "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_get_var_cart): invalid vid number, vid should be "
 				    "a nonnegative integer that less than nvar");
   ncid = files[fid].ncid;
-  fldid = files[fid].var[vid].fldid;  
+  fldid = files[fid].var[vid].fldid;
   strcpy(name, "climatology");
   status = nc_inq_attlen(ncid, fldid, name, &siz);
   if(status != NC_NOERR){
@@ -789,7 +789,7 @@ void mpp_get_var_bndname(int fid, int vid, char *bndname)
 	      "dimension variable %s from file %s", name, files[fid].var[vid].name, files[fid].name );
       netcdf_error(errmsg, status);
     }
-  }  
+  }
 }
 
 /***************************************************************************
@@ -806,13 +806,13 @@ int mpp_var_att_exist(int fid, int vid, const char *att)
 				    "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_var_att_exist): invalid vid number, vid should be "
 				    "a nonnegative integer that less than nvar");
-  
+
   status = nc_inq_att(files[fid].ncid, files[fid].var[vid].fldid, att, &atttype, &attlen);
-  if(status == NC_NOERR) 
+  if(status == NC_NOERR)
     return 1;
   else
     return 0;
-  
+
 }; /* mpp_att_exist */
 
 /***************************************************************************
@@ -827,13 +827,13 @@ int mpp_global_att_exist(int fid, const char *att)
 
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_global_att_exist): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
-  
+
   status = nc_inq_att(files[fid].ncid, NC_GLOBAL, att, &atttype, &attlen);
-  if(status == NC_NOERR) 
+  if(status == NC_NOERR)
     return 1;
   else
     return 0;
-  
+
 }; /* mpp_att_exist */
 
 
@@ -845,16 +845,16 @@ int mpp_global_att_exist(int fid, const char *att)
 
 /********************************************************************
  int mpp_def_dim(int fid, char* name, int size)
- define dimension. 
+ define dimension.
 ********************************************************************/
 int mpp_def_dim(int fid, const char* name, int size) {
   int dimid, status;
   char errmsg[512];
-  
+
   if( mpp_pe() != mpp_root_pe() ) return 0;
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_dim): invalid fid number, fid should be "
 				      "a nonnegative integer that less than nfiles");
-  
+
   status = nc_def_dim(files[fid].ncid, name, size, &dimid);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_def_dim): Error in defining dimension %s of file %s",
@@ -872,7 +872,7 @@ int mpp_def_var(int fid, const char* name, nc_type type, int ndim, const int *di
   int fldid, status, i, vid, ncid;
   va_list ap;
   char errmsg[512];
-  
+
   if( mpp_pe() != mpp_root_pe() ) return 0;
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_var): invalid fid number, fid should be "
 				      "a nonnegative integer that less than nfiles");
@@ -886,11 +886,11 @@ int mpp_def_var(int fid, const char* name, nc_type type, int ndim, const int *di
   }
   vid = files[fid].nvar;
   files[fid].nvar++;
-  if(files[fid].nvar > MAXVAR ) mpp_error("mpp_io(mpp_def_var): nvar is larger than MAXVAR, increase MAXVAR");  
+  if(files[fid].nvar > MAXVAR ) mpp_error("mpp_io(mpp_def_var): nvar is larger than MAXVAR, increase MAXVAR");
   files[fid].var[vid].fldid = fldid;
   files[fid].var[vid].type = type;
   strcpy(files[fid].var[vid].name, name);
-  
+
   va_start(ap, natts);
   for( i=0; i<natts; i++) {
     char* attname = va_arg(ap, char*);
@@ -920,7 +920,7 @@ void mpp_def_global_att(int fid, const char *name, const char *val)
 {
   size_t status;
   char errmsg[512];
-  
+
   if( mpp_pe() != mpp_root_pe() ) return;
 
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_global_att): invalid fid number, fid should be "
@@ -931,7 +931,7 @@ void mpp_def_global_att(int fid, const char *name, const char *val)
 	    name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_def_global_att */
 
 
@@ -943,7 +943,7 @@ void mpp_def_global_att_double(int fid, const char *name, size_t len, const doub
 {
   size_t status;
   char errmsg[512];
-  
+
   if( mpp_pe() != mpp_root_pe() ) return;
 
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_global_att_double): invalid fid number, fid should be "
@@ -954,7 +954,7 @@ void mpp_def_global_att_double(int fid, const char *name, size_t len, const doub
 	    name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_def_global_att_double */
 
 
@@ -966,7 +966,7 @@ void mpp_def_var_att(int fid, int vid, const char *attname, const char *attval)
 {
   int ncid, fldid, status;
   char errmsg[512];
-  
+
   if( mpp_pe() != mpp_root_pe() ) return;
 
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_var_att): invalid fid number, fid should be "
@@ -981,7 +981,7 @@ void mpp_def_var_att(int fid, int vid, const char *attname, const char *attval)
 	    attname, files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
 } /* mpp_def_var_att */
 
 
@@ -994,7 +994,7 @@ void mpp_def_var_att_double(int fid, int vid, const char *attname, double attval
 {
   int ncid, fldid, status;
   char errmsg[512];
-  
+
   if( mpp_pe() != mpp_root_pe() ) return;
 
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_def_var_att): invalid fid number, fid should be "
@@ -1009,7 +1009,7 @@ void mpp_def_var_att_double(int fid, int vid, const char *attname, double attval
 	    attname, files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
 } /* mpp_def_var_att_double */
 
 
@@ -1082,34 +1082,34 @@ void mpp_copy_var_att(int fid_in, int vid_in, int fid_out, int vid_out)
   char errmsg[512];
 
   if( mpp_pe() != mpp_root_pe() ) return;
-  
+
   if(fid_in<0 || fid_in >=nfiles) mpp_error("mpp_io(mpp_copy_var_att): invalid fid_in number, fid should be "
 				      "a nonnegative integer that less than nfiles");
   if(fid_out<0 || fid_out >=nfiles) mpp_error("mpp_io(mpp_copy_var_att): invalid fid_out number, fid should be "
 				      "a nonnegative integer that less than nfiles");
-        
+
   ncid_in   = files[fid_in].ncid;
-  ncid_out  = files[fid_out].ncid;  
+  ncid_out  = files[fid_out].ncid;
   fldid_in  = files[fid_in].var[vid_in].fldid;
   fldid_out = files[fid_out].var[vid_out].fldid;
-  
+
   status = nc_inq_varnatts(ncid_in, fldid_in, &natt);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in inquiring natts of var %s of file %s",
 	    files[fid_in].var[vid_in].name, files[fid_in].name );
     netcdf_error(errmsg, status);
   }
-  
+
   for(i=0; i<natt; i++) {
     status = nc_inq_attname(ncid_in, fldid_in, i, name);
     if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in inquiring %d attname of var %s of file %s", i, 
+      sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in inquiring %d attname of var %s of file %s", i,
 	      files[fid_in].var[vid_in].name, files[fid_in].name );
       netcdf_error(errmsg, status);
     }
     status = nc_copy_att(ncid_in, fldid_in, name, ncid_out, fldid_out);
     if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in copying att %s of var %s of file %s", name,  
+      sprintf(errmsg, "mpp_io(mpp_copy_var_att): Error in copying att %s of var %s of file %s", name,
 	      files[fid_in].var[vid_in].name, files[fid_in].name );
       netcdf_error(errmsg, status);
     }
@@ -1129,14 +1129,14 @@ void mpp_copy_data(int fid_in, int vid_in, int fid_out, int vid_out)
   char errmsg[512];
   double *data=NULL;
   if( mpp_pe() != mpp_root_pe() ) return;
-  
+
   if(fid_in<0 || fid_in >=nfiles) mpp_error("mpp_io(mpp_copy_var): invalid fid_in number, fid should be "
 				      "a nonnegative integer that less than nfiles");
   if(fid_out<0 || fid_out >=nfiles) mpp_error("mpp_io(mpp_copy_var): invalid fid_out number, fid should be "
 				      "a nonnegative integer that less than nfiles");
   /*
   ncid_in   = files[fid_in].ncid;
-  ncid_out  = files[fid_out].ncid;  
+  ncid_out  = files[fid_out].ncid;
   fldid_in  = files[fid_in].var[vid_in].fldid;
   fldid_out = files[fid_out].var[vid_out].fldid;
   */
@@ -1156,14 +1156,14 @@ void mpp_copy_data(int fid_in, int vid_in, int fid_out, int vid_out)
     }
     dsize *= size;
   }
-  
+
   data = (void *)malloc(dsize*sizeof(double));
 
   mpp_get_var_value(fid_in, vid_in, data);
   mpp_put_var_value(fid_out, vid_out, data);
   free(data);
 }
-  
+
 int mpp_get_var_natts(int fid, int vid)
 {
   int natts, ncid, fldid, status;
@@ -1171,7 +1171,7 @@ int mpp_get_var_natts(int fid, int vid)
 
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_get_var_natts): invalid fid number, fid should be "
 				      "a nonnegative integer that less than nfiles");
-        
+
   ncid   = files[fid].ncid;
   fldid  = files[fid].var[vid].fldid;
   status = nc_inq_varnatts(ncid, fldid, &natts);
@@ -1216,9 +1216,9 @@ void mpp_copy_att_by_name(int fid_in, int vid_in, int fid_out, int vid_out, cons
 				      "a nonnegative integer that less than nfiles");
   if(fid_out<0 || fid_out >=nfiles) mpp_error("mpp_io(mpp_copy_var_att): invalid fid_out number, fid should be "
 				      "a nonnegative integer that less than nfiles");
-  
+
   ncid_in   = files[fid_in].ncid;
-  ncid_out  = files[fid_out].ncid;  
+  ncid_out  = files[fid_out].ncid;
   fldid_in  = files[fid_in].var[vid_in].fldid;
   fldid_out = files[fid_out].var[vid_out].fldid;
 
@@ -1230,7 +1230,7 @@ void mpp_copy_att_by_name(int fid_in, int vid_in, int fid_out, int vid_out, cons
   }
 
 }
-  
+
 
 /**********************************************************************
   void mpp_copy_global_att(fid_in, fid_out)
@@ -1249,7 +1249,7 @@ void mpp_copy_global_att(int fid_in, int fid_out)
 				      "a nonnegative integer that less than nfiles");
   ncid_in = files[fid_in].ncid;
   ncid_out = files[fid_out].ncid;
-  
+
   status = nc_inq_varnatts(ncid_in, NC_GLOBAL, &natt);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in inquiring natts(global) of file %s",
@@ -1260,14 +1260,14 @@ void mpp_copy_global_att(int fid_in, int fid_out)
   for(i=0; i<natt; i++) {
     status = nc_inq_attname(ncid_in, NC_GLOBAL, i, name);
     if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in inquiring %d global attname of file %s", i, 
+      sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in inquiring %d global attname of file %s", i,
 	      files[fid_in].name );
       netcdf_error(errmsg, status);
-    }    
+    }
 
     status = nc_copy_att(ncid_in, NC_GLOBAL, name, ncid_out, NC_GLOBAL);
     if(status != NC_NOERR) {
-      sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in copying %d global att %s of file %s", i,  name,  
+      sprintf(errmsg, "mpp_io(mpp_copy_global_att): Error in copying %d global att %s of file %s", i,  name,
 	      files[fid_in].name );
       netcdf_error(errmsg, status);
     }
@@ -1284,7 +1284,7 @@ void mpp_put_var_value(int fid, int vid, const void* data)
 {
   size_t status;
   char errmsg[600];
-  
+
   if( mpp_pe() != mpp_root_pe() ) return;
 
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_put_var_value): invalid fid number, fid should be "
@@ -1304,20 +1304,20 @@ void mpp_put_var_value(int fid, int vid, const void* data)
     break;
   case NC_CHAR:
     status = nc_put_var_text(files[fid].ncid, files[fid].var[vid].fldid, data);
-    break;    
+    break;
   default:
     sprintf(errmsg, "mpp_io(mpp_put_var_value): field %s in file %s has an invalid type, "
 	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
 	    files[fid].var[vid].name, files[fid].name );
     mpp_error(errmsg);
   }
-  
+
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_put_var_value): Error in putting value of variable %s from file %s",
 	    files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_put_var_value*/
 
 /*********************************************************************
@@ -1330,7 +1330,7 @@ void mpp_put_var_value_block(int fid, int vid, const size_t *start, const size_t
   char errmsg[512];
 
   if( mpp_pe() != mpp_root_pe() ) return;
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_put_var_value_block): invalid fid number, fid should be "
 				    "a nonnegative integer that less than nfiles");
   if(vid<0 || vid >=files[fid].nvar) mpp_error("mpp_io(mpp_put_var_value_block): invalid vid number, vid should be "
@@ -1345,7 +1345,7 @@ void mpp_put_var_value_block(int fid, int vid, const size_t *start, const size_t
     break;
   case NC_SHORT:
     status = nc_put_vara_short(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
-    break;    
+    break;
   case NC_CHAR:
     status = nc_put_vara_text(files[fid].ncid, files[fid].var[vid].fldid, start, nwrite, data);
     break;
@@ -1354,28 +1354,28 @@ void mpp_put_var_value_block(int fid, int vid, const size_t *start, const size_t
 	    "the type should be NC_DOUBLE, NC_FLOAT, NC_INT, NC_SHORT or NC_CHAR",
 	    files[fid].var[vid].name, files[fid].name );
     mpp_error(errmsg);
-  }    
-  
+  }
+
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_put_var_value_block): Error in putting value of variable %s from file %s",
 	    files[fid].var[vid].name, files[fid].name );
     netcdf_error(errmsg, status);
   }
-  
+
 }; /* mpp_put_var_value_block */
 
 /*********************************************************************
-   void mpp_redef(int fid) 
+   void mpp_redef(int fid)
    redef the meta data of netcdf file with fid.
  *******************************************************************/
 void mpp_redef(int fid) {
   int status;
   char errmsg[512];
-  
+
   if( mpp_pe() != mpp_root_pe() ) return;
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_redef): invalid fid number, fid should be "
 				      "a nonnegative integer that less than nfiles");
-  
+
   status = nc_redef(files[fid].ncid);
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_redef): Error in redef the meta data of file %s", files[fid].name );
@@ -1384,13 +1384,13 @@ void mpp_redef(int fid) {
 } /* mpp_redef */
 
 /*********************************************************************
-   void mpp_end_def(int ncid) 
+   void mpp_end_def(int ncid)
    end the definition of netcdf file with ncid.
  *******************************************************************/
 void mpp_end_def(int fid) {
   int status;
   char errmsg[512];
-  
+
   if( mpp_pe() != mpp_root_pe() ) return;
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_end_def): invalid fid number, fid should be "
 				      "a nonnegative integer that less than nfiles");
@@ -1398,7 +1398,7 @@ void mpp_end_def(int fid) {
     status = nc__enddef(files[fid].ncid, HEADER_BUFFER_VALUE, 4, 0, 4);
   else
     status = nc_enddef(files[fid].ncid);
-    
+
   if(status != NC_NOERR) {
     sprintf(errmsg, "mpp_io(mpp_end_def): Error in end definition of file %s", files[fid].name );
     netcdf_error(errmsg, status);
@@ -1412,7 +1412,7 @@ void mpp_end_def(int fid) {
 int mpp_file_exist(const char *file)
 {
   int status, ncid;
-  
+
   status = nc_open(file,NC_NOWRITE, &ncid);
   if(status == NC_NOERR) {
     status = nc_close(ncid);
@@ -1441,7 +1441,7 @@ int mpp_field_exist(const char *file, const char *field)
 int mpp_dim_exist(int fid, const char *dimname)
 {
   int status, dimid;
-  
+
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_dim_exist): invalid fid number, fid should be "
 				      "a nonnegative integer that less than nfiles");
 
@@ -1450,7 +1450,7 @@ int mpp_dim_exist(int fid, const char *dimname)
   if(status == NC_NOERR)
     return 1;
   else
-    return 0;  
+    return 0;
 
 }
 
@@ -1461,7 +1461,7 @@ int mpp_var_exist(int fid, const char *field)
 
   if(fid<0 || fid >=nfiles) mpp_error("mpp_io(mpp_var_exist): invalid fid number, fid should be "
 				      "a nonnegative integer that less than nfiles");
-  
+
   status = nc_inq_varid(files[fid].ncid, field, &varid);
 
   if(status == NC_NOERR)
@@ -1469,7 +1469,7 @@ int mpp_var_exist(int fid, const char *field)
   else
     return 0;
 
-} 
+}
 
 
 int get_great_circle_algorithm(int fid)
@@ -1504,11 +1504,11 @@ void set_in_format(char *format)
 
 
   if(!format) return;
-  if(!strcmp(format, "netcdf4")) 
+  if(!strcmp(format, "netcdf4"))
     in_format = NC_FORMAT_NETCDF4;
-  else if(!strcmp(format, "netcdf4_classic")) 
+  else if(!strcmp(format, "netcdf4_classic"))
     in_format = NC_FORMAT_NETCDF4_CLASSIC;
-  else if(!strcmp(format, "64bit_offset")) 
+  else if(!strcmp(format, "64bit_offset"))
     in_format = NC_FORMAT_64BIT;
   else if(!strcmp(format, "classic"))
     in_format = NC_FORMAT_CLASSIC;
@@ -1519,7 +1519,7 @@ void set_in_format(char *format)
 }
 
 /**
-void reset_in_format(int format) 
+void reset_in_format(int format)
      Checks for validity of "format", prints a warning if needed, otherwise
      resets the global variable in_format to the input argument "format".
  **/

--- a/tools/libfrencutils/tool_util.c
+++ b/tools/libfrencutils/tool_util.c
@@ -17,12 +17,15 @@
  * License along with FRE-NCTools.  If not, see
  * <http://www.gnu.org/licenses/>.
  **********************************************************************/
-#include <stdlib.h> 
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <math.h> 
-#include "constant.h" 
-#include "mosaic_util.h" 
+#include <math.h>
+#include <unistd.h>
+#include <time.h>
+#include "config.h"
+#include "constant.h"
+#include "mosaic_util.h"
 #include "read_mosaic.h"
 #include "tool_util.h"
 #include "interp.h"
@@ -42,7 +45,6 @@ int lon_fix(double *x, double *y, int n_in, double tlon);
 
 int round_to_nearest_int(double r)
 {
-
   return (r > 0.0) ? floor(r + 0.5) : ceil(r - 0.5);
 }
 
@@ -57,7 +59,7 @@ void get_file_path(const char *file, char *dir)
   char *strptr = NULL;
 
   /* get the diretory */
- 
+
   strptr = strrchr(file, '/');
   if(strptr) {
     len = strptr - file;
@@ -69,13 +71,13 @@ void get_file_path(const char *file, char *dir)
   }
   dir[len] = 0;
 
-}; /* get_file_path */
+} /* get_file_path */
 
 int get_int_entry(char *line, int* value)
 {
   char* pch;
   int num;
-  
+
   pch = strtok(line, ", ");
   num = 0;
   while( pch != NULL) {
@@ -83,14 +85,14 @@ int get_int_entry(char *line, int* value)
     pch = strtok(NULL, ", ");
   }
   return num;
-    
-};
+
+}
 
 int get_double_entry(char *line, double *value)
 {
   char* pch;
   int num;
-  
+
   pch = strtok(line, ", ");
   num = 0;
   while( pch != NULL) {
@@ -98,7 +100,7 @@ int get_double_entry(char *line, double *value)
     pch = strtok(NULL, ", ");
   }
   return num;
-};
+}
 
 /*********************************************************************
   double spherical_dist(double x1, double y1, double x2, double y2)
@@ -109,7 +111,7 @@ double spherical_dist(double x1, double y1, double x2, double y2)
 {
   double dist = 0.0;
   double h1, h2;
-  
+
   if(x1 == x2) {
     h1 = RADIUS;
     h2 = RADIUS;
@@ -120,12 +122,12 @@ double spherical_dist(double x1, double y1, double x2, double y2)
     h2 = RADIUS * cos(y2*D2R);
     dist = distant(x1,x2,h1,h2);
   }
-  else 
+  else
     mpp_error("tool_till: This is not rectangular grid");
 
   return dist;
-}; /* spherical_dist */
-  
+} /* spherical_dist */
+
 
 /*********************************************************************
   void double bipolar_dist(double x1, double y1, double x2, double y2)
@@ -137,10 +139,10 @@ double bipolar_dist(double x1, double y1, double x2, double y2,
   double dist, x[2],y[2], bp_lon[2], bp_lat[2], metric[2];
   double h1[2], h2[2], chic;
   int n;
-  
+
   x[0] = x1;  x[1] = x2;
   y[0] = y1;  y[1] = y2;
-  
+
   /*--- get the bipolar grid and metric term ----------------------------*/
   for(n=0; n<2; n++){
     bp_lon[n] = bp_lam(x[n],y[n],bpeq, rp);     /* longitude (degrees) in bipolar grid system */
@@ -156,16 +158,16 @@ double bipolar_dist(double x1, double y1, double x2, double y2,
   }
 
   /*--- then calculate the distance -------------------------------------*/
-  if(x1 == x2) 
+  if(x1 == x2)
     dist = distant(bp_lon[0],bp_lon[1],metric[0]*h1[0],metric[1]*h1[1]);
-  else if(y1 == y2) 
+  else if(y1 == y2)
     dist = distant(bp_lat[0],bp_lat[1],metric[0]*h2[0],metric[1]*h2[1]);
   else
-    mpp_error("tool_util: This tripolar grid not transformed from rectangular grid");    
+    mpp_error("tool_util: This tripolar grid not transformed from rectangular grid");
 
   return dist;
-  
-}; /* bipolar_dist */
+
+} /* bipolar_dist */
 
 /*********************************************************************
   double distant(double a, double b, double met1, double met2)
@@ -174,11 +176,11 @@ double bipolar_dist(double x1, double y1, double x2, double y2,
 double distant(double a, double b, double met1, double met2)
 {
    return fabs(a-b)*D2R*(met1+met2)/2. ;
-}; /* distant */
+} /* distant */
 
 /*********************************************************************
    double spherical_area(double x1, double y1, double x2, double y2,
-                   double x3, double y3, double x4, double y4 )            
+                   double x3, double y3, double x4, double y4 )
    rectangular grid box area
  ********************************************************************/
 double spherical_area(double x1, double y1, double x2, double y2,
@@ -186,7 +188,7 @@ double spherical_area(double x1, double y1, double x2, double y2,
 {
   double area, dx, lat1, lat2, x[4],y[4];
   int i, ip;
-  
+
   x[0] = x1; y[0] = y1;
   x[1] = x2; y[1] = y2;
   x[2] = x3; y[2] = y3;
@@ -206,18 +208,18 @@ double spherical_area(double x1, double y1, double x2, double y2,
 
     if (lat1 == lat2) /* cheap area calculation along latitude  */
       area = area - dx*sin(lat1);
-    else 
+    else
       area = area - dx*(sin(lat1)+sin(lat2))/2;   /*  TRAPEZOID_RULE */
   }
 
   area = area * RADIUS * RADIUS;
 
   return area;
-}; /* spherical_area */
+} /* spherical_area */
 
 /*********************************************************************
    double bipolar_area(double x1, double y1, double x2, double y2,
-                       double x3, double y3, double x4, double y4 )            
+                       double x3, double y3, double x4, double y4 )
    bipolar grid  area
  ********************************************************************/
 double bipolar_area(double x1, double y1, double x2, double y2,
@@ -225,7 +227,7 @@ double bipolar_area(double x1, double y1, double x2, double y2,
 {
   double area, dx, lat1, lat2, x[8],y[8];
   int i, ip, n;
-  
+
   x[0] = x1; y[0] = y1;
   x[1] = x2; y[1] = y2;
   x[2] = x3; y[2] = y3;
@@ -236,7 +238,7 @@ double bipolar_area(double x1, double y1, double x2, double y2,
   n = lon_fix(x, y, 4, 180.);
 
   /*--- calculate the area ----------------------------------------------  */
-  area = 0.0;  
+  area = 0.0;
   for(i=0; i<n; i++){
     ip = i+1;
     if(ip == n) ip = 0;
@@ -252,11 +254,11 @@ double bipolar_area(double x1, double y1, double x2, double y2,
     else
       area = area - dx*(sin(lat1)+sin(lat2))/2;   /*  TRAPEZOID_RULE */
   }
-  
+
   area = area * RADIUS * RADIUS;
 
   return area;
-}; /* bipolar_area */
+} /* bipolar_area */
 
 /*********************************************************************
   double lat_dist(double x1, double x2)
@@ -265,7 +267,7 @@ double bipolar_area(double x1, double y1, double x2, double y2,
   double lat_dist(double x1, double x2)
 {
   return min(fmod(x1-x2+720,360.),fmod(x2-x1+720,360.));
-};
+}
 
 
 /*********************************************************************
@@ -295,23 +297,23 @@ double bipolar_area(double x1, double y1, double x2, double y2,
     return (-90+lat_dist(x,bpsp));
   else
     return ( 90-lat_dist(x,bpnp));
-}; /* bp_phi */
+} /* bp_phi */
 
 
 /*********************************************************************
   void tp_trans(double& lon, double& lat, double lon_ref)
   calculate tripolar grid
  ********************************************************************/
-void tp_trans(double *lon, double *lat, double lon_ref, double lon_start, 
+void tp_trans(double *lon, double *lat, double lon_ref, double lon_start,
 		    double lam0, double bpeq, double bpsp, double bpnp, double rp )
 {
   double lamc, phic, lams, chic, phis;
-  
+
   lamc = bp_lam(*lon, *lat, bpeq, rp )*D2R;
   phic = bp_phi(*lon, *lat, bpsp, bpnp)*D2R;
 
   if (fabs(*lat-90.) < SMALL) {
-       if (phic > 0) 
+       if (phic > 0)
 	 *lon=lon_in_range(lon_start,lon_ref);
        else
 	 *lon=lon_start+180.;
@@ -330,10 +332,10 @@ void tp_trans(double *lon, double *lat, double lon_ref, double lon_start,
     chic = acos(cos(lamc)*cos(phic));                          /* eqn. 6 */
     phis = M_PI*0.5-2*atan(rp*tan(chic/2));                        /* eqn. 5 */
     *lon = lams*R2D;
-    *lon = lon_in_range(*lon,lon_ref); 
+    *lon = lon_in_range(*lon,lon_ref);
     *lat = phis*R2D;
   }
-}; /* tp_trans */
+} /* tp_trans */
 
 /*********************************************************************
   double Lon_in_range(double lon, double lon_strt)
@@ -346,13 +348,13 @@ double lon_in_range(double lon, double lon_strt)
   lon_in_range = lon;
   lon_end = lon_strt+360.;
 
-  if (fabs(lon_in_range - lon_strt) < SMALL) 
+  if (fabs(lon_in_range - lon_strt) < SMALL)
     lon_in_range = lon_strt;
   else if (fabs(lon_in_range - lon_end) < SMALL)
     lon_in_range = lon_strt;
   else {
     while(1) {
-      if (lon_in_range < lon_strt)          
+      if (lon_in_range < lon_strt)
 	lon_in_range = lon_in_range +  360.;
       else if (lon_in_range  >  lon_end)
 	lon_in_range  = lon_in_range - 360.;
@@ -361,18 +363,18 @@ double lon_in_range(double lon, double lon_strt)
     }
   }
   return lon_in_range;
-}; /* lon_in_range */
+} /* lon_in_range */
 
 
 /*********************************************************************
-   int lon_fix(double *x, double *y, int n_in, double tlon) 
+   int lon_fix(double *x, double *y, int n_in, double tlon)
    fix longitude at pole.
  ********************************************************************/
 int lon_fix(double *x, double *y, int n_in, double tlon)
 {
   int i, ip, im, n_out;
   double x_sum, dx;
-  
+
   n_out = n_in;
   i     = 0;
   while( i < n_out) {
@@ -413,7 +415,7 @@ int lon_fix(double *x, double *y, int n_in, double tlon)
   x_sum = x[1];
   for(i=1;i< n_out;i++){
     dx = x[i] - x[i-1];
-    if(dx < -180) 
+    if(dx < -180)
       dx = dx + 360;
     else if (dx >  180)
       dx = dx - 360;
@@ -423,14 +425,14 @@ int lon_fix(double *x, double *y, int n_in, double tlon)
   }
 
   dx = x_sum/(n_out) - tlon;
-  if (dx < -180.) 
+  if (dx < -180.)
     for(i=0;i<n_out;i++) x[i] = x[i] + 360.;
   else if (dx > 180.)
     for(i=0;i<n_out;i++) x[i] = x[i] - 360.;
 
   return n_out;
-  
-}; /* lon_fix */
+
+} /* lon_fix */
 
 
 /*********************************************************************
@@ -447,7 +449,7 @@ void vtx_delete(double *x, double *y, int *n, int n_del)
       y[i] = y[i+1];
     }
   (*n)--;
-}; /* vtx_delete */
+} /* vtx_delete */
 
 /*********************************************************************
    void Vtx_insert(double *x, double *y, int *n, int n_del)
@@ -463,14 +465,14 @@ void vtx_insert(double *x, double *y, int *n, int n_ins)
   }
   (*n)++;
 
-}; /* vtx_insert */
+} /* vtx_insert */
 
 
 /*----------------------------------------------------------------------
     void vect_cross(e, p1, p2)
     Perform cross products of 3D vectors: e = P1 X P2
     -------------------------------------------------------------------*/
-    
+
 /********************************************************************************
   void compute_grid_bound(int nb, const couble *bnds, const int *npts, int *grid_size, const char *center_cell)
   compute the 1-D grid location. This algorithm is developed by Russell Fiedler
@@ -487,7 +489,7 @@ double* compute_grid_bound(int nb, const double *bnds, const int *npts, int *gri
     refine = 2;
   else
     mpp_error("tool_util: center should be 'none', 'c_cell' or 't_cell' ");
-	  
+
   grid1 = (double *)malloc(nb*sizeof(double));
   grid1[0] = 1;
   n = 0;
@@ -525,14 +527,14 @@ double* compute_grid_bound(int nb, const double *bnds, const int *npts, int *gri
     for(i=1; i<n;  i++) grid[2*i+1] = 2*grid[2*i] - grid[2*i-1];
 */
   }
-    
+
   free(grid1);
   free(grid2);
-  free(tmp);  
+  free(tmp);
 
   return grid;
-  
-};/* compute_grid_bound */
+
+}/* compute_grid_bound */
 
 int get_legacy_grid_size(int nb, const double *bnds, const double *dbnds)
 {
@@ -540,9 +542,9 @@ int get_legacy_grid_size(int nb, const double *bnds, const double *dbnds)
   int refine, l;
   double avg_res, chg_res, wid, an;
   int ncells;
-  
+
   refine = 2;
-  
+
   grid_size = 0;
   for(l=0; l<nb-1; l++) {
     avg_res = 0.5*(dbnds[l] + dbnds[l+1]);
@@ -551,7 +553,7 @@ int get_legacy_grid_size(int nb, const double *bnds, const double *dbnds)
     wid   = fabs(bnds[l+1] - bnds[l]);
     an    = wid/avg_res;
     ncells = round(an);
-    grid_size += ncells;    
+    grid_size += ncells;
   }
 
   grid_size *= refine;
@@ -573,16 +575,16 @@ double* compute_grid_bound_legacy(int nb, const double *bnds, const double *dbnd
   int    maxlen = MAX_GRID_LENGTH/2;
   double delta[maxlen];
   int    num, ncells, npts;
-  
+
   if(!strcmp(center, "t_cell") || !strcmp(center, "c_cell") || nb == 2 )
-    refine = 2;	         
+    refine = 2;
   else
     mpp_error("tool_util(compute_grid_bound_legacy): center should be 'c_cell' or 't_cell' when nb > 2 ");
 
   /* when center is 't_cell', stretch must be 1 */
   if( !strcmp(center, "t_cell") && stretch != 1 )
     mpp_error("tool_util(ompute_grid_bound_legacy): stretch must be 1 when center = 't_cell' ");
-  
+
   num = 0;
   for(l=0; l<nb-1; l++) {
     int keep_going;
@@ -591,7 +593,7 @@ double* compute_grid_bound_legacy(int nb, const double *bnds, const double *dbnd
        wid     = width of region
        tol     = tolerance for fitting T cels within region width
     */
-      
+
     /* provide for stretching last region if needed */
 
     if( l == nb-2 ) {
@@ -610,7 +612,7 @@ double* compute_grid_bound_legacy(int nb, const double *bnds, const double *dbnd
     if( !strcmp(center, "t_cell") ) {
       if( fabs(an-ncells) > tol )
 	mpp_error("tool_util(ompute_grid_bound_legacy): non integral number of cells in some subregion for 't_cell'");
-    
+
       for(i=0; i<ncells; i++) {
 	del = avg_res - 0.5*chg_res*cos((M_PI/ncells)*(i+0.5));
 	num++;
@@ -625,7 +627,7 @@ double* compute_grid_bound_legacy(int nb, const double *bnds, const double *dbnd
 	 note: "sum" initially discounts half of the U cells widths
 	 at the boundaries
       */
-       
+
       sum = 0.5*dbnds[l] - 0.5*dbnds[l+1];
       n   = 0;
       i = 0;
@@ -651,14 +653,14 @@ double* compute_grid_bound_legacy(int nb, const double *bnds, const double *dbnd
 	  }
 	  mpp_error("tool_util(ompute_grid_bound_legacy): non integral number of cells in some subregion for 'c_cell'");
 	}
-      }      
+      }
     }
   }
 
   npts = refine*num + 1;
   *grid_size = refine*num;
   grid = (double *)malloc(npts*sizeof(double));
-			  
+
   grid[0] = bnds[0];
   if( !strcmp(center, "t_cell") ) {
     for(i = 0; i<num; i++ ) {
@@ -671,15 +673,15 @@ double* compute_grid_bound_legacy(int nb, const double *bnds, const double *dbnd
     grid[1] = grid[0] + 0.5*dbnds[0];
     for( i = 0; i < num-1; i++ ) {
       del = 0.5*delta[i];
-      grid[2*i+2] = grid[2*i+1] + del; 
-      grid[2*i+3] = grid[2*i+2] + del; 
+      grid[2*i+2] = grid[2*i+1] + del;
+      grid[2*i+3] = grid[2*i+2] + del;
     }
     grid[2*num] = grid[2*num-1] + 0.5*delta[num-1];
   }
-    
+
   return grid;
-  
-};/* compute_grid_bound_legacy */
+
+}/* compute_grid_bound_legacy */
 
 
 void get_boundary_type( const char *grid_file, int grid_version, int *cyclic_x, int *cyclic_y, int *is_tripolar )
@@ -689,28 +691,28 @@ void get_boundary_type( const char *grid_file, int grid_version, int *cyclic_x, 
   char errmsg[512];
   char attvalue[128];
   int tile1[2], tile2[2];
-  int istart1[2], iend1[2], jstart1[2], jend1[2]; 
+  int istart1[2], iend1[2], jstart1[2], jend1[2];
   int istart2[2], iend2[2], jstart2[2], jend2[2];
-  
+
   *cyclic_x = 0;
   *cyclic_y = 0;
   *is_tripolar = 0;
 
 
-  
+
   if( grid_version == VERSION_2)  { /* mosaic grid */
     /* make sure there is only one tile in the ocean mosaic */
     ntiles = read_mosaic_ntiles(grid_file);
-      
+
     if( ntiles != 1) mpp_error("==>Error from get_boundary_type: ntiles is not 1, contact developer");
-    
+
     if(mpp_field_exist(grid_file, "contacts") ) {
       ncontacts = read_mosaic_ncontacts(grid_file);
       if(ncontacts < 1) {
 	sprintf(errmsg, "==>Error from get_boundary_type: number of contacts "
 		"number of contacts should be larger than 0 when field contacts exist in file %s",grid_file );
 	mpp_error(errmsg);
-      }  
+      }
       if(ncontacts > 2) {
 	sprintf(errmsg, "==>Error from get_boundary_type: "
                        "number of contacts should be no larger than 2 in file %s",grid_file );
@@ -759,7 +761,7 @@ void get_boundary_type( const char *grid_file, int grid_version, int *cyclic_x, 
      else
        printf("\n==>NOTE from get_boundary_type: x_boundary_type is solid_walls\n");
 
-     if(*cyclic_y) 
+     if(*cyclic_y)
        printf("\n==>NOTE from get_boundary_type: y_boundary_type is cyclic\n");
      else if(*is_tripolar)
        printf("\n==>NOTE from get_boundary_type: y_boundary_type is fold_north_edge\n");
@@ -767,4 +769,50 @@ void get_boundary_type( const char *grid_file, int grid_version, int *cyclic_x, 
        printf("\n==>NOTE from get_boundary_type: y_boundary_type is solid_walls\n");
   }
 
-}; /* get_boundary_type */
+} /* get_boundary_type */
+
+
+/*
+  write (define) the provenance information as  global attributes in the netcdf file.
+  - history (the command and arguemnts used) is written if passed in as not null).
+  - grid version is written if passed in as not null.
+  - gca_flag is the great circle algorithm flag.
+  */
+void print_provenance_gv_gca(int fid, char *history, char *grid_version, int gca_flag) {
+  char hostname[128];
+  gethostname(hostname, 128);
+
+  char *crTimeStringNoNL;
+  time_t crTime;
+  time(&crTime);
+  crTimeStringNoNL = strtok(ctime(&crTime), "\n");  // remove the newline char
+
+  if (grid_version != NULL) {
+    mpp_def_global_att(fid, "grid_version", grid_version);
+  }
+
+  mpp_def_global_att(fid, "code_release_version", PACKAGE_VERSION);  // from autotools config.h
+
+  if (gca_flag != 0) {
+    mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
+  }
+
+  mpp_def_global_att(fid, "git_hash", GIT_HEADHASH);
+
+  mpp_def_global_att(fid, "creationtime", crTimeStringNoNL);
+
+  mpp_def_global_att(fid, "hostname", hostname);
+
+  if (history != NULL) {
+    mpp_def_global_att(fid, "history", history);
+  }
+}
+
+void print_provenance_gv(int fid, char * history, char * grid_version){
+  print_provenance_gv_gca(fid, history, grid_version, 0 );
+}
+
+void print_provenance(int fid,  char * history){
+  print_provenance_gv_gca(fid, history, NULL, 0 );
+}
+

--- a/tools/libfrencutils/tool_util.h
+++ b/tools/libfrencutils/tool_util.h
@@ -20,7 +20,7 @@
 /***********************************************************************
                       tool_util.h
     This header file provide some utilities routine that will be used in many tools.
-    
+
     contact: Zhi.Liang@noaa.gov
 ***********************************************************************/
 #ifndef TOOL_UTIL_H_
@@ -31,16 +31,20 @@
 #define VERSION_3 3
 int round_to_nearest_int(double r);
 void get_file_path(const char *file, char *dir);
-int get_int_entry(char *line, int *value); 
+int get_int_entry(char *line, int *value);
 int get_double_entry(char *line, double *value);
 double spherical_dist(double x1, double y1, double x2, double y2);
-double spherical_area(double x1, double y1, double x2, double y2, double x3, double y3, double x4, double y4 ); 
+double spherical_area(double x1, double y1, double x2, double y2, double x3, double y3, double x4, double y4 );
 double bipolar_dist(double x1, double y1, double x2, double y2, double bpeq, double bpsp, double bpnp, double rp );
 double bipolar_area(double x1, double y1, double x2, double y2, double x3, double y3, double x4, double y4 );
-void tp_trans(double *lon, double *lat, double lon_ref, double lon_start, 
+void tp_trans(double *lon, double *lat, double lon_ref, double lon_start,
               double lam0, double bpeq, double bpsp, double bpnp, double rp );
 double* compute_grid_bound(int nb, const double *bnds, const int *npts, int *grid_size, const char *center);
 double* compute_grid_bound_legacy(int nb, const double *bnds, const double *dbnds, double stretch, int *grid_size, const char *center);
 int get_legacy_grid_size(int nb, const double *bnds, const double *dbnds);
 void get_boundary_type( const char *grid_file, int grid_version, int *cyclic_x, int *cyclic_y, int *is_tripolar );
+
+void print_provenance_gv_gca(int fid,  char * history, char * grid_version, int gca_flag);
+void print_provenance_gv(int fid,  char * history, char * grid_version);
+void print_provenance(int fid, char * history);
 #endif

--- a/tools/make_coupler_mosaic/make_coupler_mosaic.c
+++ b/tools/make_coupler_mosaic/make_coupler_mosaic.c
@@ -33,10 +33,10 @@
 	Calculate LND grid cell area area_lnd, =area_atm if the same grid
 	Read in OCN (super) grid xocn,yocn (I added read grid cell area)
 	Calculate OCN grid cell area area_ocn
-	Extend OCN grid south if it does not cover the southern cap 			
+	Extend OCN grid south if it does not cover the southern cap
 	*** Extending area_ocn[j=0,:]=area_ocn[j=1,:] is inaccurate if it's used
 	Read OCN depth and set ocean mask omask=1 where wet
-	 
+
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -611,7 +611,7 @@ int main (int argc, char *argv[])
     }
     else {
       for(n=0; n<ntile_atm; n++) {
-	int i, j;   
+	int i, j;
         //Calculate the ATM grid cell area (not read from grid files)
 	get_grid_global_area(nxa[n], nya[n], xatm[n], yatm[n], area_atm[n]);
 	for(j=0; j<nya[n]; j++) for(i=0; i<nxa[n]; i++) {
@@ -762,10 +762,10 @@ int main (int argc, char *argv[])
     lnd_great_circle_algorithm = atm_great_circle_algorithm;
   }
   int n;
-  for(n=0; n<ntile_lnd; n++) {      
+  for(n=0; n<ntile_lnd; n++) {
     if(mpp_pe()==mpp_root_pe() && verbose) printf("Number of ATM and LND cells for tile %d are %d, %d.\n",n+1,nxa[n]*nya[n],nxl[n]*nyl[n]);
-    if(nxa[n]*nya[n] != nxl[n]*nyl[n]) printf("Warning: Number of ATM and LND cells for tile %d are not equal %d, %d.\n",n+1,nxa[n]*nya[n],nxl[n]*nyl[n]); 
-  } 
+    if(nxa[n]*nya[n] != nxl[n]*nyl[n]) printf("Warning: Number of ATM and LND cells for tile %d are not equal %d, %d.\n",n+1,nxa[n]*nya[n],nxl[n]*nyl[n]);
+  }
   if(print_memory)print_mem_usage("after read land grid");
 
   if (strcmp(omosaic, amosaic) == 0 ) ocn_same_as_atm = 1;
@@ -1214,7 +1214,7 @@ int main (int argc, char *argv[])
       double   x_out[MV], y_out[MV], z_out[MV];
       double   y_out_max, y_out_min;
       double   atmxlnd_x[MX][MV], atmxlnd_y[MX][MV], atmxlnd_z[MX][MV];
-      int      atmxlnd_c[MX][MV]; 
+      int      atmxlnd_c[MX][MV];
       int      num_v[MX];
       int      axl_i[MX], axl_j[MX], axl_t[MX];
       double   axl_xmin[MX], axl_xmax[MX], axl_ymin[MX], axl_ymax[MX];
@@ -1481,7 +1481,7 @@ int main (int argc, char *argv[])
 	        n_out = clip_2dx2d( xa, ya, na_in, xl, yl, nl_in, x_out, y_out );
 	      }
 	   }
-	 
+
 	    if (  n_out > 0 ) {
 	      if(clip_method == GREAT_CIRCLE_CLIP)
 		xarea=great_circle_area ( n_out, x_out, y_out, z_out);
@@ -2050,12 +2050,9 @@ int main (int argc, char *argv[])
 	    sprintf(ocn_mask_file, "ocean_mask_tile%d.nc", no+1);
 	  else
 	    strcpy(ocn_mask_file, "ocean_mask.nc");
-	  fid = mpp_open(ocn_mask_file, MPP_WRITE);
-	  mpp_def_global_att(fid, "grid_version", grid_version);
-	  mpp_def_global_att(fid, "code_version", tagname);
-	  if( clip_method == GREAT_CIRCLE_CLIP) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-	  mpp_def_global_att(fid, "history", history);
 
+	  fid = mpp_open(ocn_mask_file, MPP_WRITE);
+    print_provenance_gv_gca(fid, history, grid_version, clip_method == GREAT_CIRCLE_CLIP );
 
 	  dims[1] = mpp_def_dim(fid, "nx", nxo[no]);
 	  dims[0] = mpp_def_dim(fid, "ny", ny);
@@ -2103,10 +2100,8 @@ int main (int argc, char *argv[])
 	  else
 	    strcpy(lnd_mask_file, "land_mask.nc");
 	  fid = mpp_open(lnd_mask_file, MPP_WRITE);
-	  mpp_def_global_att(fid, "grid_version", grid_version);
-	  mpp_def_global_att(fid, "code_version", tagname);
-	  if( clip_method == GREAT_CIRCLE_CLIP) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-	  mpp_def_global_att(fid, "history", history);
+    print_provenance_gv_gca(fid, history, grid_version, clip_method == GREAT_CIRCLE_CLIP );
+
 	  dims[1] = mpp_def_dim(fid, "nx", nxl[nl]);
 	  dims[0] = mpp_def_dim(fid, "ny", nyl[nl]);
 	  id_mask = mpp_def_var(fid, "mask", MPP_DOUBLE, 2, dims,  2, "standard_name",
@@ -2158,11 +2153,10 @@ int main (int argc, char *argv[])
 	  else
 	    sprintf(axl_file[nfile_axl], "%s_%sX%s_%s.nc", amosaic_name, atile_name[na], lmosaic_name, ltile_name[nl]);
 	  sprintf(contact, "%s:%s::%s:%s", amosaic_name, atile_name[na], lmosaic_name, ltile_name[nl]);
+
 	  fid = mpp_open(axl_file[nfile_axl], MPP_WRITE);
-	  mpp_def_global_att(fid, "grid_version", grid_version);
-	  mpp_def_global_att(fid, "code_version", tagname);
-	  if( clip_method == GREAT_CIRCLE_CLIP) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-	  mpp_def_global_att(fid, "history", history);
+    print_provenance_gv_gca(fid, history, grid_version,  clip_method == GREAT_CIRCLE_CLIP);
+
 	  dim_string = mpp_def_dim(fid, "string", STRING);
 	  dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
 	  dim_two    = mpp_def_dim(fid, "two", 2);
@@ -2280,10 +2274,8 @@ int main (int argc, char *argv[])
 
 	  sprintf(contact, "%s:%s::%s:%s", amosaic_name, atile_name[na], omosaic_name, otile_name[no]);
 	  fid = mpp_open(axo_file[nfile_axo], MPP_WRITE);
-	  mpp_def_global_att(fid, "grid_version", grid_version);
-          mpp_def_global_att(fid, "code_version", tagname);
-	  if( clip_method == GREAT_CIRCLE_CLIP) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-	  mpp_def_global_att(fid, "history", history);
+    print_provenance_gv_gca(fid, history, grid_version, clip_method == GREAT_CIRCLE_CLIP );
+
 	  dim_string = mpp_def_dim(fid, "string", STRING);
 	  dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
 	  dim_two    = mpp_def_dim(fid, "two", 2);
@@ -2850,10 +2842,8 @@ int main (int argc, char *argv[])
 	  sprintf(contact, "%s:%s::%s:%s", lmosaic_name, ltile_name[nl], omosaic_name, otile_name[no]);
 
 	  fid = mpp_open(lxo_file[nfile_lxo], MPP_WRITE);
-	  mpp_def_global_att(fid, "grid_version", grid_version);
-          mpp_def_global_att(fid, "code_version", tagname);
-	  if( clip_method == GREAT_CIRCLE_CLIP) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-	  mpp_def_global_att(fid, "history", history);
+    print_provenance_gv_gca(fid, history, grid_version, clip_method == GREAT_CIRCLE_CLIP );
+
 	  dim_string = mpp_def_dim(fid, "string", STRING);
 	  dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
 	  dim_two    = mpp_def_dim(fid, "two", 2);
@@ -3398,7 +3388,7 @@ int main (int argc, char *argv[])
       }
 
       /* calculate land/sea fraction for wave grid from wavxocn */
-      {
+  {
 	int    iw, jw;
 	double ocn_frac;
 	int    id_mask, fid, dims[2];
@@ -3418,12 +3408,9 @@ int main (int argc, char *argv[])
 	    sprintf(wav_mask_file, "wave_mask_tile%d.nc", nw+1);
 	  else
 	    strcpy(wav_mask_file, "wave_mask.nc");
-	  fid = mpp_open(wav_mask_file, MPP_WRITE);
-	  mpp_def_global_att(fid, "grid_version", grid_version);
-	  mpp_def_global_att(fid, "code_version", tagname);
-	  if( clip_method == GREAT_CIRCLE_CLIP) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-	  mpp_def_global_att(fid, "history", history);
 
+	  fid = mpp_open(wav_mask_file, MPP_WRITE);
+    print_provenance_gv_gca(fid, history, grid_version, clip_method == GREAT_CIRCLE_CLIP );
 
 	  dims[1] = mpp_def_dim(fid, "nx", nxw[nw]);
 	  dims[0] = mpp_def_dim(fid, "ny", nyw[nw]);
@@ -3434,7 +3421,9 @@ int main (int argc, char *argv[])
 	  mpp_close(fid);
 	  free(mask);
 	}
-      }
+
+
+  }
     }
 
 
@@ -3469,10 +3458,8 @@ int main (int argc, char *argv[])
 	  sprintf(contact, "%s:%s::%s:%s", wmosaic_name, wtile_name[nw], omosaic_name, otile_name[no]);
 
 	  fid = mpp_open(wxo_file[nfile_wxo], MPP_WRITE);
-	  mpp_def_global_att(fid, "grid_version", grid_version);
-          mpp_def_global_att(fid, "code_version", tagname);
-	  if( clip_method == GREAT_CIRCLE_CLIP) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-	  mpp_def_global_att(fid, "history", history);
+    print_provenance_gv_gca(fid, history, grid_version, clip_method == GREAT_CIRCLE_CLIP );
+
 	  dim_string = mpp_def_dim(fid, "string", STRING);
 	  dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
 	  dim_two    = mpp_def_dim(fid, "two", 2);
@@ -3628,7 +3615,7 @@ int main (int argc, char *argv[])
 	for(i=0; i<nxa[n]*nya[n]; i++) {
 	  cur_ratio = fabs(atm_xarea[n][i] - area_atm[n][i])/area_atm[n][i];
 	  if(cur_ratio > 1.e-5) {
-	    printf("at tile =%d, i=%d, j=%d, ratio=%g, area1=%g, area2=%g\n", 
+	    printf("at tile =%d, i=%d, j=%d, ratio=%g, area1=%g, area2=%g\n",
 		   n+1, i%nxa[n], i/nxa[n], cur_ratio,  area_atm[n][i], atm_xarea[n][i] );
 	  }
 	  if(cur_ratio > max_ratio) {
@@ -3686,10 +3673,8 @@ int main (int argc, char *argv[])
     int id_amosaic, id_lmosaic, id_omosaic, id_wmosaic;
 
     fid = mpp_open(mosaic_file, MPP_WRITE);
-    mpp_def_global_att(fid, "grid_version", grid_version);
-    mpp_def_global_att(fid, "code_version", tagname);
-    if( clip_method == GREAT_CIRCLE_CLIP) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-    mpp_def_global_att(fid, "history", history);
+    print_provenance_gv_gca(fid, history, grid_version, clip_method == GREAT_CIRCLE_CLIP );
+
     dim_string = mpp_def_dim(fid, "string", STRING);
     if(nfile_axo >0) dim_axo = mpp_def_dim(fid, "nfile_aXo", nfile_axo);
     if(nfile_axl >0) dim_axl = mpp_def_dim(fid, "nfile_aXl", nfile_axl);
@@ -3809,7 +3794,7 @@ int main (int argc, char *argv[])
      else{
        printf("\n***** You have run make_coupler_mosaic, but there were at least %d grid cells with issues.\n",nbad);
        mpp_error("make_coupler_mosaic: omask is not equal ocn_frac");}
-  } 
+  }
   mpp_end();
 
   return 0;

--- a/tools/make_hgrid/make_hgrid.c
+++ b/tools/make_hgrid/make_hgrid.c
@@ -1237,14 +1237,11 @@ int main(int argc, char* argv[])
       else
         id_arcx = mpp_def_var(fid, "arcx", MPP_CHAR, 1, dimlist, 2, "standard_name", "grid_edge_x_arc_type",
                               "north_pole", north_pole_arcx );
-      mpp_def_global_att(fid, "grid_version", grid_version);
-      //mpp_def_global_att(fid, "code_version", tagname);
-      if(use_great_circle_algorithm) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-      if(n>=ntiles_global) mpp_def_global_att(fid, "nest_grids", "TRUE");
-      print_provenance(fid,  history);
-      //mpp_def_global_att(fid, "history", history);
 
+      print_provenance_gv_gca(fid,  history, grid_version, use_great_circle_algorithm);
+      if(n>=ntiles_global) mpp_def_global_att(fid, "nest_grids", "TRUE");
       mpp_end_def(fid);
+
       for(m=0; m<4; m++) { start[m] = 0; nwrite[m] = 0; }
       nwrite[0] = strlen(tilename);
       mpp_put_var_value_block(fid, id_tile, start, nwrite, tilename );

--- a/tools/make_hgrid/make_hgrid.c
+++ b/tools/make_hgrid/make_hgrid.c
@@ -447,7 +447,11 @@ int parse_comma_list(char *arg_list, int var_array[MAX_NESTS])
   return i;
 }
 
+#include <unistd.h>
 void print_provenance(int fid, char * history){
+  char hostname[128];
+  gethostname(hostname, 128);
+
   char * crTimeStringNoNL;
   time_t crTime;
   time(&crTime);
@@ -458,6 +462,8 @@ void print_provenance(int fid, char * history){
   mpp_def_global_att(fid, "git_hash", GIT_HEADHASH);
 
   mpp_def_global_att(fid, "creationtime", crTimeStringNoNL);
+
+  mpp_def_global_att(fid, "hostname", hostname);
 
   if(history != NULL){
     mpp_def_global_att(fid, "history", history);

--- a/tools/make_hgrid/make_hgrid.c
+++ b/tools/make_hgrid/make_hgrid.c
@@ -42,8 +42,6 @@
 #include <string.h>
 #include <getopt.h>
 #include <netcdf.h>
-#include <time.h>
-#include "config.h"
 #include "create_hgrid.h"
 #include "mpp.h"
 #include "mpp_domain.h"
@@ -445,29 +443,6 @@ int parse_comma_list(char *arg_list, int var_array[MAX_NESTS])
     }
 
   return i;
-}
-
-#include <unistd.h>
-void print_provenance(int fid, char * history){
-  char hostname[128];
-  gethostname(hostname, 128);
-
-  char * crTimeStringNoNL;
-  time_t crTime;
-  time(&crTime);
-  crTimeStringNoNL = strtok( ctime(&crTime), "\n");//remove the newline char
-
-  mpp_def_global_att(fid, "code_version", PACKAGE_VERSION);  //from autotools config.h
-
-  mpp_def_global_att(fid, "git_hash", GIT_HEADHASH);
-
-  mpp_def_global_att(fid, "creationtime", crTimeStringNoNL);
-
-  mpp_def_global_att(fid, "hostname", hostname);
-
-  if(history != NULL){
-    mpp_def_global_att(fid, "history", history);
-  }
 }
 
 

--- a/tools/make_quick_mosaic/make_quick_mosaic.c
+++ b/tools/make_quick_mosaic/make_quick_mosaic.c
@@ -491,14 +491,16 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
       mask = (double *)malloc(nx[n]*ny[n]*sizeof(double));
       for(i=0; i<nx[n]*ny[n]; i++) mask[i] = land_area[n][i]/cell_area[n][i];
 
-      if(ntiles > 1)
-	sprintf(lnd_mask_file, "land_mask_tile%d.nc", n+1);
-      else
-	strcpy(lnd_mask_file, "land_mask.nc");
+      if (ntiles > 1) {
+        sprintf(lnd_mask_file, "land_mask_tile%d.nc", n + 1);
+      } else {
+        strcpy(lnd_mask_file, "land_mask.nc");
+      }
+
       fid = mpp_open(lnd_mask_file, MPP_WRITE);
       mpp_def_global_att(fid, "grid_version", grid_version);
-      mpp_def_global_att(fid, "code_version", tagname);
-      mpp_def_global_att(fid, "history", history);
+      print_provenance(fid, history);
+
       dims[1] = mpp_def_dim(fid, "nx", nx[n]);
       dims[0] = mpp_def_dim(fid, "ny", ny[n]);
       id_mask = mpp_def_var(fid, "mask", MPP_DOUBLE, 2, dims,  2, "standard_name",
@@ -519,14 +521,16 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
       mask = (double *)malloc(nx[n]*ny[n]*sizeof(double));
       for(i=0; i<nx[n]*ny[n]; i++) mask[i] = ocean_area[n][i]/cell_area[n][i];
 
-      if(ntiles > 1)
-	sprintf(ocn_mask_file, "ocean_mask_tile%d.nc", n+1);
-      else
-	strcpy(ocn_mask_file, "ocean_mask.nc");
+      if (ntiles > 1) {
+        sprintf(ocn_mask_file, "ocean_mask_tile%d.nc", n + 1);
+      } else {
+        strcpy(ocn_mask_file, "ocean_mask.nc");
+      }
+
       fid = mpp_open(ocn_mask_file, MPP_WRITE);
       mpp_def_global_att(fid, "grid_version", grid_version);
-      mpp_def_global_att(fid, "code_version", tagname);
-      mpp_def_global_att(fid, "history", history);
+      print_provenance(fid, history);
+
       dims[1] = mpp_def_dim(fid, "nx", nx[n]);
       dims[0] = mpp_def_dim(fid, "ny", ny[n]);
       id_mask = mpp_def_var(fid, "mask", MPP_DOUBLE, 2, dims,  2, "standard_name",
@@ -599,23 +603,23 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
     /* write out the atmosXland exchange grid file, The file name will be atmos_mosaic_tile#Xland_mosaic_tile#.nc */
     nxgrid = 0;
     for(j=0; j<ny[n]; j++) for(i=0; i<nx[n]; i++) {
-      if(land_area[n][j*nx[n]+i] >0) {
-	i1[nxgrid] = i+1;
-	j1[nxgrid] = j+1;
-	i2[nxgrid] = i+1;
-	j2[nxgrid] = j+1;
-	area[nxgrid] = land_area[n][j*nx[n]+i];
-	di[nxgrid] = 0;
-	dj[nxgrid] = 0;
-	nxgrid++;
-      }
+        if (land_area[n][j * nx[n] + i] > 0) {
+          i1[nxgrid] = i + 1;
+          j1[nxgrid] = j + 1;
+          i2[nxgrid] = i + 1;
+          j2[nxgrid] = j + 1;
+          area[nxgrid] = land_area[n][j * nx[n] + i];
+          di[nxgrid] = 0;
+          dj[nxgrid] = 0;
+          nxgrid++;
+        }
     }
 
     fid = mpp_open(axl_file[n], MPP_WRITE);
     sprintf(contact, "atmos_mosaic:%s::land_mosaic:%s", tilename[n], tilename[n]);
     mpp_def_global_att(fid, "grid_version", grid_version);
-    mpp_def_global_att(fid, "code_version", tagname);
-    mpp_def_global_att(fid, "history", history);
+    print_provenance(fid, history);
+
     dim_string = mpp_def_dim(fid, "string", STRING);
     dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
     dim_two    = mpp_def_dim(fid, "two", 2);
@@ -650,23 +654,23 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
     /* write out the atmosXocean exchange grid file, The file name will be atmos_mosaic_tile#Xocean_mosaic_tile#.nc */
     nxgrid = 0;
     for(j=0; j<ny[n]; j++) for(i=0; i<nx[n]; i++) {
-      if(ocean_area[n][j*nx[n]+i] >0) {
-	i1[nxgrid] = i+1;
-	j1[nxgrid] = j+1;
-	i2[nxgrid] = i+1;
-	j2[nxgrid] = j+1;
-	area[nxgrid] = ocean_area[n][j*nx[n]+i];
-	di[nxgrid] = 0;
-	dj[nxgrid] = 0;
-	nxgrid++;
-      }
+        if (ocean_area[n][j * nx[n] + i] > 0) {
+          i1[nxgrid] = i + 1;
+          j1[nxgrid] = j + 1;
+          i2[nxgrid] = i + 1;
+          j2[nxgrid] = j + 1;
+          area[nxgrid] = ocean_area[n][j * nx[n] + i];
+          di[nxgrid] = 0;
+          dj[nxgrid] = 0;
+          nxgrid++;
+        }
     }
+
     fid = mpp_open(axo_file[n], MPP_WRITE);
+    mpp_def_global_att(fid, "grid_version", grid_version);
+    print_provenance(fid, history);
 
     sprintf(contact, "atmos_mosaic:%s::ocean_mosaic:%s", tilename[n], tilename[n]);
-    mpp_def_global_att(fid, "grid_version", grid_version);
-    mpp_def_global_att(fid, "code_version", tagname);
-    mpp_def_global_att(fid, "history", history);
     dim_string = mpp_def_dim(fid, "string", STRING);
     dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
     dim_two    = mpp_def_dim(fid, "two", 2);
@@ -703,8 +707,8 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
     fid = mpp_open(lxo_file[n], MPP_WRITE);
     sprintf(contact, "land_mosaic:%s::ocean_mosaic:%s", tilename[n], tilename[n]);
     mpp_def_global_att(fid, "grid_version", grid_version);
-    mpp_def_global_att(fid, "code_version", tagname);
-    mpp_def_global_att(fid, "history", history);
+    print_provenance(fid, history);
+
     dim_string = mpp_def_dim(fid, "string", STRING);
     dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
     dim_two    = mpp_def_dim(fid, "two", 2);
@@ -762,8 +766,8 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
     printf("mosaic_file is %s\n", mosaic_file);
     fid = mpp_open(mosaic_file, MPP_WRITE);
     mpp_def_global_att(fid, "grid_version", grid_version);
-    mpp_def_global_att(fid, "code_version", tagname);
-    mpp_def_global_att(fid, "history", history);
+    print_provenance(fid, history);
+
     dim_string = mpp_def_dim(fid, "string", STRING);
     dim_axo = mpp_def_dim(fid, "nfile_aXo", ntiles);
     dim_axl = mpp_def_dim(fid, "nfile_aXl", ntiles);

--- a/tools/make_quick_mosaic/make_quick_mosaic.c
+++ b/tools/make_quick_mosaic/make_quick_mosaic.c
@@ -498,8 +498,7 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
       }
 
       fid = mpp_open(lnd_mask_file, MPP_WRITE);
-      mpp_def_global_att(fid, "grid_version", grid_version);
-      print_provenance(fid, history);
+      print_provenance_gv(fid, history, grid_version);
 
       dims[1] = mpp_def_dim(fid, "nx", nx[n]);
       dims[0] = mpp_def_dim(fid, "ny", ny[n]);
@@ -528,8 +527,7 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
       }
 
       fid = mpp_open(ocn_mask_file, MPP_WRITE);
-      mpp_def_global_att(fid, "grid_version", grid_version);
-      print_provenance(fid, history);
+      print_provenance_gv(fid, history, grid_version);
 
       dims[1] = mpp_def_dim(fid, "nx", nx[n]);
       dims[0] = mpp_def_dim(fid, "ny", ny[n]);
@@ -617,8 +615,7 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
 
     fid = mpp_open(axl_file[n], MPP_WRITE);
     sprintf(contact, "atmos_mosaic:%s::land_mosaic:%s", tilename[n], tilename[n]);
-    mpp_def_global_att(fid, "grid_version", grid_version);
-    print_provenance(fid, history);
+    print_provenance_gv(fid, history, grid_version);
 
     dim_string = mpp_def_dim(fid, "string", STRING);
     dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
@@ -667,8 +664,7 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
     }
 
     fid = mpp_open(axo_file[n], MPP_WRITE);
-    mpp_def_global_att(fid, "grid_version", grid_version);
-    print_provenance(fid, history);
+    print_provenance_gv(fid, history,grid_version);
 
     sprintf(contact, "atmos_mosaic:%s::ocean_mosaic:%s", tilename[n], tilename[n]);
     dim_string = mpp_def_dim(fid, "string", STRING);
@@ -706,8 +702,7 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
     /* write out landXocean exchange grid information */
     fid = mpp_open(lxo_file[n], MPP_WRITE);
     sprintf(contact, "land_mosaic:%s::ocean_mosaic:%s", tilename[n], tilename[n]);
-    mpp_def_global_att(fid, "grid_version", grid_version);
-    print_provenance(fid, history);
+    print_provenance_gv(fid, history, grid_version);
 
     dim_string = mpp_def_dim(fid, "string", STRING);
     dim_ncells = mpp_def_dim(fid, "ncells", nxgrid);
@@ -765,8 +760,7 @@ printf("%15.10f, %15.10f, %15.10f\n", ocean_area[n][i], land_area[n][i]+AREA_RAT
     }
     printf("mosaic_file is %s\n", mosaic_file);
     fid = mpp_open(mosaic_file, MPP_WRITE);
-    mpp_def_global_att(fid, "grid_version", grid_version);
-    print_provenance(fid, history);
+    print_provenance_gv(fid, history, grid_version);
 
     dim_string = mpp_def_dim(fid, "string", STRING);
     dim_axo = mpp_def_dim(fid, "nfile_aXo", ntiles);

--- a/tools/make_regional_mosaic/make_regional_mosaic.c
+++ b/tools/make_regional_mosaic/make_regional_mosaic.c
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
   double *x=NULL, *y=NULL;
   char history[512], dir[512];
   char gridfile[512], tilename[32];
-  int errflg, c, i;  
+  int errflg, c, i;
   int option_index;
 
   static struct option long_options[] = {
@@ -116,13 +116,13 @@ int main(int argc, char* argv[])
     printf("ERROR from make_regional_mosaic: regional_file is not specified");
     errflg++;
   }
-  
+
   if (errflg) {
     char **u = usage;
     while (*u) { fprintf(stderr, "%s\n", *u); u++; }
     exit(2);
   }
-  
+
   strcpy(history,argv[0]);
 
   for(i=1;i<argc;i++) {
@@ -140,7 +140,7 @@ int main(int argc, char* argv[])
     ntiles = mpp_get_dimlen(fid, "ntiles");
     mpp_close(fid);
   }
-  
+
   /* figure out the tile number from the regional_file name */
   {
     char *pch=NULL;
@@ -150,7 +150,7 @@ int main(int argc, char* argv[])
     for(n=0; n<ntiles; n++) {
       sprintf(str, ".tile%d.nc", n+1);
       pch = strstr (regional_file, str);
-      
+
       if( pch ) {
 	tile = n;
 	break;
@@ -159,12 +159,12 @@ int main(int argc, char* argv[])
     }
     if(tile == -1) mpp_error("make_regional_mosaic: tile number not found in the regional_file name");
   }
-    
+
   {
     int fid, vid;
     double *tmpx=NULL, *tmpy=NULL;
     int *indx=NULL, *indy=NULL;
-    
+
     fid = mpp_open(regional_file, MPP_READ);
     nx = mpp_get_dimlen(fid, xaxis_name);
     ny = mpp_get_dimlen(fid, yaxis_name);
@@ -190,14 +190,14 @@ int main(int argc, char* argv[])
     /* i_max-i_min+1 should equal nx and j_max-j_min+1 should equal ny */
     if( i_max-i_min+1 != nx ) mpp_error("make_regional_mosaic: i_max-i_min+1 != nx ");
     if( j_max-j_min+1 != ny ) mpp_error("make_regional_mosaic: j_max-j_min+1 != ny ");
-    
+
   }
-  
+
   {
     char filename[512], gridfile[512];
     size_t start[4], nread[4];
     int fid, vid, n;
-    
+
     /* read the regional grid from global grid */
     for(n=0; n<4; n++) {
       start[n] = 0;
@@ -210,10 +210,10 @@ int main(int argc, char* argv[])
     mpp_get_var_value_block(fid, vid, start, nread, filename);
     sprintf(gridfile, "%s/%s", dir, filename);
     mpp_close(fid);
-    
+
     x = (double *)malloc((2*nx+1)*(2*ny+1)*sizeof(double));
     y = (double *)malloc((2*nx+1)*(2*ny+1)*sizeof(double));
-  
+
     fid = mpp_open(gridfile, MPP_READ);
     start[0] = 2*j_min - 2; nread[0] = 2*ny+1;
     start[1] = 2*i_min - 2; nread[1] = 2*nx+1;
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
     int fid;
     int m;
     size_t start[4], nwrite[4];
-    
+
     sprintf(gridfile, "regional_grid.tile%d.nc", tile+1);
     fid = mpp_open(gridfile, MPP_WRITE);
     dimlist[0] = mpp_def_dim(fid, "string", STRING);
@@ -245,8 +245,8 @@ int main(int argc, char* argv[])
 		       "units", "degree_east");
     id_y = mpp_def_var(fid, "y", MPP_DOUBLE, 2, dims, 2, "standard_name", "geographic_latitude",
 		       "units", "degree_north");
-    mpp_def_global_att(fid, "code_version", tagname);
-    mpp_def_global_att(fid, "history", history);
+
+    print_provenance(fid, history);
 
     mpp_end_def(fid);
     sprintf(tilename, "tile%d", tile+1);
@@ -275,8 +275,9 @@ int main(int argc, char* argv[])
     dim[0] = dim_ntiles; dim[1] = dim_string;
     id_gridfiles = mpp_def_var(fid, "gridfiles", MPP_CHAR, 2, dim, 0);
     id_gridtiles = mpp_def_var(fid, "gridtiles", MPP_CHAR, 2, dim, 0);
-    mpp_def_global_att(fid, "code_version", tagname);
-    mpp_def_global_att(fid, "history", history);
+
+    print_provenance(fid, history);
+
     mpp_end_def(fid);
 
         /* write out data */
@@ -297,5 +298,5 @@ int main(int argc, char* argv[])
   printf("congradulation: You have successfully run make_regional_mosaic\n");
 
   return 0;
-  
+
 }; // end of main

--- a/tools/make_solo_mosaic/make_solo_mosaic.c
+++ b/tools/make_solo_mosaic/make_solo_mosaic.c
@@ -25,6 +25,7 @@
 #include "constant.h"
 #include "mpp_io.h"
 #include "mpp.h"
+#include "tool_util.h"
 
 char *usage[] = {
   "",
@@ -302,9 +303,10 @@ int main (int argc, char *argv[])
 				     "starting_ending_point_index_of_contact");
 
     }
+
     mpp_def_global_att(fid, "grid_version", grid_version);
-    mpp_def_global_att(fid, "code_version", tagname);
-    mpp_def_global_att(fid, "history", history);
+    print_provenance(fid, history);
+
     mpp_end_def(fid);
 
     /* write out data */

--- a/tools/make_solo_mosaic/make_solo_mosaic.c
+++ b/tools/make_solo_mosaic/make_solo_mosaic.c
@@ -304,8 +304,7 @@ int main (int argc, char *argv[])
 
     }
 
-    mpp_def_global_att(fid, "grid_version", grid_version);
-    print_provenance(fid, history);
+    print_provenance_gv(fid, history, grid_version);
 
     mpp_end_def(fid);
 

--- a/tools/make_topog/make_topog.c
+++ b/tools/make_topog/make_topog.c
@@ -723,11 +723,7 @@ int main(int argc, char* argv[])
     }
     mpp_close(m_fid);
 
-    mpp_def_global_att(fid, "grid_version", grid_version);
-    if(use_great_circle_algorithm){
-       mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-    }
-    print_provenance(fid, history);
+    print_provenance_gv_gca(fid, history, grid_version, use_great_circle_algorithm);
     mpp_end_def(fid);
 
     if(mpp_pe()==mpp_root_pe() && use_great_circle_algorithm)

--- a/tools/make_topog/make_topog.c
+++ b/tools/make_topog/make_topog.c
@@ -79,7 +79,7 @@ char *usage[] = {
   "     3.  'gaussian':          Construct gaussian bump on a sloping bottom.               ",
   "                              --bottom_depth, --min_depth --gauss_amp, --gauss_scale,    ",
   "                              --slope_x, --slope_y are optional arguments.               ",
-  "                                                                                         ",  
+  "                                                                                         ",
   "     4.. 'bowl':              --bottom_depth, --min_depth, --bowl_south, --bowl_north,   ",
   "                              --bowl_west, --bowl_east are optional arguments.           ",
   "                                                                                         ",
@@ -123,13 +123,13 @@ char *usage[] = {
   "                                                                                         ",
   "   --min_depth #                 Specify minimum depth of ocean.                         ",
   "                                 default value is 10 meter.                              ",
-  "                                                                                         ",  
+  "                                                                                         ",
   "   --scale_factor #              Specify scaling factor for topography data (e.g. -1 to  ",
   "                                 flip sign or 0.01 to convert from centimeters).         ",
   "                                 default value is 1.                                     ",
   "                                                                                         ",
   "   --num_filter_pass #           Specify number of passes of spatial filter              ",
-  "                                 default value is 1.                                     ",  
+  "                                 default value is 1.                                     ",
   "                                                                                         ",
   "   --gauss_amp #                 specify height of gaussian bump as percentage of ocean  ",
   "                                 depth. default value is 0.5.                            ",
@@ -147,11 +147,11 @@ char *usage[] = {
   "                                 Default value is 60.                                    ",
   "                                                                                         ",
   "   --bowl_north #                Specify northern boundary of Winton bowl.               ",
-  "                                 Default value is 70.                                    ",  
+  "                                 Default value is 70.                                    ",
   "                                                                                         ",
   "   --bowl_west #                 Specify western boundary of Winton bowl.                ",
   "                                 Default value is 0.                                     ",
-  "                                                                                         ",  
+  "                                                                                         ",
   "   --bowl_east #                 Specify eastern boundary of Winton bowl.                ",
   "                                 Default value is 20.                                    ",
   "                                                                                         ",
@@ -178,7 +178,7 @@ char *usage[] = {
   "                                 the box channel.                                        ",
   "                                                                                         ",
   "   --jwest_north #               Specify the ending j-index on the west boundary of      ",
-  "                                 the box channel.                                        ",  
+  "                                 the box channel.                                        ",
   "                                                                                         ",
   "   --jeast_south #               Specify the starting j-index on the east boundary of    ",
   "                                 the box channel.                                        ",
@@ -241,8 +241,8 @@ char *usage[] = {
   "   --verbose                     Will print out running time message when this           ",
   "                                 option is set. Otherwise the run will be silent         ",
   "                                 when there is no error.                                 ",
-  
-  "   Example                                                                               ", 
+
+  "   Example                                                                               ",
   "                                                                                         ",
   "   1. Generate 'realistic' topography                                                    ",
   "   > make_topog --mosaic mosaic.nc --topog_type realistic                                ",
@@ -295,7 +295,7 @@ int main(int argc, char* argv[])
   int    jwest_south=0, jwest_north=0, jeast_south=0, jeast_north=0;
   double dome_slope=0.01;
   double dome_bottom=3600.0;
-  double dome_embayment_west=19.0; 
+  double dome_embayment_west=19.0;
   double dome_embayment_east=21.0;
   double dome_embayment_south=69.0;
   double dome_embayment_depth=600.0;
@@ -314,7 +314,7 @@ int main(int argc, char* argv[])
   int    errflg = (argc == 1);
   int    option_index, i, c;
   unsigned int verbose = 0;
-  
+
   /*
    * process command line
    */
@@ -332,14 +332,14 @@ int main(int argc, char* argv[])
     {"num_filter_pass",             required_argument, NULL, 'j'},
     {"gauss_amp",                   required_argument, NULL, 'k'},
     {"gauss_scale",                 required_argument, NULL, 'l'},
-    {"slope_x",                     required_argument, NULL, 'm'},    
+    {"slope_x",                     required_argument, NULL, 'm'},
     {"slope_y",                     required_argument, NULL, 'n'},
     {"bowl_south",                  required_argument, NULL, 'p'},
     {"bowl_north",                  required_argument, NULL, 'q'},
     {"bowl_west",                   required_argument, NULL, 'r'},
     {"bowl_east",                   required_argument, NULL, 's'},
     {"fill_first_row",              no_argument,       NULL, 't'},
-    {"filter_topog",                no_argument,       NULL, 'u'},    
+    {"filter_topog",                no_argument,       NULL, 'u'},
     {"round_shallow",               no_argument,       NULL, 'v'},
     {"fill_shallow",                no_argument,       NULL, 'w'},
     {"deepen_shallow",              no_argument,       NULL, 'x'},
@@ -374,13 +374,13 @@ int main(int argc, char* argv[])
 
   mpp_init(&argc, &argv);
 
-  mpp_domain_init();  
-   
+  mpp_domain_init();
+
   while ((c = getopt_long(argc, argv, "", long_options, &option_index)) != -1)
     switch (c) {
     case 'a':
       mosaic_file = optarg;
-      break;      
+      break;
     case 'b':
       strcpy(topog_type, optarg);
       break;
@@ -389,7 +389,7 @@ int main(int argc, char* argv[])
       break;
     case 'Y':
       y_refine = atoi(optarg);
-      break;      
+      break;
     case 'd':
       topog_file = optarg;
       break;
@@ -398,7 +398,7 @@ int main(int argc, char* argv[])
       break;
     case 'f':
       bottom_depth = atof(optarg);
-      break; 
+      break;
     case 'g':
       min_depth = atof(optarg);
       break;
@@ -407,7 +407,7 @@ int main(int argc, char* argv[])
       break;
     case 'j':
       num_filter_pass = atoi(optarg);
-      break; 
+      break;
     case 'k':
       gauss_amp = atof(optarg);
       break;
@@ -515,7 +515,7 @@ int main(int argc, char* argv[])
       break;
     case 'V':
       verbose = 1;
-      break;      
+      break;
     case '?':
       errflg++;
       break;
@@ -536,7 +536,7 @@ int main(int argc, char* argv[])
   if(mpp_pe() == mpp_root_pe() && verbose) printf("NOTE from make_topog ==> x_refine is %d, y_refine is %d\n",
 				       x_refine, y_refine);
 
-  /* vgrid_file can only be passed in when topog_type is realistic */ 
+  /* vgrid_file can only be passed in when topog_type is realistic */
   if(vgrid_file && strcmp(topog_type,"realistic"))
       mpp_error("make_topog: --vgrid_file should not be specified when topog_type = realistic");
 
@@ -552,7 +552,7 @@ int main(int argc, char* argv[])
       printf("NOTE from make_topog ==> gauss_amp is: %f\n", gauss_amp );
       printf("NOTE from make_topog ==> gauss_scale is: %f\n", gauss_scale );
       printf("NOTE from make_topog ==> slope_x is: %f\n", slope_x );
-      printf("NOTE from make_topog ==> slope_y is: %f\n", slope_y );      
+      printf("NOTE from make_topog ==> slope_y is: %f\n", slope_y );
     }
   }
   else if(strcmp(topog_type,"bowl") == 0) {
@@ -592,7 +592,7 @@ int main(int argc, char* argv[])
 	printf("NOTE from make_topog ==> vgrid_file is %s\n", vgrid_file);
       else
 	printf("NOTE from make_topog ==> no vgrid_file is specified\n");
-      
+
       if(fill_first_row) printf("NOTE from make_topog ==>make first row of ocean model all land points.\n");
       if(filter_topog) printf("NOTE from make_topog ==>will apply filter to topography.\n");
       if(round_shallow) printf("NOTE from make_topog ==>Make cells land if depth is less than 1/2 "
@@ -624,7 +624,7 @@ int main(int argc, char* argv[])
   else {
     mpp_error("make_topog: topog_type should be rectangular_basin, gaussian, bowl, idealized, realistic, box_channel or dome");
   }
-  
+
   if(mpp_pe() == mpp_root_pe() && verbose) {
     printf("**************************************************\n");
     printf("Begin to generate topography \n");
@@ -642,7 +642,7 @@ int main(int argc, char* argv[])
     char **tile_files=NULL;
     char history[512], dimx_name[128], dimy_name[128], depth_name[128], level_name[128];
     char gridfile[256], griddir[256];
-    
+
     /* history will be write out as global attribute
        in output file to specify the command line arguments
     */
@@ -656,11 +656,11 @@ int main(int argc, char* argv[])
 
     /* grid should be located in the same directory of mosaic file */
     get_file_path(mosaic_file, griddir);
-    
+
     /* get mosaic dimension */
     m_fid = mpp_open(mosaic_file, MPP_READ);
     ntiles = mpp_get_dimlen( m_fid, "ntiles");
-    
+
     tile_files = (char **)malloc(ntiles*sizeof(double *));
     id_depth = (int *)malloc(ntiles*sizeof(int));
     id_level = (int *)malloc(ntiles*sizeof(int));
@@ -671,10 +671,10 @@ int main(int argc, char* argv[])
     nx = (int *)malloc(ntiles*sizeof(int));
     ny = (int *)malloc(ntiles*sizeof(int));
     nxp = (int *)malloc(ntiles*sizeof(int));
-    nyp = (int *)malloc(ntiles*sizeof(int));   
+    nyp = (int *)malloc(ntiles*sizeof(int));
     for( n = 0; n < ntiles; n++ ) {
       int use_great_circle_algorithm_prev=0;
-      
+
       tile_files[n] = (char *)malloc(STRING*sizeof(double));
       start[0] = n;
       start[1] = 0;
@@ -705,7 +705,7 @@ int main(int argc, char* argv[])
 	if(vgrid_file)sprintf(level_name, "num_levels_tile%d", n+1);
       }
 
-      dims[1] = mpp_def_dim(fid, dimx_name, nx[n]); 
+      dims[1] = mpp_def_dim(fid, dimx_name, nx[n]);
       dims[0] = mpp_def_dim(fid, dimy_name, ny[n]);
       id_depth[n] = mpp_def_var(fid, depth_name, NC_DOUBLE, 2, dims,  2, "standard_name",
 				"topographic depth at T-cell centers", "units", "meters");
@@ -722,26 +722,27 @@ int main(int argc, char* argv[])
       mpp_close(g_fid);
     }
     mpp_close(m_fid);
+
     mpp_def_global_att(fid, "grid_version", grid_version);
-    mpp_def_global_att(fid, "code_version", tagname);
-    if(use_great_circle_algorithm) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-    mpp_def_global_att(fid, "history", history);
-    
+    if(use_great_circle_algorithm){
+       mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
+    }
+    print_provenance(fid, history);
     mpp_end_def(fid);
 
     if(mpp_pe()==mpp_root_pe() && use_great_circle_algorithm)
       printf("\n NOTE from make_topog: use great circle algorithm\n");
-    
+
     /* get the boundary condition for realistics topogrpahy, currently only support tripolar_grid,
      cyclic_x and cyclic_y*/
     if(my_topog_type == REALISTIC) get_boundary_type(mosaic_file, VERSION_2, &cyclic_x, &cyclic_y, &tripolar_grid);
-    
+
     /* Generate topography and write out to the output_file */
     for(n=0; n<ntiles; n++) {
       int layout[2], isc, iec, jsc, jec, nxc, nyc, ni, i, j;
       double *gdata=NULL, *tmp=NULL;
       domain2D domain;
-      
+
       /* define the domain, each tile will be run on all the processors. */
       mpp_define_layout( nx[n], ny[n], mpp_npes(), layout);
       mpp_define_domain2d( nx[n], ny[n], layout, 0, 0, &domain);
@@ -758,7 +759,7 @@ int main(int argc, char* argv[])
 	y   = (double *)malloc((nxc+1)*(nyc+1)*sizeof(double));
       }
       depth = (double *)malloc(nxc*nyc*sizeof(double));
-      if(vgrid_file) num_levels = (int* )malloc(nxc*nyc*sizeof(int)); 
+      if(vgrid_file) num_levels = (int* )malloc(nxc*nyc*sizeof(int));
       tmp   = (double *)malloc((nxc*x_refine+1)*(nyc*y_refine+1)*sizeof(double));
       start[0] = jsc*y_refine; start[1] = isc*x_refine;
       nread[0] = nyc*y_refine+1; nread[1] = nxc*x_refine+1;
@@ -800,7 +801,7 @@ int main(int argc, char* argv[])
       case IDEALIZED:
 	create_idealized_topog( nx[n], ny[n], x, y, bottom_depth, min_depth, depth);
 	break;
-      case REALISTIC:	
+      case REALISTIC:
 	create_realistic_topog(nxc, nyc, x, y, vgrid_file, topog_file, topog_field, scale_factor,
 			       tripolar_grid, cyclic_x, cyclic_y, fill_first_row, filter_topog, num_filter_pass,
 			       smooth_topo_allow_deepening, round_shallow, fill_shallow,
@@ -841,7 +842,7 @@ int main(int argc, char* argv[])
       mpp_delete_domain2d(&domain);
     }
     mpp_close(fid);
-  
+
     /*release memory */
     free(id_depth);
     free(id_level);
@@ -852,7 +853,7 @@ int main(int argc, char* argv[])
     free(nxp);
     free(nyp);
   }
-    
+
   if(mpp_pe() == mpp_root_pe() && verbose ) printf("Successfully generate %s\n",output_file);
 
   mpp_end();

--- a/tools/make_vgrid/make_vgrid.c
+++ b/tools/make_vgrid/make_vgrid.c
@@ -73,11 +73,11 @@ char *usage[] = {
   "                                                                                 ",
   "   --nbnds nbnds             Specify number of vertical regions for varying      ",
   "                             resolution.                                         ",
-  "                                                                                 ", 
+  "                                                                                 ",
   "   --bnds z(1),.,z(nbnds)    Specify boundaries for defining vertical regions of ",
   "                             varying resolution.                                 ",
   "                                                                                 ",
-  
+
   "   Optional Flags:                                                               ",
   "                                                                                 ",
   "   --nz nz(1),..,nz(nbnds-1) Number of supergrid points (double number of        ",
@@ -92,7 +92,7 @@ char *usage[] = {
   " --grid_name gridname        Specify the grid name. The output grid file name    ",
   "                             will be grid_name.nc. The default value is          ",
   "                             vertical_grid.                                      ",
-  "                                                                                 ", 
+  "                                                                                 ",
   " --center   center           Specify the center location of grid. The valid      ",
   "                             entry will be 'none', 't_cell' or 'c_cell' with     ",
   "                             default value 'none'. The grid refinement is        ",
@@ -101,7 +101,7 @@ char *usage[] = {
   "                             used in MOM.                                        ",
   "                                                                                 ",
   "                                                                                 ",
-  "   Example 1: Use Monotonic cubic spline interpolation                           ", 
+  "   Example 1: Use Monotonic cubic spline interpolation                           ",
   "                                                                                 ",
   "     make_vgrid --nbnds 3 --bnds 10,200,1000 --nz 10,20                          ",
   "       will make a grid file with 60 supergrid cells, 30 model grid cells        ",
@@ -125,7 +125,7 @@ char *usage[] = {
   "      Will make a vertical grid similar to GFDL/CM2/ocn w/ 100 supergrid cells.  ",
   "                                                                                 ",
   "",
-  NULL };  
+  NULL };
 
 char grid_version[] = "0.2";
 char tagname[] = "$Name: fre-nctools-bronx-10 $";
@@ -145,17 +145,17 @@ int main(int argc, char* argv[])
   char entry[512];
   char history[256];
   int errflg, c, option_index = 0;
-  static struct option long_options[]= {  
+  static struct option long_options[]= {
     {"nbnds",    required_argument, NULL, 'n'},
     {"bnds",     required_argument, NULL, 'b'},
     {"nz",       required_argument, NULL, 'z'},
     {"dbnds",    required_argument, NULL, 'd'},
     {"stretch",    required_argument, NULL, 's'},
-    {"grid_name",required_argument, NULL, 'o'},        
-    {"center",   required_argument, NULL, 'c'},    
+    {"grid_name",required_argument, NULL, 'o'},
+    {"center",   required_argument, NULL, 'c'},
     {0, 0, 0, 0}
   };
-  
+
     /*
    * process command line
    */
@@ -190,14 +190,14 @@ int main(int argc, char* argv[])
       strcpy(center, optarg);
       break;
     case '?':
-      errflg++;      
+      errflg++;
     }
 
   if (errflg ) {
     char **u = usage;
     while (*u) { fprintf(stderr, "%s\n", *u); u++; }
     mpp_error("Wrong usage of this program, check arguments") ;
-  }    
+  }
 
   /* check the command-line arguments to make sure the value are suitable */
   if( nbnds < 2 ) mpp_error("number of bounds specified through -nbnd should be an integer greater than 1");
@@ -221,7 +221,7 @@ int main(int argc, char* argv[])
     create_vgrid(nbnds, bnds, nz, dbnds, stretch, use_legacy, zeta, &npts, center);
     if(use_legacy) nk = npts;
   }
-  
+
   /* define history to be the history in the grid file */
   strcpy(history,argv[0]);
 
@@ -231,27 +231,26 @@ int main(int argc, char* argv[])
   }
 
   sprintf(filename, "%s.nc", gridname);
-  
+
   /* write out vertical grid into a netcdf file */
   {
     int fid, dim, varid;
-    
+
     fid = mpp_open(filename, MPP_WRITE);
     dim  = mpp_def_dim(fid, "nzv", nk+1);
     varid = mpp_def_var(fid, "zeta", NC_DOUBLE, 1, &dim, 2, "standard_name", "vertical_grid_vertex",
 			"units", "meters");
     mpp_def_global_att(fid, "grid_version", grid_version);
-    mpp_def_global_att(fid, "code_version", tagname);
-    mpp_def_global_att(fid, "history", history);    
+    print_provenance(fid, history);
     mpp_end_def(fid);
     mpp_put_var_value(fid, varid, zeta);
-  
+
     mpp_close(fid);
   }
 
   /*  if(mpp_pe() == mpp_root_pe()) printf("Successfully generate vertical grid file %s\n", filename); */
-  
+
   mpp_end();
 
   return 0;
-}    
+}

--- a/tools/make_vgrid/make_vgrid.c
+++ b/tools/make_vgrid/make_vgrid.c
@@ -240,8 +240,7 @@ int main(int argc, char* argv[])
     dim  = mpp_def_dim(fid, "nzv", nk+1);
     varid = mpp_def_var(fid, "zeta", NC_DOUBLE, 1, &dim, 2, "standard_name", "vertical_grid_vertex",
 			"units", "meters");
-    mpp_def_global_att(fid, "grid_version", grid_version);
-    print_provenance(fid, history);
+    print_provenance_gv(fid, history, grid_version);
     mpp_end_def(fid);
     mpp_put_var_value(fid, varid, zeta);
 

--- a/tools/remap_land/remap_land.c
+++ b/tools/remap_land/remap_land.c
@@ -1414,8 +1414,7 @@ int main(int argc, char *argv[]) {
             id_index_lake =
               mpp_def_var(fid, "remap_index_lake", NC_INT, 1, &dim_npts, 1, "standard_name", "lake remap index");
           }
-          mpp_def_global_att(fid, "history", history);
-
+          print_provenance(fid, history);
           mpp_end_def(fid);
 
           mpp_gather_field_int_root(nxc_dst, face_map_soil, gdata);
@@ -1688,8 +1687,7 @@ int main(int argc, char *argv[]) {
         }
       }
 
-      mpp_def_global_att(fid_dst, "history", history);
-
+      print_provenance(fid_dst, history);
       mpp_end_def(fid_dst);
 
       /*-------------------------------------------------------------------------------

--- a/tools/river_regrid/river_regrid.c
+++ b/tools/river_regrid/river_regrid.c
@@ -109,7 +109,7 @@ char   x_name[]     = "x";
 char   y_name[]     = "y";
 int    sizeof_int  = 0;
 int    sizeof_double = 0;
-double suba_cutoff = 1.e12;  
+double suba_cutoff = 1.e12;
 double land_thresh = 0;
 double min_frac = 0;
 
@@ -163,7 +163,7 @@ double distance(double lon1, double lat1, double lon2, double lat2);
 
 int main(int argc, char* argv[])
 {
-  unsigned int opcode = 0;  
+  unsigned int opcode = 0;
   int          option_index, c;
   char         *mosaic_file     = NULL;
   char         *river_src_file  = NULL;
@@ -171,11 +171,11 @@ int main(int argc, char* argv[])
   int          ntiles, n;
   char         land_mosaic_dir[256];
   char         land_mosaic[256];
-  char         land_mosaic_file[256];  
+  char         land_mosaic_file[256];
   char         history[1024];
   int          read_land_mask = 0;
   int          great_circle_algorithm = 0;
-  
+
   river_type river_in;
   river_type *river_out; /* may be more than one tile */
 
@@ -189,12 +189,12 @@ int main(int argc, char* argv[])
     {"min_frac",          required_argument, NULL, 'e'},
     {"read_land_mask",    no_argument,       NULL, 'f'},
     {0, 0, 0, 0},
-  };      
+  };
 
   mpp_init(&argc, &argv);
   sizeof_int = sizeof(int);
   sizeof_double = sizeof(double);
-  
+
   /* currently we are assuming the tool is always run on 1 processor */
   if(mpp_npes() > 1) mpp_error("river_regrid: parallel is not supported yet, try running one single processor");
   while ((c = getopt_long(argc, argv, "", long_options, &option_index)) != -1) {
@@ -213,7 +213,7 @@ int main(int argc, char* argv[])
       break;
     case 'e':
       min_frac = atof(optarg);
-      break;      
+      break;
     case 'f':
       read_land_mask = 1;
       break;
@@ -222,12 +222,12 @@ int main(int argc, char* argv[])
       break;
     }
   }
-  
+
   if (errflg) {
     char **u = usage;
     while (*u) { fprintf(stderr, "%s\n", *u); u++; }
     exit(2);
-  }       
+  }
 
   /* check the arguments */
   if( !mosaic_file    ) mpp_error("fregrid: mosaic_grid is not specified");
@@ -236,10 +236,10 @@ int main(int argc, char* argv[])
   strcpy(history,argv[0]);
   for(n=1;n<argc;n++)  {
     strcat(history, " ");
-    strcat(history, argv[n]); 
+    strcat(history, argv[n]);
   }
 
-#ifdef test_qsort  
+#ifdef test_qsort
   {
     /* test qsort_index here */
     int    i, size = 7;
@@ -250,7 +250,7 @@ int main(int argc, char* argv[])
     for(i=0; i<size; i++) printf("value = %f, rank = %d \n", array[i], rank[i]);
   }
 #endif
-  
+
   /* First read the source data and source grid */
   get_source_data(river_src_file, &river_in);
 
@@ -268,11 +268,11 @@ int main(int argc, char* argv[])
     mpp_close(fid);
   }
   river_out = (river_type *)malloc(ntiles*sizeof(river_type));
-  
+
   get_mosaic_grid(mosaic_file, land_mosaic, ntiles, river_out, &opcode, read_land_mask, &great_circle_algorithm);
 
   init_river_data(ntiles, river_out, &river_in);
-  
+
   calc_max_subA(&river_in, river_out, ntiles, opcode );
 
   calc_tocell(ntiles, river_out, opcode );
@@ -280,17 +280,17 @@ int main(int argc, char* argv[])
   calc_river_data(ntiles, river_out, opcode );
 
   sort_basin(ntiles, river_out);
-  
+
   check_river_data(ntiles, river_out);
-  
+
   write_river_data(river_src_file, output_file, river_out, history, ntiles, great_circle_algorithm);
-  
+
   printf("Successfully running river_regrid and the following output file are generated.\n");
   for(n=0; n<ntiles; n++) printf("****%s\n", river_out[n].filename);
-  
+
   mpp_end();
 
-  return 0;  
+  return 0;
 
 } /* end of main */
 
@@ -308,7 +308,7 @@ void get_source_data(const char *src_file, river_type *river_data)
 
   fid = mpp_open(src_file, MPP_READ);
   vid = mpp_get_varid(fid, subA_name);
-  
+
   mpp_get_var_dimname(fid, vid, 1, xaxis_name);
   mpp_get_var_dimname(fid, vid, 0, yaxis_name);
   nx  = mpp_get_dimlen(fid, xaxis_name );
@@ -317,12 +317,12 @@ void get_source_data(const char *src_file, river_type *river_data)
   nyp = ny + 1;
   river_data->nx  = nx;
   river_data->ny  = ny;
-  
+
   river_data->xt   = (double *)malloc(nx*sizeof(double));
   river_data->yt   = (double *)malloc(ny*sizeof(double));
-  river_data->xb   = (double *)malloc(nxp*sizeof(double)); 
+  river_data->xb   = (double *)malloc(nxp*sizeof(double));
   river_data->yb   = (double *)malloc(nyp*sizeof(double));
-  river_data->xb_r = (double *)malloc(nxp*sizeof(double)); 
+  river_data->xb_r = (double *)malloc(nxp*sizeof(double));
   river_data->yb_r = (double *)malloc(nyp*sizeof(double));
   river_data->subA = (double *)malloc(nx*ny*sizeof(double));
   mpp_get_var_att(fid, vid, "missing_value", &(river_data->subA_missing) );
@@ -347,7 +347,7 @@ void get_source_data(const char *src_file, river_type *river_data)
   vid = mpp_get_varid(fid, yaxis_name);
   mpp_get_var_value(fid, vid, river_data->yt);
   mpp_close(fid);
-  
+
   for(i=1; i<nx; i++ ) river_data->xb[i] = 0.5*(river_data->xt[i-1]+river_data->xt[i]);
   for(j=1; j<ny; j++ ) river_data->yb[j] = 0.5*(river_data->yt[j-1]+river_data->yt[j]);
   river_data->xb[0] = 2*river_data->xt[0] - river_data->xb[1];
@@ -357,9 +357,9 @@ void get_source_data(const char *src_file, river_type *river_data)
 
   /* make sure the xb is in the range [0,360] and yb is in the range [-90,90] */
   if(fabs(river_data->xb[0]) > EPSLN) mpp_error("river_regrid: The starting longitude of grid bound is not 0");
-  if(fabs(river_data->xb[nx]-360) > EPSLN) mpp_error("river_regrid: The ending longitude of grid bound is not 360");  
+  if(fabs(river_data->xb[nx]-360) > EPSLN) mpp_error("river_regrid: The ending longitude of grid bound is not 360");
   if(fabs(river_data->yb[0]+90) > EPSLN) mpp_error("river_regrid: The starting latitude of grid bound is not -90");
-  if(fabs(river_data->yb[ny]-90) > EPSLN) mpp_error("river_regrid: The ending latitude of grid bound is not 90");  
+  if(fabs(river_data->yb[ny]-90) > EPSLN) mpp_error("river_regrid: The ending latitude of grid bound is not 90");
   river_data->xb[0]  = 0.;
   river_data->xb[nx] = 360.;
   river_data->yb[0]  = -90.;
@@ -370,11 +370,11 @@ void get_source_data(const char *src_file, river_type *river_data)
 }
 
 /*----------------------------------------------------------------------
-   read the grid of detination mosaic. 
+   read the grid of detination mosaic.
    void get_mosaic_grid(char *file)
    where file is the coupler mosaic file.
    --------------------------------------------------------------------*/
-void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int ntiles, 
+void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int ntiles,
                      river_type *river_data, unsigned int *opcode, int read_land_mask, int *great_circle_algorithm)
 {
   int    n_xgrid_files, nx, ny, nxp, nyp, ni, nj, nip, njp;
@@ -389,17 +389,17 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
   int  m_fid, m_vid, g_fid, g_vid;
 
 
-  
+
   /* coupler_mosaic, land_mosaic, and exchange grid file should be located in the same directory */
   get_file_path(coupler_mosaic, dir);
-  
+
   m_fid = mpp_open(coupler_mosaic, MPP_READ);
 
   /* first find out if great_circle_algorithm is used or not, normally it could find from
    reading attribute of field aXl_file
   */
   *great_circle_algorithm = get_great_circle_algorithm(m_fid);
-  
+
   m_vid = mpp_get_varid(m_fid, "lnd_mosaic");
   mpp_get_var_value(m_fid, m_vid, land_mosaic_name);
 
@@ -409,23 +409,23 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
     xgrid_file = (char **)malloc(n_xgrid_files*sizeof(char *));
 
     m_vid = mpp_get_varid(m_fid, "aXl_file");
-  
+
     for(n=0; n<n_xgrid_files; n++) {
       xgrid_file[n] = (char *)malloc(STRING*sizeof(char));
       start[0] = n;
       start[1] = 0;
       nread[0] = 1;
-      nread[1] = STRING;    
+      nread[1] = STRING;
       mpp_get_var_value_block(m_fid, m_vid, start, nread, xgrid_file[n]);
     }
   }
   mpp_close(m_fid);
   m_fid = mpp_open(land_mosaic, MPP_READ);
   m_vid = mpp_get_varid(m_fid, "gridfiles");
-  
+
   for( n = 0; n < ntiles; n++ ) {
     double *area;
-    
+
     start[0] = n;
     start[1] = 0;
     nread[0] = 1;
@@ -454,16 +454,16 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
     nyp2 = ny + 2;
     river_data[n].nx       = nx;
     river_data[n].ny       = ny;
-    river_data[n].xt       = (double *)malloc(nxp2*nyp2*sizeof(double));        
+    river_data[n].xt       = (double *)malloc(nxp2*nyp2*sizeof(double));
     river_data[n].yt       = (double *)malloc(nxp2*nyp2*sizeof(double));
     river_data[n].xb       = (double *)malloc(nxp*nyp*sizeof(double));
     river_data[n].yb       = (double *)malloc(nxp*nyp*sizeof(double));
     river_data[n].xb_r     = (double *)malloc(nxp*nyp*sizeof(double));
-    river_data[n].yb_r     = (double *)malloc(nxp*nyp*sizeof(double));    
+    river_data[n].yb_r     = (double *)malloc(nxp*nyp*sizeof(double));
     river_data[n].area     = (double *)malloc(nx*ny*sizeof(double));
-    river_data[n].landfrac = (double *)malloc(nx*ny*sizeof(double));    
+    river_data[n].landfrac = (double *)malloc(nx*ny*sizeof(double));
     area                   = (double *)malloc(nx*ny*sizeof(double));
-    
+
     /* copy the data from super grid to fine grid */
     for(i=0; i<nx*ny; i++) area[i] = 0.0;
     for(j = 0; j < ny; j++) for(i = 0; i < nx; i++) {
@@ -475,7 +475,7 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
     for(j = 0; j < nyp; j++) for(i = 0; i < nxp; i++) {
       river_data[n].xb[j*nxp+i] = x[(j*y_refine)*nip+i*x_refine];
       river_data[n].yb[j*nxp+i] = y[(j*y_refine)*nip+i*x_refine];
-    }     
+    }
     free(x);
     free(y);
     /* calculate cell area */
@@ -491,7 +491,7 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
     else {
       get_grid_great_circle_area(&nx, &ny, river_data[n].xb_r, river_data[n].yb_r, river_data[n].area);
     }
-	      
+
     /* calculate the land fraction */
     if(!read_land_mask) {
       sprintf(tilename, "X%s_tile%d", land_mosaic_name, n+1);
@@ -501,13 +501,13 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
 	  int    *i1, *j1, *i2, *j2;
 	  double *xgrid_area;
 	  char filewithpath[512];
-	
+
 	  sprintf(filewithpath, "%s/%s", dir, xgrid_file[m]);
 	  g_fid = mpp_open(filewithpath, MPP_READ);
 	  nxgrid = mpp_get_dimlen(g_fid, "ncells");
 	  mpp_close(g_fid);
 	  i1         = (int    *)malloc(nxgrid*sizeof(int));
-	  j1         = (int    *)malloc(nxgrid*sizeof(int));	  
+	  j1         = (int    *)malloc(nxgrid*sizeof(int));
 	  i2         = (int    *)malloc(nxgrid*sizeof(int));
 	  j2         = (int    *)malloc(nxgrid*sizeof(int));
 	  xgrid_area = (double *)malloc(nxgrid*sizeof(double));
@@ -528,7 +528,7 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
     else { /* read from land_mask.tile#.nc */
       char land_mask_file[512];
       int nx2, ny2;
-      
+
       sprintf(land_mask_file, "%s/land_mask_tile%d.nc", dir, n+1);
       g_fid = mpp_open(land_mask_file, MPP_READ);
       nx2 = mpp_get_dimlen(g_fid, "nx");
@@ -542,25 +542,25 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
 
     for(m=0; m<nx*ny; m++) {
       /* consider truncation error */
-      if(river_data[n].landfrac[m] > 1 + 1.e-3) mpp_error("river_regrid: land_frac > 1 + 1.e-3" ); 
+      if(river_data[n].landfrac[m] > 1 + 1.e-3) mpp_error("river_regrid: land_frac > 1 + 1.e-3" );
       if(river_data[n].landfrac[m] > 1 - land_thresh) river_data[n].landfrac[m] = 1;
       if(fabs(river_data[n].landfrac[m])   < min_frac) river_data[n].landfrac[m] = 0;
       if(river_data[n].landfrac[m] > 1 || river_data[n].landfrac[m] < 0)
 	mpp_error("river_regrid: land_frac should be between 0 or 1");
-    }    
+    }
 
-      
+
     free(area);
   } /* n = 0, ntiles */
 
   mpp_close(m_fid);
-  
+
   /* currently we are assuming all the times have the same grid size */
   for(n=1; n<ntiles; n++) {
     if(river_data[n].nx != river_data[0].nx || river_data[n].ny != river_data[0].ny )
       mpp_error("river_regrid: all the tiles should have the same grid size");
   }
-  
+
   /*----------------------------------------------------------------------------
     get boundary condition, currently we are assuming the following case,
     solid walls: number of contact will be 0.
@@ -574,7 +574,7 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
     int *tile1, *tile2;
     int *istart1, *iend1, *jstart1, *jend1;
     int *istart2, *iend2, *jstart2, *jend2;
-    
+
     ncontact = read_mosaic_ncontacts(land_mosaic);
     tile1   = (int *)malloc(ncontact*sizeof(int));
     tile2   = (int *)malloc(ncontact*sizeof(int));
@@ -631,7 +631,7 @@ void get_mosaic_grid(const char *coupler_mosaic, const char *land_mosaic, int nt
   update_halo_double(ntiles, pyt, nx, ny, *opcode);
   free(pxt);
   free(pyt);
-  
+
 }; /* get_mosaic_grid */
 
 /*------------------------------------------------------------------------------
@@ -643,7 +643,7 @@ void init_river_data(int ntiles, river_type *river_out, const river_type * const
   int nx, ny, nxp2, nyp2, n, i;
   int tocell_missing, subA_missing, travel_missing, basin_missing;
   double cellarea_missing, celllength_missing;
-  
+
   nx = river_out->nx;
   ny = river_out->ny;
   nxp2 = nx + 2;
@@ -700,18 +700,18 @@ void calc_max_subA(const river_type *river_in, river_type *river_out, int ntiles
   double *xb_in, *yb_in;
   double *xb_out, *yb_out;
   double **psubA;
-  
+
   nx_in = river_in->nx;
   ny_in = river_in->ny;
   xb_in = river_in->xb_r;
   yb_in = river_in->yb_r;
   missing = river_out->subA_missing;
-  
+
   for(n=0; n<ntiles; n++) {
     nx_out   = river_out[n].nx;
     ny_out   = river_out[n].ny;
     nxp2     = nx_out + 2;
-    nyp2     = ny_out + 2;    
+    nyp2     = ny_out + 2;
     nxp_out  = nx_out+1;
     xb_out   = river_out[n].xb_r;
     yb_out   = river_out[n].yb_r;
@@ -723,16 +723,16 @@ void calc_max_subA(const river_type *river_in, river_type *river_out, int ntiles
 	river_out[n].subA[j1*nxp2+i1] = LARGE_VALUE;
 	continue;
       }
-      
+
       xv1[0] = xb_out[j*nxp_out+i];
       xv1[1] = xb_out[j*nxp_out+i1];
       xv1[2] = xb_out[j1*nxp_out+i1];
-      xv1[3] = xb_out[j1*nxp_out+i]; 
+      xv1[3] = xb_out[j1*nxp_out+i];
       yv1[0] = yb_out[j*nxp_out+i];
       yv1[1] = yb_out[j*nxp_out+i1];
       yv1[2] = yb_out[j1*nxp_out+i1];
-      yv1[3] = yb_out[j1*nxp_out+i]; 
-      
+      yv1[3] = yb_out[j1*nxp_out+i];
+
       for(jj=0; jj<ny_in; jj++) {
 	ll_y = yb_in[jj];
 	ur_y = yb_in[jj+1];
@@ -740,7 +740,7 @@ void calc_max_subA(const river_type *river_in, river_type *river_out, int ntiles
 	      && (yv1[2]<=ll_y) && (yv1[3]<=ll_y) ) continue;
 	if (  (yv1[0]>=ur_y) && (yv1[1]>=ur_y)
 	      && (yv1[2]>=ur_y) && (yv1[3]>=ur_y) ) continue;
-	
+
 	for(ii=0; ii<nx_in; ii++) {
 	  if(river_in->subA[jj*nx_in+ii] == missing) continue;
 	  ll_x = xb_in[ii];
@@ -748,9 +748,9 @@ void calc_max_subA(const river_type *river_in, river_type *river_out, int ntiles
 	  /* adjust xv1 to make sure it is in the range as ll_x and ur_x */
 	  adjust_lon(xv1, 0.5*(ll_x + ur_x) );
 	  if ( (xv1[0]<=ll_x) && (xv1[1]<=ll_x) && (xv1[2]<=ll_x) && (xv1[3]<=ll_x) ) continue;
-	  if ( (xv1[0]>=ur_x) && (xv1[1]>=ur_x) && (xv1[2]>=ur_x) && (xv1[3]>=ur_x) ) continue;	  
+	  if ( (xv1[0]>=ur_x) && (xv1[1]>=ur_x) && (xv1[2]>=ur_x) && (xv1[3]>=ur_x) ) continue;
 	  if ( (n_out = clip ( xv1, yv1, 4, ll_x, ll_y, ur_x, ur_y, xv2, yv2 )) > 0 ) {
-	    double xarea; 
+	    double xarea;
 	    xarea = poly_area (xv2, yv2, n_out );
 	    if( xarea/river_out[n].area[j*nx_out+i] < MIN_AREA_RATIO ) continue;
 	    if(river_in->subA[jj*nx_in+ii] > river_out[n].subA[j1*nxp2+i1])
@@ -760,11 +760,11 @@ void calc_max_subA(const river_type *river_in, river_type *river_out, int ntiles
       }
     }
   }
-	
+
   /* fill the halo of subA */
   psubA = (double **)malloc(ntiles*sizeof(double *));
-  for(n=0; n<ntiles; n++) psubA[n] = river_out[n].subA; 
-  update_halo_double(ntiles, psubA, river_out->nx, river_out->ny, opcode); 
+  for(n=0; n<ntiles; n++) psubA[n] = river_out[n].subA;
+  update_halo_double(ntiles, psubA, river_out->nx, river_out->ny, opcode);
   free(psubA);
 };/* calc_max_subA */
 
@@ -776,7 +776,7 @@ void update_halo_double(int ntiles, double **data, int nx, int ny, unsigned int 
 {
   int nxp1, nyp1, nxp2, i, j, n;
   int te, tw, ts, tn;
-  
+
   nxp1   = nx + 1;
   nyp1   = ny + 1;
   nxp2   = nx + 2;
@@ -794,14 +794,14 @@ void update_halo_double(int ntiles, double **data, int nx, int ny, unsigned int 
   }
   if(opcode & X_CYCLIC && opcode & Y_CYCLIC) {
     data[0][0]              = data[0][ny*nxp2];      /* southwest */
-    data[0][nxp1]           = data[0][ny*nxp2+1];    /* southeast */    
+    data[0][nxp1]           = data[0][ny*nxp2+1];    /* southeast */
     data[0][nyp1*nxp2+nxp1] = data[0][nxp2+1];       /* northeast */
-    data[0][nyp1*nxp2]      = data[0][nxp2+nx];      /* northwest */     
+    data[0][nyp1*nxp2]      = data[0][nxp2+nx];      /* northwest */
   }
 
   if(opcode & CUBIC_GRID) {
     for(n=0; n<ntiles; n++) {
-      
+
       if(n%2) { /* tile 2 4 6 */
 	tw = (n+5)%ntiles; te = (n+2)%ntiles; ts = (n+4)%ntiles; tn = (n+1)%ntiles;
 	for(j=1; j<nyp1; j++) {
@@ -825,19 +825,19 @@ void update_halo_double(int ntiles, double **data, int nx, int ny, unsigned int 
       }
     }
   }
-  
+
 };/* update_halo */
 
 void update_halo_int(int ntiles, int **data, int nx, int ny, unsigned int opcode)
 {
   double **ldata;
   int n, i, j, nxp2, nyp2;
-  
+
   nxp2 = nx + 2;
   nyp2 = ny + 2;
 
 
-  
+
   ldata = (double **)malloc(ntiles*sizeof(double *));
   for(n=0; n<ntiles; n++) {
     ldata[n] =  (double *)malloc(nxp2*nyp2*sizeof(double));
@@ -849,7 +849,7 @@ void update_halo_int(int ntiles, int **data, int nx, int ny, unsigned int opcode
     free(ldata[n]);
   }
   free(ldata);
-  
+
 }
 
 void adjust_lon(double x[], double tlon)
@@ -876,7 +876,7 @@ void adjust_lon(double x[], double tlon)
   Find the tocell value for the new grid.
   void calc_tocell( )
   ----------------------------------------------------------------------------*/
-void calc_tocell(int ntiles, river_type *river_data, unsigned int opcode )  
+void calc_tocell(int ntiles, river_type *river_data, unsigned int opcode )
 {
   const int out_flow[] = { 8, 4, 2, 16, -1, 1, 32, 64, 128};
   const int out_dir[]  = { 3, 2, 1, 4,  -1, 0, 5,   6,   7};
@@ -884,7 +884,7 @@ void calc_tocell(int ntiles, river_type *river_data, unsigned int opcode )
   int i, j, ii, jj, iget, jget, im1, jm1;
   double tval, subA_missing, subA, subA_me;
   int **ptocell, **pdir;
-  
+
   nx = river_data->nx;
   ny = river_data->ny;
   nxp2 = nx + 2;
@@ -895,7 +895,7 @@ void calc_tocell(int ntiles, river_type *river_data, unsigned int opcode )
     ptocell[n] = river_data[n].tocell;
     pdir   [n] = river_data[n].dir;
   }
-  
+
   for(n=0; n<ntiles; n++) {
     for(j=1; j<=ny; j++) for(i=1; i<=nx; i++) {
       jm1 = j - 1;
@@ -968,16 +968,16 @@ void calc_tocell(int ntiles, river_type *river_data, unsigned int opcode )
 	  else
 	    ptocell[n][j*nxp2+i] = 0;
 	}
-	else 
+	else
 	  ptocell[n][j*nxp2+i] = 0;
       }
     }
   }
-  update_halo_int(ntiles, ptocell, nx, ny, opcode);   
+  update_halo_int(ntiles, ptocell, nx, ny, opcode);
   update_halo_int(ntiles, pdir, nx, ny, opcode);
   free(ptocell);
   free(pdir);
-  
+
 };/* calc_tocell */
 
 
@@ -998,7 +998,7 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
   int    **pbasin, **ptravel, **pdir;
   double **psubA;
   double xv[4], yv[4];
-  
+
   const int di[] = {1,1,0,-1,-1,-1,0,1};
   const int dj[] = {0,-1,-1,-1,0,1,1,1};
   nx = river_data->nx;
@@ -1027,9 +1027,9 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
 
   /* reinitialize subA */
   for(n=0; n<ntiles; n++) {
-    for(i=0; i<nxp2*nyp2; i++) psubA[n][i] = subA_missing;    
+    for(i=0; i<nxp2*nyp2; i++) psubA[n][i] = subA_missing;
   }
-  
+
   /* calculate celllength and cellarea */
   for(n=0; n<ntiles; n++) {
     for(j=0; j<ny; j++) for(i=0; i<nx; i++) {
@@ -1049,7 +1049,7 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
 	dir = pdir[n][jj*nxp2+ii];
 	if( dir >= 0) {
 	  i_dest = ii + di[dir];
-	  j_dest = jj + dj[dir];	
+	  j_dest = jj + dj[dir];
 	  river_data[n].celllength[j*nx+i] = distance(river_data[n].xt[jj*nxp2+ii],
 						      river_data[n].yt[jj*nxp2+ii],
 						      river_data[n].xt[j_dest*nxp2+i_dest],
@@ -1061,9 +1061,9 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
     }
   }
 
-  
+
   /* define the basinid and travel for the coast point */
-  
+
   for(n=0; n<ntiles; n++) {
     for(j=1; j<=ny; j++) for(i=1; i<=nx; i++) {
       if(river_data[n].tocell[j*nxp2+i] == 0) {
@@ -1086,7 +1086,7 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
 
   update_halo_int(ntiles, pbasin, nx, ny, opcode);
   update_halo_int(ntiles, ptravel, nx, ny, opcode);
-  
+
   /* then define the travel and basin for all other points */
   cur_travel = 0;
 
@@ -1112,7 +1112,7 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
     }
     cur_travel++;
     update_halo_int(ntiles, pbasin, nx, ny, opcode);
-    update_halo_int(ntiles, ptravel, nx, ny, opcode);    
+    update_halo_int(ntiles, ptravel, nx, ny, opcode);
   }
 
   /* figure out maximum travel and maximum basin*/
@@ -1120,7 +1120,7 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
   maxbasin  = -1;
   basin_missing = river_data->basin_missing;
   for(n=0; n<ntiles; n++) {
-    for(j=1; j<=ny; j++) for(i=1; i<=nx; i++) {    
+    for(j=1; j<=ny; j++) for(i=1; i<=nx; i++) {
       maxtravel = max(maxtravel, ptravel[n][j*nxp2+i]);
       maxbasin  = max(maxbasin,  pbasin[n][j*nxp2+i]);
     }
@@ -1141,7 +1141,7 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
 	  /* consider about the rotation when it is on the boundary */
 	  if(dir >=0 ) {
 	    if( opcode & CUBIC_GRID ) {
-	      if(ii == 0) { /* west */ 
+	      if(ii == 0) { /* west */
 		if(n%2==0) dir = (dir+2)%8;  /* tile 1 3 5 */
 	      }
 	      else if(ii == nxp) { /*east */
@@ -1163,7 +1163,7 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
     }
     update_halo_double(ntiles, psubA, nx, ny, opcode);
   }
-  
+
   free(pbasin);
   free(ptravel);
   free(psubA);
@@ -1175,7 +1175,7 @@ void calc_river_data(int ntiles, river_type* river_data, unsigned int opcode )
   check to make sure all the river points have been assigned travel and basin value
   and all the ocean points will have missing value.
   ----------------------------------------------------------------------------*/
-  
+
 void check_river_data(int ntiles, river_type *river_data )
 {
   int maxtravel = -1;
@@ -1187,7 +1187,7 @@ void check_river_data(int ntiles, river_type *river_data )
   int ncoast_full_land, nsink;
   double subA, subA_missing;
   int *ncoast;
-  
+
   /* print out maximum travel and number of rivers */
   maxtravel = -1;
   maxbasin  = -1;
@@ -1199,9 +1199,9 @@ void check_river_data(int ntiles, river_type *river_data )
   tocell_missing = river_data->tocell_missing;
   basin_missing = river_data->basin_missing;
   travel_missing = river_data->travel_missing;
-  
+
   for(n=0; n<ntiles; n++) {
-    for(j=1; j<=ny; j++) for(i=1; i<=nx; i++) {    
+    for(j=1; j<=ny; j++) for(i=1; i<=nx; i++) {
       maxtravel = max(maxtravel, river_data[n].travel[j*nxp2+i]);
       maxbasin  = max(maxbasin, river_data[n].basin[j*nxp2+i]);
     }
@@ -1250,7 +1250,7 @@ void check_river_data(int ntiles, river_type *river_data )
 	}
 	 printf("At point (i=%d,j=%d,t=%d), tocell = 0 and landfrac = 1 is a sink point\n", i, j, n+1);
         nsink++;
-      done_check: continue;	
+      done_check: continue;
       }
     }
   }
@@ -1264,7 +1264,7 @@ void check_river_data(int ntiles, river_type *river_data )
     printf("Warning from river_regrid: there are %d sink points is a full land cell\n", nsink);
   else
     printf("NOTE from river_regrid: there are no sink points is a full land cell\n");
-  
+
   /* check river travel to make sure there is one and only one point with travel = 0. */
   ncoast = (int *)malloc(maxbasin*sizeof(int));
   for(n=0; n<maxbasin; n++) ncoast[n] = 0;
@@ -1284,7 +1284,7 @@ void check_river_data(int ntiles, river_type *river_data )
     }
   }
   free(ncoast);
-  
+
 
 }; /* check_river_data */
 
@@ -1301,7 +1301,7 @@ void sort_basin(int ntiles, river_type* river_data)
   int    maxbasin, basin_missing, basin;
   int    *rank, *indx;
   double subA_missing, *maxsuba;
-  
+
   river_type *river_tmp;
 
   nx   = river_data->nx;
@@ -1314,10 +1314,10 @@ void sort_basin(int ntiles, river_type* river_data)
   maxbasin  = -1;
   basin_missing = river_data->basin_missing;
   for(n=0; n<ntiles; n++) {
-    for(j=1; j<=ny; j++) for(i=1; i<=nx; i++) {    
+    for(j=1; j<=ny; j++) for(i=1; i<=nx; i++) {
       maxbasin  = max(maxbasin,  river_data[n].basin[j*nxp2+i]);
     }
-  }  
+  }
 
   /* copy basinid data to the tmp data */
   for(n=0; n<ntiles; n++) {
@@ -1349,14 +1349,14 @@ void sort_basin(int ntiles, river_type* river_data)
   for(n=0; n<maxbasin; n++) {
     if(maxsuba[n] == subA_missing) mpp_error("river_regrid: maxsuba is not assigned for some basin");
   }
-  
+
   /* sort maxsuba to get the index rank */
   qsort_index(maxsuba, 0, maxbasin-1, indx);
   for(n=0; n<maxbasin; n++) rank[indx[n]] = n;
   for(n=0; n<maxbasin; n++) {
     if(rank[n] < 0) mpp_error("river_regrid: rank should be no less than 0");
   }
-  
+
   /* now assign basin according to the index rank */
   for(n=0; n<ntiles; n++) for(j=1; j<=ny; j++) for(i=1; i<=nx; i++) {
     basin = river_tmp[n].basin[j*nxp2+i];
@@ -1365,7 +1365,7 @@ void sort_basin(int ntiles, river_type* river_data)
       river_data[n].basin[j*nxp2+i] = maxbasin - rank[basin-1];
     }
   }
-  
+
   /* release the memory */
   for(n=0; n<ntiles; n++) free(river_tmp[n].basin);
   free(river_tmp);
@@ -1392,7 +1392,7 @@ void write_river_data(const char *river_src_file, const char *output_file, river
   int id_xaxis, id_yaxis, id_xaxis_in, id_yaxis_in;
   int fid, fid_in, dimid[2];
   int n, i, j, ii, jj, nx, ny, nxp2;
-  
+
   fid_in = mpp_open(river_src_file, MPP_READ);
   id_subA_in = mpp_get_varid(fid_in, subA_name);
   id_tocell_in = mpp_get_varid(fid_in, tocell_name);
@@ -1411,11 +1411,10 @@ void write_river_data(const char *river_src_file, const char *output_file, river
     nx = river_data[n].nx;
     ny = river_data[n].ny;
     nxp2 = nx + 2;
+
     fid = mpp_open(river_data[n].filename, MPP_WRITE);
-    mpp_def_global_att(fid, "version", version);  
-    mpp_def_global_att(fid, "code_version", tagname);
-    if(great_circle_algorithm) mpp_def_global_att(fid, "great_circle_algorithm", "TRUE");
-    mpp_def_global_att(fid, "history", history);
+    print_provenance_gv_gca(fid, history, NULL, great_circle_algorithm );
+
     dimid[1] = mpp_def_dim(fid, gridx_name, nx);
     dimid[0] = mpp_def_dim(fid, gridy_name, ny);
     id_xaxis = mpp_def_var(fid, gridx_name, MPP_DOUBLE, 1, &(dimid[1]), 0);
@@ -1439,7 +1438,7 @@ void write_river_data(const char *river_src_file, const char *output_file, river
     id_x        = mpp_def_var(fid, x_name, MPP_DOUBLE, 2, dimid, 2,
 			      "long_name", "Geographic longitude", "units", "degree_east");
     id_y        = mpp_def_var(fid, y_name, MPP_DOUBLE, 2, dimid, 2,
-			      "long_name", "Geographic latitude", "units", "degree_north");    
+			      "long_name", "Geographic latitude", "units", "degree_north");
     mpp_end_def(fid);
     xt = (double *)malloc(nx*sizeof(double));
     yt = (double *)malloc(ny*sizeof(double));
@@ -1478,7 +1477,7 @@ void write_river_data(const char *river_src_file, const char *output_file, river
       xt    [j*nx+i] = river_data[n].xt    [jj*nxp2+ii];
       yt    [j*nx+i] = river_data[n].yt    [jj*nxp2+ii];
     }
-    
+
     mpp_put_var_value(fid, id_subA, subA);
     mpp_put_var_value(fid, id_tocell, tocell);
     mpp_put_var_value(fid, id_travel, travel);
@@ -1509,14 +1508,14 @@ double distance(double lon1, double lat1, double lon2, double lat2)
 {
   double s1, s2, dx;
   double dist;
-    
+
   dx = lon2 - lon1;
   if(dx > 180.) dx = dx - 360.;
   if(dx < -180.) dx = dx + 360.;
 
   if(lon1 == lon2)
     dist = fabs(lat2 - lat1) * D2R;
-  else if(lat1 == lat2) 
+  else if(lat1 == lat2)
     dist = fabs(dx) * D2R * cos(lat1*D2R);
   else {   /* diagonal distance */
     s1 =  fabs(dx)  * D2R * cos(lat1*D2R);
@@ -1526,13 +1525,13 @@ double distance(double lon1, double lat1, double lon2, double lat2)
   dist *= RADIUS;
 
   return dist;
-}    
+}
 
 /*------------------------------------------------------------------------------
   void qsort_index(double array[], int start, int end, int rank[])
   sort array in increasing order and get the rank of each member in the original array
-  the array size of array and rank will be size. 
-  
+  the array size of array and rank will be size.
+
   ----------------------------------------------------------------------------*/
 #define swap(a,b,t) ((t)=(a),(a)=(b),(b)=(t))
 void qsort_index(double array[], int start, int end, int rank[])
@@ -1574,6 +1573,6 @@ void qsort_index(double array[], int start, int end, int rank[])
       }
    }
 }
- 
+
 
 

--- a/tools/runoff_regrid/runoff_regrid.c
+++ b/tools/runoff_regrid/runoff_regrid.c
@@ -23,20 +23,20 @@
 
  AUTHOR: Zhi Liang (Zhi.Liang@noaa.gov)
           NOAA Geophysical Fluid Dynamics Lab, Princeton, NJ
- 
+
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2 of the License, or
   (at your option) any later version.
- 
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
- 
+
   For the full text of the GNU General Public License,
   write to: Free Software Foundation, Inc.,
-            675 Mass Ave, Cambridge, MA 02139, USA.  
+            675 Mass Ave, Cambridge, MA 02139, USA.
 -----------------------------------------------------------------------
 */
 
@@ -116,7 +116,7 @@ typedef struct {
   double *xt;
   double *yt;
   double *xc;
-  double *yc;  
+  double *yc;
   double *xt1d;
   double *yt1d;
   double *xc1d;
@@ -143,7 +143,7 @@ void setup_remap(const Grid_type *grid_in, const Grid_type *grid_out, Remap_type
 void process_data(const char *infile, const char *fld_name_in, const char *outfile, const char *fld_name_out,
 		  const Grid_type *grid_in, const Grid_type *grid_out, const Remap_type *remap, const char *history);
 void nearest(int nlon, int nlat, double *mask, const double *lon, const double *lat,
-	     double plon, double plat, int *iout, int *jout);  
+	     double plon, double plat, int *iout, int *jout);
 int main(int argc, char* argv[])
 {
   unsigned int opcode = 0;
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
   char    *output_mosaic=NULL;           /* output mosaic file name */
   char    *output_topog=NULL;
   double  sea_level = 0;
-  char    history[MAXATT];  
+  char    history[MAXATT];
   char    default_output_file[] = "runoff.nc";
   char    default_fld_name[]    = "runoff";
   int errflg = (argc == 1);
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
   Grid_type grid_in;
   Grid_type grid_out;
   Remap_type remap;
-  
+
   static struct option long_options[] = {
     {"input_file",        required_argument, NULL, 'a'},
     {"input_fld_name",    required_argument, NULL, 'b'},
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
     {"sea_level",         required_argument, NULL, 'g'},
     {"help",              no_argument,       NULL, 'h'},
     {0, 0, 0, 0},
-  };  
+  };
 
   mpp_init(NULL,NULL);
   /*  if(mpp_npes() > 1) mpp_error("runoff_regrid: the tool is supposed to run on single processor"); */
@@ -227,17 +227,17 @@ int main(int argc, char* argv[])
     strcat(history, " ");
     strcat(history, argv[i]);
   }
-  
+
   /* get input grid */
   get_input_grid(input_file, input_fld_name, &grid_in);
   if(mpp_pe() == mpp_root_pe() )printf("\nNOTE from runoff_regrid: complete get_input_grid\n");
   /* get output grid */
   get_output_grid(output_mosaic, output_topog, sea_level, &grid_out);
-  if(mpp_pe() == mpp_root_pe() ) printf("\nNOTE from runoff_regrid: complete get_output_grid\n");  
+  if(mpp_pe() == mpp_root_pe() ) printf("\nNOTE from runoff_regrid: complete get_output_grid\n");
   /* computing remapping information */
   setup_remap(&grid_in, &grid_out, &remap);
   if(mpp_pe() == mpp_root_pe() )printf("\nNOTE from runoff_regrid: complete setup_remap\n");
-  
+
   /* do the remapping and write out data */
   /* process data on the root pe */
   if(mpp_pe() == mpp_root_pe()) {
@@ -249,9 +249,9 @@ int main(int argc, char* argv[])
   mpp_end();
 
   return 0;
-}  
-     
-  
+}
+
+
 
 void get_input_grid(const char *file, const char *field, Grid_type *grid)
 {
@@ -261,7 +261,7 @@ void get_input_grid(const char *file, const char *field, Grid_type *grid)
   size_t start[4], nread[4];
   double *data=NULL;
   double missing_value;
-  
+
   fid = mpp_open(file, MPP_READ);
   vid = mpp_get_varid(fid, field);
   ndim = mpp_get_var_ndim(fid, vid);
@@ -283,7 +283,7 @@ void get_input_grid(const char *file, const char *field, Grid_type *grid)
   grid->yc   = (double *)malloc(nyp*nxp*sizeof(double));
   grid->mask = (double *)malloc(nx*ny*sizeof(double));
   grid->area = (double *)malloc(nx*ny*sizeof(double));
-  
+
   vid = mpp_get_varid(fid, xname);
   mpp_get_var_value(fid, vid, grid->xt1d);
   vid = mpp_get_varid(fid, yname);
@@ -299,20 +299,20 @@ void get_input_grid(const char *file, const char *field, Grid_type *grid)
   /* convert to radians */
   for(i=0; i<nxp; i++) grid->xc1d[i] *= D2R;
   for(j=0; j<nyp; j++) grid->yc1d[j] *= D2R;
-    
+
   for(j=0; j<nyp; j++) for(i=0; i<nxp; i++) {
     grid->xc[j*nxp+i] = grid->xc1d[i];
     grid->yc[j*nxp+i] = grid->yc1d[j];
   }
 
   get_grid_area(&nx, &ny, grid->xc, grid->yc, grid->area);
-  
+
   /* get the mask */
   vid = mpp_get_varid(fid, field);
   data = (double *)malloc(nx*ny*sizeof(double));
   for(i=0; i<4; i++) {
     start[i] = 0; nread[i] = 1;
-  }  
+  }
   nread[ndim-1] = nx;
   nread[ndim-2] = ny;
   mpp_get_var_value_block(fid, vid, start, nread, data);
@@ -327,18 +327,18 @@ void get_input_grid(const char *file, const char *field, Grid_type *grid)
   }
 
   free(data);
-  
+
   mpp_close(fid);
-  
+
 }
-   
+
 void get_output_grid(const char *mosaic, const char *topog_file, double sea_level, Grid_type *grid)
 {
   int fid, ntile, vid, i, j, ind, n_ext;
   int ni, nj, nip, njp, nx, ny, nxp, nyp, ny_old;
   char gridfile[256], filename[256], dir[256];
-  double *tmp=NULL, *depth=NULL;  
-  
+  double *tmp=NULL, *depth=NULL;
+
    get_file_path(mosaic, dir);
    fid = mpp_open(mosaic, MPP_READ);
    ntile  = mpp_get_dimlen(fid, "ntiles");
@@ -359,7 +359,7 @@ void get_output_grid(const char *mosaic, const char *topog_file, double sea_leve
    mpp_get_var_value(fid, vid, tmp);
    /* we might need to add one extra raw to expand to south pole to ensure conservative */
    n_ext = 0;
-   
+
    if(tmp[0] > -90 + EPSLN10 ) n_ext = 1;
    if(mpp_pe() == mpp_root_pe() ) printf("The south extension is %d\n", n_ext);
    nx  = ni/2;
@@ -367,7 +367,7 @@ void get_output_grid(const char *mosaic, const char *topog_file, double sea_leve
    ny_old = ny;
    ny += n_ext;
    nxp = nx+1;
-   nyp = ny+1;   
+   nyp = ny+1;
    grid->nx = nx;
    grid->ny = ny;
    grid->n_ext = n_ext;
@@ -378,17 +378,17 @@ void get_output_grid(const char *mosaic, const char *topog_file, double sea_leve
    grid->xt1d = (double *)malloc(nx*sizeof(double));
    grid->yt1d = (double *)malloc(ny_old*sizeof(double));
    grid->area = (double *)malloc(nx*ny*sizeof(double));
-   
+
    for(j=n_ext; j<nyp; j++) for(i=0; i<nxp; i++) grid->yc[j*nxp+i] = tmp[2*(j-n_ext)*nip+2*i];
    for(j=n_ext; j<ny ; j++) for(i=0; i<nx ; i++) grid->yt[j*nx +i] = tmp[(2*(j-n_ext)+1)*nip+2*i+1];
    ind = nx/4;
-   for(j=0; j<ny_old; j++) grid->yt1d[j] = tmp[(2*j+1)*nip+2*ind];   
-   
+   for(j=0; j<ny_old; j++) grid->yt1d[j] = tmp[(2*j+1)*nip+2*ind];
+
    if(n_ext >0) {
      for(i=0; i<nxp; i++) grid->yc[i] = -90;
      for(i=0; i<nx; i++) grid->yt[i] = 0.5*(grid->yc[i] + grid->yc[nxp+i]);
    }
-        
+
 
    vid = mpp_get_varid(fid, "x");
    mpp_get_var_value(fid, vid, tmp);
@@ -398,8 +398,8 @@ void get_output_grid(const char *mosaic, const char *topog_file, double sea_leve
    if(n_ext >0) {
      for(i=0; i<nxp; i++) grid->xc[i] = grid->xc[nxp+i];
      for(i=0; i<nx; i++) grid->xt[i] =  grid->xt[nx+i];
-   }     
-   
+   }
+
    free(tmp);
    mpp_close(fid);
 
@@ -414,7 +414,7 @@ void get_output_grid(const char *mosaic, const char *topog_file, double sea_leve
    }
 
    get_grid_area(&nx, &ny, grid->xc, grid->yc, grid->area);
-   
+
    /* read the topography data to get the land sea mask */
    fid = mpp_open(topog_file, MPP_READ);
    ntile = 1;
@@ -434,10 +434,10 @@ void get_output_grid(const char *mosaic, const char *topog_file, double sea_leve
    for(j=n_ext; j<ny; j++) for(i=0; i<nx; i++) {
      if(depth[(j-n_ext)*nx+i] >sea_level) grid->mask[j*nx+i] = 1.0;
    }
-   free(depth);			    
+   free(depth);
 
 
-    
+
 }
 
 void setup_remap(const Grid_type *grid_in, const Grid_type *grid_out, Remap_type *remap)
@@ -451,14 +451,14 @@ void setup_remap(const Grid_type *grid_in, const Grid_type *grid_out, Remap_type
   domain2D domain;
   double *xc=NULL, *yc=NULL;
   int *imap=NULL, *jmap=NULL;
-  
-  
+
+
   nx_in = grid_in ->nx;
   ny_in = grid_in ->ny;
   nx_out = grid_out ->nx;
   ny_out = grid_out ->ny;
   npes = mpp_npes();
-  
+
   mpp_define_layout(nx_out, ny_out, npes, layout);
   mpp_define_domain2d(nx_out, ny_out, layout, 0, 0, &domain);
 
@@ -472,10 +472,10 @@ void setup_remap(const Grid_type *grid_in, const Grid_type *grid_out, Remap_type
   for(j=0; j<=nyc; j++) for(i=0; i<=nxc; i++) {
     jj = j+jsc;
     ii = i+isc;
-    xc[j*(nxc+1)+i] = grid_out->xc[jj*(nx_out+1)+ii];  
+    xc[j*(nxc+1)+i] = grid_out->xc[jj*(nx_out+1)+ii];
     yc[j*(nxc+1)+i] = grid_out->yc[jj*(nx_out+1)+ii];
   }
-    
+
   i_in       = (int    *)malloc(MAXXGRID   * sizeof(int   ));
   j_in       = (int    *)malloc(MAXXGRID   * sizeof(int   ));
   i_out      = (int    *)malloc(MAXXGRID   * sizeof(int   ));
@@ -492,12 +492,12 @@ void setup_remap(const Grid_type *grid_in, const Grid_type *grid_out, Remap_type
   }
 
   nxgrid_local = nxgrid;
-  
+
   mpp_sum_int(1, &nxgrid);
-  
+
   remap->nxgrid = nxgrid;
   remap->i_in = (int *)malloc(nxgrid*sizeof(int));
-  remap->j_in = (int *)malloc(nxgrid*sizeof(int));  
+  remap->j_in = (int *)malloc(nxgrid*sizeof(int));
   remap->i_out = (int *)malloc(nxgrid*sizeof(int));
   remap->j_out = (int *)malloc(nxgrid*sizeof(int));
   remap->xgrid_area = (double *)malloc(nxgrid*sizeof(double));
@@ -508,7 +508,7 @@ void setup_remap(const Grid_type *grid_in, const Grid_type *grid_out, Remap_type
   mpp_gather_field_int_root( nxgrid_local, j_out, remap->j_out);
   mpp_gather_field_double_root( nxgrid_local, xgrid_area, remap->xgrid_area);
 
-  
+
   /* compute the nearest ocean points for any land points */
   imap = (int *)malloc(nxc*nyc*sizeof(int));
   jmap = (int *)malloc(nxc*nyc*sizeof(int));
@@ -519,8 +519,8 @@ void setup_remap(const Grid_type *grid_in, const Grid_type *grid_out, Remap_type
     imap[i] = -1;
     jmap[i] = -1;
   }
-  
-  
+
+
   for(j=0; j<nyc; j++) {
     for(i=0; i<nxc; i++) {
       jj = j+jsc;
@@ -535,11 +535,11 @@ void setup_remap(const Grid_type *grid_in, const Grid_type *grid_out, Remap_type
   }
   mpp_global_field_int(domain, nxc, nyc, imap, remap->imap);
   mpp_global_field_int(domain, nxc, nyc, jmap, remap->jmap);
-  
+
 
   free(imap);
   free(jmap);
-    
+
   free(xc);
   free(yc);
   free(i_in);
@@ -548,7 +548,7 @@ void setup_remap(const Grid_type *grid_in, const Grid_type *grid_out, Remap_type
   free(j_out);
   free(xgrid_area);
   mpp_delete_domain2d(&domain);
-  
+
 }
 
 
@@ -567,7 +567,7 @@ void process_data(const char *infile, const char *fld_name_in, const char *outfi
   double *data_in=NULL, *data_out=NULL;
   double runoff_total_in, runoff_total_out, rate_change;
   char timename[128];
-  
+
   /* get the time information in the file */
   fid_in = mpp_open(infile, MPP_READ);
   vid_in = mpp_get_varid(fid_in, fld_name_in);
@@ -580,7 +580,7 @@ void process_data(const char *infile, const char *fld_name_in, const char *outfi
     id_time_in = mpp_get_varid(fid_in, timename);
     mpp_get_var_value(fid_in, id_time_in, time_value);
   }
-  
+
   /* set up the output metadata */
   nx_in = grid_in ->nx;
   ny_in = grid_in ->ny;
@@ -591,7 +591,8 @@ void process_data(const char *infile, const char *fld_name_in, const char *outfi
   data_out = (double *)malloc(nx_out*ny_out*sizeof(double));
 
   fid_out = mpp_open(outfile, MPP_WRITE);
-  mpp_def_global_att(fid_out, "history", history);
+  print_provenance(fid_out, history );
+
   dims[ndim-1] = mpp_def_dim(fid_out, "grid_x_T", nx_out);
   dims[ndim-2] = mpp_def_dim(fid_out, "grid_y_T", ny_out-n_ext);
   if(ndim>2) { /* has time axis */
@@ -606,13 +607,13 @@ void process_data(const char *infile, const char *fld_name_in, const char *outfi
   id_yt = mpp_def_var(fid_out, "grid_y_T", NC_DOUBLE, 1, dims+(ndim-2), 0);
   mpp_def_var_att(fid_out, id_yt, "long_name", "Nominal Latitude of T-cell center");
   mpp_def_var_att(fid_out, id_yt, "cartesian_axis", "Y");
-  mpp_def_var_att(fid_out, id_yt, "units", "degree_north");  
+  mpp_def_var_att(fid_out, id_yt, "units", "degree_north");
 
   if(ndim > 2) {
     id_time = mpp_def_var(fid_out, "Time", NC_DOUBLE, 1, dims, 0);
     mpp_copy_var_att(fid_in, id_time_in, fid_out, id_time);
   }
-    
+
   id_fld = mpp_def_var(fid_out, fld_name_out, NC_DOUBLE, ndim, dims, 0);
   mpp_copy_var_att(fid_in, vid_in, fid_out, id_fld);
   mpp_end_def(fid_out);
@@ -620,13 +621,13 @@ void process_data(const char *infile, const char *fld_name_in, const char *outfi
   /* write out axis data */
   mpp_put_var_value(fid_out, id_xt, grid_out->xt1d);
   mpp_put_var_value(fid_out, id_yt, grid_out->yt1d);
-  
+
   /* loop through ntime */
   for(n=0; n<ntime; n++) {
-    
+
     for(i=0; i<4; i++) {
       start[i] = 0; nwrite[i] = 1; nread[i] = 1;
-    }        
+    }
     start[0] = n;
     if(ndim>2) {
       mpp_put_var_value_block(fid_out, id_time, start, nwrite, time_value+n);
@@ -640,14 +641,14 @@ void process_data(const char *infile, const char *fld_name_in, const char *outfi
       i2   = remap->i_out[l];
       j2   = remap->j_out[l];
       i1   = remap->i_in [l];
-      j1   = remap->j_in [l];    
+      j1   = remap->j_in [l];
       xarea = remap->xgrid_area [l];
       /* since input mask is already considered when computing exchange grid,
 	 there is no need to consider missing value
       */
       data_out[j2*nx_out+i2] += data_in[j1*nx_in+i1]*xarea;
     }
-    
+
     /* move the runoff to the nearest ocean points */
     for(j=0; j<ny_out; j++) for(i=0; i<nx_out; i++) {
       l = j*nx_out+i;
@@ -681,13 +682,13 @@ void process_data(const char *infile, const char *fld_name_in, const char *outfi
       if(grid_in->mask[i]>0)runoff_total_in += (data_in[i]*grid_in->area[i]);
     }
     for(i=0; i<nx_out*ny_out; i++) runoff_total_out += (data_out[i]*grid_out->area[i]);
-    if(runoff_total_in > 0 && runoff_total_out > 0) 
+    if(runoff_total_in > 0 && runoff_total_out > 0)
       rate_change = (runoff_total_out-runoff_total_in)/runoff_total_in;
     else
       rate_change = 0.0;
     printf("At time step %d, runoff_total_in=%g, runoff_total_out=%g, change rate is =%g%%\n",
 	   n, runoff_total_in, runoff_total_out, rate_change);
-    
+
   }
   mpp_close(fid_out);
   mpp_close(fid_in);
@@ -695,7 +696,7 @@ void process_data(const char *infile, const char *fld_name_in, const char *outfi
   free(time_value);
   free(data_in);
   free(data_out);
-  
+
 }
 
 /* calculate a distance in 3-d between points on unit square */
@@ -703,7 +704,7 @@ double distance(double lon1, double lat1, double lon2, double lat2)
 {
   double dist, z1, z2, x1, x2, y1, y2;
 
-  
+
   z1 = sin(lat1);
   z2 = sin(lat2);
   x1 = cos(lat1)*cos(lon1);
@@ -714,7 +715,7 @@ double distance(double lon1, double lat1, double lon2, double lat2)
   dist = sqrt(pow((z1-z2),2)+pow((x1-x2),2)+pow((y1-y2),2));
   return dist;
 }
-	  
+
 /* find the nearest ocean point of a given land point. */
 
 void nearest(int nlon, int nlat, double *mask, const double *lon, const double *lat,
@@ -758,4 +759,4 @@ void nearest(int nlon, int nlat, double *mask, const double *lon, const double *
 
 
 /*   } */
-  
+


### PR DESCRIPTION
This PR creates print_provenance utility functions to uniformly (accross all NCTols apps using the functions) write as netcdf global attributes provenance and provenance related information.
A sample of the info is 
```
// global attributes:
		:grid_version = "0.2" ;
		:code_release_version = "19.0.1" ;
		:git_hash = "51ed4692c8b238e1e15bbc1d240951d3000e6f35" ;
		:creationtime = "Wed Nov 24 13:52:24 2021" ;
		:hostname = "edison" ;
		:history = "make_hgrid --grid_type gnomonic_ed --nlon 96 --grid_name C48_gridy" ;
```
The new functions are in /tools/libfrencutil/tool_util.c.
configure.ac was modified to place the git_hash info into the generated config.h file.
Numerous apps were modified to use the new functionality.


