### PR TITLE
Draft GFDL gitlab updates for deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ variables:
     - autoreconf -i
     - mkdir ${buildDir}
     - cd ${buildDir}
-    - ../configure --prefix=${FMS_HOME}/local/opt/fre-nctools/test/${FRE_SITE}
+    - ../configure
     - make
     - make -j check
   artifacts:
@@ -73,6 +73,7 @@ deploy:gfdl-ws:
     FMS_HOME: /home/fms
   only:
     - master
+    - tags
   dependencies:
     - build:gfdl-ws
   <<: *deployScript
@@ -88,6 +89,7 @@ deploy:gfdl:
     FMS_HOME: /home/fms
   only:
     - master
+    - tags
   dependencies:
     - build:gfdl
   <<: *deployScript

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@
 
 # Prelude
 AC_PREREQ([2.63])
-AC_INIT([FRE NC Tools], [19.1], [oar.gfdl.help@noaa.gov], [fre-nctools], [https://github.com/NOAA-GFDL/FRE-NCtools])
+AC_INIT([FRE NC Tools], [test], [oar.gfdl.help@noaa.gov], [fre-nctools], [https://github.com/NOAA-GFDL/FRE-NCtools])
 # Place the git description informatin in the configure script
 m4_define([git_revision],
   [m4_esyscmd_s([git describe --always --dirty 2> /dev/null || echo "unknown version"])])


### PR DESCRIPTION
Do not merge!

While we want to enable deployments using the gitlab CI, it doesn't feel safe with the settings as is. i.e.:

The version to be installed to is set in configure.ac, but the tag is the gitlab trigger, so with a new tag, the existing old tag installation location would be overwritten.

I think it would be safer to install the location to the git tag instead of the configure.ac package version if possible.