### PR TITLE
Disable the optimized Intel Math Library for PP/AN and WS compilations

### DIFF
--- a/site-configs/gfdl-ws/config.site
+++ b/site-configs/gfdl-ws/config.site
@@ -29,4 +29,7 @@ test -z "$CC" && CC=icc
 test -z "$FC" && FC=ifort
 
 # Compile/Link flags
-test -z "$FCFLAGS" && FCFLAGS="-fltconsistency -fno-alias -stack_temps -ftz -assume byterecl -i4 -traceback"
+# Note: using -lm before the object file causes the Intel compiler to use the
+#       standard GNU math library instead of the optimized Intel Math library
+test -z "$CFLAGS" && CFLAGS="-xSSE2 -lm"
+test -z "$FCFLAGS" && FCFLAGS="-fltconsistency -fno-alias -stack_temps -ftz -assume byterecl -i4 -traceback -xSSE2"

--- a/site-configs/gfdl/config.site
+++ b/site-configs/gfdl/config.site
@@ -29,4 +29,7 @@ test -z "$CC" && CC=icc
 test -z "$FC" && FC=ifort
 
 # Compile/Link flags
-test -z "$FCFLAGS" && FCFLAGS="-fltconsistency -fno-alias -stack_temps -ftz -assume byterecl -i4 -traceback"
+# Note: using -lm before the object file causes the Intel compiler to use the
+#       standard GNU math library instead of the optimized Intel Math library
+test -z "$CFLAGS" && CFLAGS="-xSSE2 -lm"
+test -z "$FCFLAGS" && FCFLAGS="-fltconsistency -fno-alias -stack_temps -ftz -assume byterecl -i4 -traceback -xSSE2"


### PR DESCRIPTION
Specifying -lm before the object file has the effect of using the standard GNU math library instead of the optimized Intel Math library for C programs. Additionally, add the -xsse2 option to use a stricter set of ISA than the default -msse2, which is also used for the gaea settings.