### PR TITLE
mppnccombine fixes for use with monolithic files

### DIFF
--- a/postprocessing/mppnccombine/mppnccombine.c
+++ b/postprocessing/mppnccombine/mppnccombine.c
@@ -990,9 +990,9 @@ int process_vars(struct fileinfo *ncinfile, struct fileinfo *ncoutfile,
    int varrecdim;  /* Variable's record dimension */
    static unsigned char first=1;  /* First time reading variables? */
    int imax, jmax, kmax, lmax;
-   int imaxfull, jmaxfull, kmaxfull, lmaxfull;
-   int imaxjmaxfull, imaxjmaxkmaxfull;
-   int offset, ioffset, joffset, koffset, loffset;
+   long long int imaxfull, jmaxfull, kmaxfull, lmaxfull;
+   long long int imaxjmaxfull, imaxjmaxkmaxfull;
+   long long int offset, ioffset, joffset, koffset, loffset;
    int recdimsize; /* Using a local recdimsize to correct issue when netcdf file does not have a record dimension */
    long long varbufsize;
 

--- a/postprocessing/mppnccombine/mppnccombine.c
+++ b/postprocessing/mppnccombine/mppnccombine.c
@@ -980,7 +980,7 @@ int process_vars(struct fileinfo *ncinfile, struct fileinfo *ncoutfile,
                  unsigned char appendnc, int *nrecs, int *nblocks, int* bf, int r, int nfiles,
                  int f, unsigned char verbose, unsigned char missing)
   {
-   int v, d, i, j, k, l, b, s;  /* Loop variables */
+   int v, d, i, j, k, l, s;  /* Loop variables */
    int dimid;  /* ID of a dimension */
    void *values = NULL;  /* Current data values */
    long instart[MAX_NC_DIMS], outstart[MAX_NC_DIMS];  /* Data array sizes */
@@ -993,8 +993,10 @@ int process_vars(struct fileinfo *ncinfile, struct fileinfo *ncoutfile,
    long long int imaxfull, jmaxfull, kmaxfull, lmaxfull;
    long long int imaxjmaxfull, imaxjmaxkmaxfull;
    long long int offset, ioffset, joffset, koffset, loffset;
+   long long int b;
    int recdimsize; /* Using a local recdimsize to correct issue when netcdf file does not have a record dimension */
    long long varbufsize;
+
 
    if ( ncinfile->recdim < 0 )
      recdimsize=1;
@@ -1260,7 +1262,7 @@ int process_vars(struct fileinfo *ncinfile, struct fileinfo *ncoutfile,
            }
          else lmaxfull=1;
          if (verbose > 1)
-           printf("      imaxfull=%d  jmaxfull=%d  kmaxfull=%d  lmaxfull=%d\n",
+           printf("      imaxfull=%lld  jmaxfull=%lld  kmaxfull=%lld  lmaxfull=%lld\n",
                   imaxfull,jmaxfull,kmaxfull,lmaxfull);
          imaxjmaxfull=imaxfull*jmaxfull;
          imaxjmaxkmaxfull=imaxfull*jmaxfull*kmaxfull;
@@ -1294,7 +1296,7 @@ int process_vars(struct fileinfo *ncinfile, struct fileinfo *ncoutfile,
               }
            }
          if (verbose > 1)
-           printf("      ioffset=%d  joffset=%d  koffset=%d  loffset=%d\n",
+           printf("      ioffset=%lld  joffset=%lld  koffset=%lld  loffset=%lld\n",
                   ioffset,joffset,koffset,loffset);
          switch (ncinfile->datatype[v])
            {


### PR DESCRIPTION
This PR changes several variables in mppnccombine.c that are indices , or are related to indices, from "int"
to "long long int" - i.e. from 32 bit ints to 64 bit ints. The 32 bit indices could not hold the info when the index
was set to a  number larger that pow(2,32 -1). For example, test files with
``` NLAT * NLON * NTILES = 5400 * 7200 * 64```, that product being greater than pow(2,32-1), 
 would evntually  have negative values for variables ```offset```  and ```b``` in loop  calculation such as this one:
```for (l=0; l < lmax; l++)
                for (k=0; k < kmax; k++)
                  for (j=0; j < jmax; j++)
                    for (i=0; i < imax; i++)
                      {
                       offset=(i+ioffset)+
                              (j+joffset)*imaxfull+
                              (k+koffset)*imaxjmaxfull+
                              (l+loffset)*imaxjmaxkmaxfull;
                       *((unsigned char *)(varbuf[(r % (*bf))][v])+offset)=
                       *((unsigned char *)values+(b++));
                      }
```
Some variables that were used in calculations (on the right has side) of a "long long int" were also changed from "int" to "long long int".

Testing:
1) We are hoping to hear from the end user , but in the meantime :
2) We made runs combining 16 NetCDF files of size 5400 * 7200 * X (where X varied depending on experiment).
The NetCDF files were created  by ncgen from NCL files that were generated from this c++ app : https://github.com/ngs333/gfdl_misc/blob/master/src/cpp_execs/restarts_fcom_gen.cpp. 
The args to mppnccombile were : 
```
ppnccombine -vv -n4 output.nc \
	     data.nc.0000 data.nc.0001 data.nc.0002 data.nc.0003 \
	     data.nc.0004 data.nc.0005 data.nc.0006 data.nc.0007 \
	     data.nc.0008 data.nc.0009 data.nc.0010 data.nc.0011 \
	     data.nc.0012 data.nc.0013 data.nc.0014 data.nc.0015
3) some reproducibility tests were done with smaller files.
```