### PR TITLE
Updates build system to use correct -I and -L for Fortran files

### DIFF
--- a/m4/ax_lib_netcdf.m4
+++ b/m4/ax_lib_netcdf.m4
@@ -259,8 +259,8 @@ AS_IF([test ! -z "${NF_CONFIG+x}"],[
   # has nf-config --fflags not return the -I flag.  This causes issues if trying to not use the
   # wrapper.  Thus, we add the -I flag if the cflags variable doesn't have it.  This should be
   # harmless.
-  _ax_c_lib_netcdf_includedir=$(eval $NC_CONFIG --includedir 2> /dev/null)
-  echo "$_ax_c_lib_netcdf_cflags" | $GREP -e "-I$_ac_c_lib_netcdf_includedir" 2>&1 > /dev/null || _ax_c_lib_netcdf_cflags="$_ax_c_lib_netcdf_cflags -I$_ax_c_lib_netcdf_includedir"
+  _ax_fc_lib_netcdf_includedir=$(eval $NF_CONFIG --includedir 2> /dev/null)
+  echo "$_ax_fc_lib_netcdf_cflags" | $GREP -e "-I$_ax_fc_lib_netcdf_includedir" 2>&1 > /dev/null || _ax_fc_lib_netcdf_cflags="$_ax_fc_lib_netcdf_cflags -I$_ax_fc_lib_netcdf_includedir"
   # LIBS and LDFLAGS sorted based on prefix (e.g. -L and -l)
   for arg in $(eval $NF_CONFIG --flibs 2> /dev/null) ; do
     AS_CASE([$arg],
@@ -333,7 +333,7 @@ rm conftest.$ac_ext
 FCFLAGS=$_ax_fc_lib_netcdf_save_FCFLAGS
 AS_VAR_COPY([ax_netcdf_cflags_res], [ax_netcdf_cflags_search])
 AS_IF([test "$ax_netcdf_fcflags_res" != no],
-      [test "$ax_netcdf_fcflags_res" = "none required" || NETCDF_CFLAGS=$ax_netcdf_fcflags_res
+      [test "$ax_netcdf_fcflags_res" = "none required" || NETCDF_FCFLAGS=$ax_netcdf_fcflags_res
        ax_netcdf_fcflags_search="yes"])
 ])
 # Check for the netcdf module, and if it is usable with the current FC compiler

--- a/tools/nc_null_check/Makefile.am
+++ b/tools/nc_null_check/Makefile.am
@@ -22,6 +22,6 @@ bin_PROGRAMS = nc_null_check
 AM_FCFLAGS = -I$(top_srcdir)/tools/libfrencutils \
 				$(NETCDF_FCFLAGS)
 LDADD = $(top_builddir)/tools/libfrencutils/libfrencutils.a \
-        $(NETCDF_LDFLAGS) $(NETCDF_FCLIBS)
+        $(NETCDF_FCLDFLAGS) $(NETCDF_FCLIBS)
 
 nc_null_check_SOURCES = nc_null_check.F90

--- a/tools/simple_hydrog/lakes/Makefile.am
+++ b/tools/simple_hydrog/lakes/Makefile.am
@@ -25,7 +25,7 @@ FMSROOT = $(top_builddir)/tools/simple_hydrog/libfmslite
 
 AM_CFLAGS = $(NETCDF_CFLAGS)
 AM_FCFLAGS = -I$(FMSROOT) $(FC_DEFAULT_REAL_KIND8_FLAG) $(NETCDF_FCFLAGS)
-LDADD = $(NETCDF_LDFLAGS) $(NETCDF_LIBS) $(NETCDF_FCLIBS)
+LDADD = $(NETCDF_FCLDFLAGS) $(NETCDF_LIBS) $(NETCDF_FCLIBS)
 
 cr_lake_files_SOURCES = cr_lake_files.f90
 cr_lake_files_LDADD = $(FMSROOT)/libfms.a $(LDADD)

--- a/tools/simple_hydrog/rmvpr/Makefile.am
+++ b/tools/simple_hydrog/rmvpr/Makefile.am
@@ -21,7 +21,7 @@ bin_PROGRAMS = rmv_parallel_rivers
 
 AM_FCFLAGS = $(FC_DEFAULT_REAL_KIND8_FLAG) $(NETCDF_FCFLAGS)
 
-LDADD = $(NETCDF_LDFLAGS) $(NETCDF_FCLIBS)
+LDADD = $(NETCDF_FCLDFLAGS) $(NETCDF_FCLIBS)
 
 rmv_parallel_rivers_SOURCES = rmv_parallel_rivers.f90  
 


### PR DESCRIPTION
Resolves #140 based on the discussion.

Updates the autotools files and Makefile.in to use the correct -I for Fortran netcdf and -L for the Fortran netcdf libraries.

Tested in a preliminary HPC-ME container and on gfdl:lscamd-50 built with intel 20 and intel 22 (ifort and icc)