### PR TITLE
Additional changes to build with recent c99 compliant compilers.

### DIFF
--- a/postprocessing/land_utils/is-compressed.c
+++ b/postprocessing/land_utils/is-compressed.c
@@ -82,6 +82,8 @@ int main(int argc, char* argv[])
 	 usage(argv[0]);
 	 return 1;
       }
+
+   int optind = argc - 1;
    
    __NC_ASRT__(nc_open(argv[optind],NC_NOWRITE,&ncid));
    __NC_ASRT__(nc_inq_ndims(ncid,&ndims));

--- a/tools/fregrid/fregrid.c
+++ b/tools/fregrid/fregrid.c
@@ -277,7 +277,6 @@ char *usage[] = {
   "                                                                                      ",
   NULL};
 #define EPSLN10  (1.e-10)
-const double D2R = M_PI/180.;
 char tagname[] = "$Name: bronx-10_performance_z1l $";
 
 extern int in_format; //declared in mpp_io.c

--- a/tools/libfrencutils/constant.h
+++ b/tools/libfrencutils/constant.h
@@ -17,5 +17,21 @@
  * License along with FRE-NCTools.  If not, see
  * <http://www.gnu.org/licenses/>.
  **********************************************************************/
+
+#ifndef NCTOOLS_CONSTANT_H
+#define NCTOOLS_CONSTANT_H
+
 #define RADIUS        (6371000.)
 #define STRING        255
+
+#ifndef M_PI
+#define M_PI		(3.14159265358979323846)
+#endif
+
+#define R2D (180/M_PI)
+#define D2R (M_PI/180)
+#define TPI (2.0*M_PI)
+#define HPI (0.5*M_PI)
+
+#endif
+

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -29,9 +29,7 @@
 #define EPSLN8            (1.e-8)
 #define EPSLN30           (1.0e-30)
 #define EPSLN10           (1.0e-10)
-#define R2D (180/M_PI)
-#define TPI (2.0*M_PI)
-#define HPI (0.5*M_PI)
+
 double grid_box_radius(const double *x, const double *y, const double *z, int n);
 double dist_between_boxes(const double *x1, const double *y1, const double *z1, int n1,
 			  const double *x2, const double *y2, const double *z2, int n2);

--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -32,9 +32,9 @@
 #include <mpi.h>
 #endif
 
-#define R2D (180. / M_PI)
-#define HPI (0.5 * M_PI)
-#define TPI (2.0 * M_PI)
+#define R2D (180./M_PI)
+#define HPI (0.5*M_PI)
+#define TPI (2.0*M_PI)
 #define TOLORENCE (1.e-6)
 #define EPSLN8 (1.e-8)
 #define EPSLN10 (1.e-10)
@@ -44,12 +44,7 @@
     void error_handler(char *str)
     error handler: will print out error message and then abort
 ***********************************************************/
-
-//PolyAreaStrategy fix_lon_strategy = ORIG_LON_FIX; //Needs original_lon_fix or no_lon_fix
-PolyAreaStrategy fix_lon_strategy = NO_LON_FIX; //Needs original_lon_fix or no_lon_fix
-
 int reproduce_siena = 0;
-
 
 void set_reproduce_siena_true(void)
 {
@@ -58,22 +53,13 @@ void set_reproduce_siena_true(void)
 
 void error_handler(const char *msg)
 {
-  fprintf(stderr, "FATAL Error: %s\n", msg);
+  fprintf(stderr, "FATAL Error: %s\n", msg );
 #ifdef use_libMPI
   MPI_Abort(MPI_COMM_WORLD, -1);
 #else
   exit(1);
 #endif
-} /* error_handler */
-
-int areApproxEqual(double a, double b, double delta){
-  if(fabs( a - b) <= delta){
-    return 1;
-  }else{
-    return 0;
-  }
-}
-
+}; /* error_handler */
 
 /*********************************************************************
 
@@ -94,84 +80,71 @@ int nearest_index(double value, const double *array, int ia)
   int index, i;
   int keep_going;
 
-  for (i = 1; i < ia; i++)
-  {
-    if (array[i] < array[i - 1])
+  for(i=1; i<ia; i++){
+    if (array[i] < array[i-1])
       error_handler("nearest_index: array must be monotonically increasing");
   }
-  if (value < array[0])
+  if (value < array[0] )
     index = 0;
-  else if (value > array[ia - 1])
-    index = ia - 1;
+  else if ( value > array[ia-1])
+    index = ia-1;
   else
-  {
-    i = 0;
-    keep_going = 1;
-    while (i < ia && keep_going)
     {
-      i = i + 1;
-      if (value <= array[i])
-      {
-        index = i;
-        if (array[i] - value > value - array[i - 1])
-          index = i - 1;
-        keep_going = 0;
+      i=0;
+      keep_going = 1;
+      while (i < ia && keep_going) {
+   i = i+1;
+   if (value <= array[i]) {
+     index = i;
+     if (array[i]-value > value-array[i-1]) index = i-1;
+     keep_going = 0;
+   }
       }
     }
-  }
   return index;
+
 };
 
 /******************************************************************/
 
-void tokenize(const char *const string, const char *tokens, unsigned int varlen,
-              unsigned int maxvar, char *pstring, unsigned int *const nstr)
+void tokenize(const char * const string, const char *tokens, unsigned int varlen,
+         unsigned int maxvar, char * pstring, unsigned int * const nstr)
 {
   size_t i, j, nvar, len, ntoken;
   int found, n;
 
-  nvar = 0;
-  j = 0;
+  nvar = 0; j = 0;
   len = strlen(string);
   ntoken = strlen(tokens);
   /* here we use the fact that C array [][] is contiguous in memory */
-  if (string[0] == 0)
-    error_handler("Error from tokenize: to-be-parsed string is empty");
+  if(string[0] == 0)error_handler("Error from tokenize: to-be-parsed string is empty");
 
-  for (i = 0; i < len; i++)
-  {
-    if (string[i] != ' ' && string[i] != '\t')
-    {
+  for(i = 0; i < len; i ++){
+    if(string[i] != ' ' && string[i] != '\t'){
       found = 0;
-      for (n = 0; n < ntoken; n++)
-      {
-        if (string[i] == tokens[n])
-        {
-          found = 1;
-          break;
-        }
+      for(n=0; n<ntoken; n++) {
+   if(string[i] == tokens[n] ) {
+     found = 1;
+     break;
+   }
       }
-      if (found)
-      {
-        if (j != 0)
-        { /* remove :: */
-          *(pstring + (nvar++) * varlen + j) = 0;
-          j = 0;
-          if (nvar >= maxvar)
-            error_handler("Error from tokenize: number of variables exceeds limit");
-        }
+      if(found) {
+   if( j != 0) { /* remove :: */
+     *(pstring + (nvar++)*varlen + j) = 0;
+     j = 0;
+     if(nvar >= maxvar) error_handler("Error from tokenize: number of variables exceeds limit");
+   }
       }
-      else
-      {
-        *(pstring + nvar * varlen + j++) = string[i];
-        if (j >= varlen)
-          error_handler("error from tokenize: variable name length exceeds limit during tokenization");
+      else {
+        *(pstring + nvar*varlen + j++) = string[i];
+        if(j >= varlen ) error_handler("error from tokenize: variable name length exceeds limit during tokenization");
       }
     }
   }
-  *(pstring + nvar * varlen + j) = 0;
+  *(pstring + nvar*varlen + j) = 0;
 
   *nstr = ++nvar;
+
 }
 
 /*******************************************************************************
@@ -184,15 +157,14 @@ double maxval_double(int size, const double *data)
   double maxval;
 
   maxval = data[0];
-  for (n = 1; n < size; n++)
-  {
-    if (data[n] > maxval)
-      maxval = data[n];
+  for(n=1; n<size; n++){
+    if( data[n] > maxval ) maxval = data[n];
   }
 
   return maxval;
 
 }; /* maxval_double */
+
 
 /*******************************************************************************
   double minval_double(int size, double *data)
@@ -204,10 +176,8 @@ double minval_double(int size, const double *data)
   double minval;
 
   minval = data[0];
-  for (n = 1; n < size; n++)
-  {
-    if (data[n] < minval)
-      minval = data[n];
+  for(n=1; n<size; n++){
+    if( data[n] < minval ) minval = data[n];
   }
 
   return minval;
@@ -224,13 +194,13 @@ double avgval_double(int size, const double *data)
   double avgval;
 
   avgval = 0;
-  for (n = 0; n < size; n++)
-    avgval += data[n];
+  for(n=0; n<size; n++) avgval += data[n];
   avgval /= size;
 
   return avgval;
 
 }; /* avgval_double */
+
 
 /*******************************************************************************
   void latlon2xyz
@@ -240,10 +210,9 @@ void latlon2xyz(int size, const double *lon, const double *lat, double *x, doubl
 {
   int n;
 
-  for (n = 0; n < size; n++)
-  {
-    x[n] = cos(lat[n]) * cos(lon[n]);
-    y[n] = cos(lat[n]) * sin(lon[n]);
+  for(n=0; n<size; n++) {
+    x[n] = cos(lat[n])*cos(lon[n]);
+    y[n] = cos(lat[n])*sin(lon[n]);
     z[n] = sin(lat[n]);
   }
 
@@ -253,31 +222,29 @@ void latlon2xyz(int size, const double *lon, const double *lat, double *x, doubl
        void xyz2laton(np, p, xs, ys)
    Transfer cartesian coordinates to spherical coordinates
    ----------------------------------------------------------*/
-void xyz2latlon(int np, const double *x, const double *y, const double *z, double *lon, double *lat)
+void xyz2latlon( int np, const double *x, const double *y, const double *z, double *lon, double *lat)
 {
 
   double xx, yy, zz;
   double dist, sinp;
   int i;
 
-  for (i = 0; i < np; i++)
-  {
+  for(i=0; i<np; i++) {
     xx = x[i];
     yy = y[i];
     zz = z[i];
-    dist = sqrt(xx * xx + yy * yy + zz * zz);
+    dist = sqrt(xx*xx+yy*yy+zz*zz);
     xx /= dist;
     yy /= dist;
     zz /= dist;
 
-    if (fabs(xx) + fabs(yy) < EPSLN10)
-      lon[i] = 0;
-    else
-      lon[i] = atan2(yy, xx);
-    lat[i] = asin(zz);
+    if ( fabs(xx)+fabs(yy)  < EPSLN10 )
+       lon[i] = 0;
+     else
+       lon[i] = atan2(yy, xx);
+     lat[i] = asin(zz);
 
-    if (lon[i] < 0.)
-      lon[i] = 2. * M_PI + lon[i];
+     if ( lon[i] < 0.) lon[i] = 2.*M_PI + lon[i];
   }
 
 } /* xyz2latlon */
@@ -288,17 +255,16 @@ void xyz2latlon(int np, const double *x, const double *y, const double *z, doubl
   ----------------------------------------------------------------------------*/
 double box_area(double ll_lon, double ll_lat, double ur_lon, double ur_lat)
 {
-  double dx = ur_lon - ll_lon;
+  double dx = ur_lon-ll_lon;
   double area;
 
-  if (dx > M_PI)
-    dx = dx - 2.0 * M_PI;
-  if (dx < -M_PI)
-    dx = dx + 2.0 * M_PI;
+  if(dx > M_PI)  dx = dx - 2.0*M_PI;
+  if(dx < -M_PI) dx = dx + 2.0*M_PI;
 
-  return (dx * (sin(ur_lat) - sin(ll_lat)) * RADIUS * RADIUS);
+  return (dx*(sin(ur_lat)-sin(ll_lat))*RADIUS*RADIUS ) ;
 
 }; /* box_area */
+
 
 /*------------------------------------------------------------------------------
   double poly_area(const x[], const y[], int n)
@@ -310,44 +276,37 @@ double box_area(double ll_lon, double ll_lat, double ur_lon, double ur_lat)
 double poly_area_dimensionless(const double x[], const double y[], int n)
 {
   double area = 0.0;
-  int i;
+  int    i;
 
-  for (i = 0; i < n; i++)
-  {
-    int ip = (i + 1) % n;
-    double dx = (x[ip] - x[i]);
+  for (i=0;i<n;i++) {
+    int ip = (i+1) % n;
+    double dx = (x[ip]-x[i]);
     double lat1, lat2;
     double dy, dat;
 
     lat1 = y[ip];
     lat2 = y[i];
-    if (dx > M_PI)
-      dx = dx - 2.0 * M_PI;
-    if (dx < -M_PI)
-      dx = dx + 2.0 * M_PI;
-    if (dx == 0.0)
-      continue;
+    if(dx > M_PI)  dx = dx - 2.0*M_PI;
+    if(dx < -M_PI) dx = dx + 2.0*M_PI;
+    if (dx==0.0) continue;
 
-    if (fabs(lat1 - lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
-      area -= dx * sin(0.5 * (lat1 + lat2));
-    else
-    {
-      if (reproduce_siena)
-      {
-        area += dx * (cos(lat1) - cos(lat2)) / (lat1 - lat2);
+    if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
+      area -= dx*sin(0.5*(lat1+lat2));
+    else {
+      if(reproduce_siena) {
+   area += dx*(cos(lat1)-cos(lat2))/(lat1-lat2);
       }
-      else
-      {
-        dy = 0.5 * (lat1 - lat2);
-        dat = sin(dy) / dy;
-        area -= dx * sin(0.5 * (lat1 + lat2)) * dat;
+      else {
+   dy = 0.5*(lat1-lat2);
+   dat = sin(dy)/dy;
+   area -= dx*sin(0.5*(lat1+lat2))*dat;
       }
     }
   }
-  if (area < 0)
-    return (-area / (4 * M_PI));
+  if(area < 0)
+    return (-area/(4*M_PI));
   else
-    return (area / (4 * M_PI));
+    return (area/(4*M_PI));
 
 }; /* poly_area */
 
@@ -430,45 +389,21 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
       Ir_thru_pole = Il_thru_pole = pi  
     where Ir_thru_pole is the integral over the segment passing through the pole.
    ----------------------------------------------------------------------------*/
-double poly_area(const double xo[], const double yo[], int n ) {
+double poly_area(const double x[], const double y[], int n)
+{
   double area = 0.0;
-  double area_se = 0.0;
-  double da = 0;
-  int dflag = 0;
-  int pole = 0;
-  double xr[4]; //rotated lon
-  double yr[4]; //rotated lat
-  double x[4], y[4];
+  int    i;
 
-  if(n == 4){
-    for (int i = 0; i<4; i++){
-        x[i] = xo[i];
-        y[i] = yo[i];
-    }
-  }
-
-  //If the code is set to call the origin fix_lon function. then just proceed as normal.
-  //Otherwise we can call various methods to compare.
-  pole = at_pole(x, y, n); 
-   if (pole == 1) { 
-    area_se = se_area(x, y, n);   
-    if (fix_lon_strategy != ORIG_LON_FIX){  
-      rotate_poly(x, y, n, xr, yr);  
-     }
-   }
-  
-  for (int i = 0; i < n; i++){
-    int ip = (i + 1) % n;
-    double dx = (x[ip] - x[i]);
+  for (i=0;i<n;i++) {
+    int ip = (i+1) % n;
+    double dx = (x[ip]-x[i]);
     double lat1, lat2;
     double dy, dat;
 
     lat1 = y[ip];
     lat2 = y[i];
-    if (dx > M_PI)
-      dx = dx - 2.0 * M_PI;
-    if (dx <= -M_PI)
-      dx = dx + 2.0 * M_PI;
+    if(dx > M_PI)  dx = dx - 2.0*M_PI;
+    if(dx <= -M_PI) dx = dx + 2.0*M_PI;
     /*When the path goes through a Pole the line integral cannot be
       approximated by the fomula below. But we can show for these
       special grid cells the contribution of such paths to the area is pi.
@@ -477,281 +412,160 @@ double poly_area(const double xo[], const double yo[], int n ) {
       Note in that situation we should extend the if(dx < -M_PI) to if(dx <= -M_PI)
       so the resulting contribution to area is positive.
     */
-    if (fabs(dx + M_PI) < SMALL_VALUE || fabs(dx - M_PI) < SMALL_VALUE){
+    if(fabs(dx+M_PI)< SMALL_VALUE || fabs(dx-M_PI)< SMALL_VALUE){
       area += M_PI;
       continue; //next i
     }
 
-    if (fabs(lat1 - lat2) < SMALL_VALUE){ /* cheap area calculation along latitude */
-      da = dx * sin(0.5 * (lat1 + lat2));
-      area -= da;
-    }else{
-      if (reproduce_siena){
-        area += dx * (cos(lat1) - cos(lat2)) / (lat1 - lat2);
+    if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
+      area -= dx*sin(0.5*(lat1+lat2));
+    else {
+      if(reproduce_siena) {
+	area += dx*(cos(lat1)-cos(lat2))/(lat1-lat2);
       }
-      else{
-        //This expression is a trig identity with the above reproduce_siena case
-        dy = 0.5 * (lat1 - lat2);
-        dat = sin(dy) / dy;
-        da = dx * sin(0.5 * (lat1 + lat2)) * dat;
-        area -= da;
+      else {
+	//This expression is a trig identity with the above reproduce_siena case
+	dy = 0.5*(lat1-lat2);
+	dat = sin(dy)/dy;
+	area -= dx*sin(0.5*(lat1+lat2))*dat; 
       }
     }
   }
-  if (area < 0){
-    area=  -area * RADIUS * RADIUS;
-  }else{
-    area =  area * RADIUS * RADIUS;
-  }
+  if(area < 0)
+     return -area*RADIUS*RADIUS;
+  else
+     return area*RADIUS*RADIUS;
 
-  if (pole == 1){
-    printf("poly_area : poly had pole. Poly was:\n");
-    v_print(x, y, n);
-    printf("--------->\n");
-    printf(" strategy se_area area : %d %g %g", fix_lon_strategy , area_se, area);
-  }
-    return area;
-}
+}; /* poly_area */
 
-double poly_area_no_adjust(const double x[], const double y[], int n){
+double poly_area_no_adjust(const double x[], const double y[], int n)
+{
   double area = 0.0;
+  int    i;
 
-  for (int i = 0; i < n; i++){
-    int ip = (i + 1) % n;
-    double dx = (x[ip] - x[i]);
+  for (i=0;i<n;i++) {
+    int ip = (i+1) % n;
+    double dx = (x[ip]-x[i]);
     double lat1, lat2;
 
     lat1 = y[ip];
     lat2 = y[i];
-    if (dx == 0.0)
-      continue;
+    if (dx==0.0) continue;
 
-    if (fabs(lat1 - lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
-      area -= dx * sin(0.5 * (lat1 + lat2));
+    if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
+      area -= dx*sin(0.5*(lat1+lat2));
     else
-      area += dx * (cos(lat1) - cos(lat2)) / (lat1 - lat2);
+      area += dx*(cos(lat1)-cos(lat2))/(lat1-lat2);
   }
-  if (area < 0)
-    return -area * RADIUS * RADIUS;
+  if(area < 0)
+     return area*RADIUS*RADIUS;
   else
-    return area * RADIUS * RADIUS;
-} 
+     return area*RADIUS*RADIUS;
+}; /* poly_area_no_adjust */
 
-int delete_vtx(double x[], double y[], int n, int n_del){
-  for (; n_del < n - 1; n_del++){
-    x[n_del] = x[n_del + 1];
-    y[n_del] = y[n_del + 1];
+int delete_vtx(double x[], double y[], int n, int n_del)
+{
+  for (;n_del<n-1;n_del++) {
+    x[n_del] = x[n_del+1];
+    y[n_del] = y[n_del+1];
   }
-  return (n - 1);
-}
+
+  return (n-1);
+} /* delete_vtx */
 
 int insert_vtx(double x[], double y[], int n, int n_ins, double lon_in, double lat_in)
 {
-  for (int i = n - 1; i >= n_ins; i--){
-    x[i + 1] = x[i];
-    y[i + 1] = y[i];
+  int i;
+
+  for (i=n-1;i>=n_ins;i--) {
+    x[i+1] = x[i];
+    y[i+1] = y[i];
   }
 
   x[n_ins] = lon_in;
   y[n_ins] = lat_in;
-  return (n + 1);
+  return (n+1);
 } /* insert_vtx */
 
-void v_print(double x[], double y[], int n){
-  for (int i = 0; i < n; i++){
-    printf(" %20g   %20g\n", x[i] * R2D, y[i] * R2D);
-  }
-}
-
-int fix_lon_v2(double x[], double y[], int n){
-  for (int i = 0; i < n; i++){
-    if (y[i] >= HPI - TOLORENCE)
-      {
-        y[i] -= (TOLORENCE * 1.01);
-      }
-    else if (y[i] <= HPI - TOLORENCE)
-      {
-        y[i] += (TOLORENCE * 1.01);
-      }
-  }
-  return n;
-}
-
-int at_pole(const double x[], const double y[], int n)
+void v_print(double x[], double y[], int n)
 {
-  int pole = 0;
-  for (int i = 0; i < n; i++) {
-    if (fabs(y[i]) >= M_PI_2 - TOLORENCE){
-      pole = 1;
-    }
-  }
-  return pole;
-}
+  int i;
 
-double se_area(const double x[], const double y[], const int n){
-  int i;  
-  double area;
-  double v1[3], v2[3], v3[3];
-  double p_ll[2],  p_ul[2], p_lr[2], p_ur[2];
-  double radius = RADIUS;
-
-  i = 3;
-  p_ll[0] = x[i];
-  p_ll[1] = y[i];
-  i = 2;
-  p_ul[0] = x[i];
-  p_ul[1] = y[i];
-  i = 0;
-  p_lr[0] = x[i];
-  p_lr[1] = y[i];
-  i = 1;
-  p_ur[0] = x[i];
-  p_ur[1] = y[i];
-
-  area = spherical_excess_area(p_ll, p_ul, p_lr, p_ur, radius);
-  return area;
-
-}
-
- /* Rotate 45 degrees bout axis <1,1,1>/sqrt(3) */
-void rotate_point_ra( double rv[]){
-  double m [3][3];
-  double v[3];
-
-  m[0][0] = 0.8047;
-  m[0][1] = -0.31;
-  m[0][2] = 0.5058;
-  m[1][0] =0.5058;
-  m[1][1] = 0.8047;
-  m[1][2] = -0.31;
-  m[2][0] = -0.31;
-  m[2][1] =0.5058;
-  m[2][2] = 0.8047;
-
-  for(int i = 0; i < 3; i++){
-    v[i] = 0.0;
-    for (int j = 0; j<3; j++){
-      v[i] += m[i][j] * rv[j];
-    }
-  }
-  for(int i = 0; i < 3; i++){
-    rv[i] = v[i];
-  }
-}
-
-double rotate_poly(const double x[], const double y[], const int n, double xr[], double yr[]){
-  double area;
-  double sv[2]; //a rotated lat/lon
-  double rv[3]; //rotated xyz point
-  
-  for(int i = 0; i < n; i++){
-    latlon2xyz(1, &x[i], &y[i], &rv[0], &rv[1], &rv[2]);
-    rotate_point_ra(rv);
-    xyz2latlon(1, &rv[0], &rv[1], &rv[2], &sv[0], &sv[1]);
-    xr[i] = sv[0];
-    yr[i] = sv[1];
-  }
-}
+  for (i=0;i<n;i++) printf(" %20g   %20g\n", x[i]*R2D, y[i]*R2D);
+} /* v_print */
 
 int fix_lon(double x[], double y[], int n, double tlon)
-{
-  int  nn = n;
-
-  if(fix_lon_strategy != ORIG_LON_FIX){
-    return nn;
-  }else{
-    nn = fix_lon_pas(x, y, n, tlon, ORIG_LON_FIX );
-    return nn;
-  }
-}
-
-int fix_lon_pas(double x[], double y[], int n, double tlon, PolyAreaStrategy pas)
 {
   double x_sum, dx;
   int i, nn = n, pole = 0;
 
-  if(pas != ORIG_LON_FIX){
-    return n;
+  for (i=0;i<nn;i++) if (fabs(y[i])>=HPI-TOLORENCE) pole = 1;
+  if (0&&pole) {
+    printf("fixing pole cell\n");
+    v_print(x, y, nn);
+    printf("---------");
   }
 
   /* all pole points must be paired */
   /* The reason is poly_area() function needs a contribution equal to the angle (in radians) 
      between the sides that connect to the pole. */
-  for (i = 0; i < nn; i++)
-    if (fabs(y[i]) >= HPI - TOLORENCE) {
-      int im = (i + nn - 1) % nn, ip = (i + 1) % nn;
+  for (i=0;i<nn;i++) if (fabs(y[i])>=HPI-TOLORENCE) {
+    int im=(i+nn-1)%nn, ip=(i+1)%nn;
 
-      if (y[im] == y[i] && y[ip] == y[i]){
-        nn = delete_vtx(x, y, nn, i);
-        i--;
-      }else if (y[im] != y[i] && y[ip] != y[i]){
-        nn = insert_vtx(x, y, nn, i, x[i], y[i]);
-        i++;
-      }
+    if (y[im]==y[i] && y[ip]==y[i]) {
+      nn = delete_vtx(x, y, nn, i);
+      i--;
+    } else if (y[im]!=y[i] && y[ip]!=y[i]) {
+      nn = insert_vtx(x, y, nn, i, x[i], y[i]);
+      i++;
     }
+  }
   /* first of pole pair has longitude of previous vertex */
   /* second of pole pair has longitude of subsequent vertex */
-  for (i = 0; i < nn; i++)
-    if (fabs(y[i]) >= HPI - TOLORENCE)
-    {
-      int im = (i + nn - 1) % nn, ip = (i + 1) % nn;
+  for (i=0;i<nn;i++) if (fabs(y[i])>=HPI-TOLORENCE) {
+    int im=(i+nn-1)%nn, ip=(i+1)%nn;
 
-      if (y[im] != y[i])
-        x[i] = x[im];
-      if (y[ip] != y[i])
-        x[i] = x[ip];
-    }
+    if (y[im]!=y[i]) x[i] = x[im];
+    if (y[ip]!=y[i]) x[i] = x[ip];
+  }
 
   /*If a polygon side passes through a Pole insert twin vertices at the Pole*/
   /*A fix is also directly applied to poly_area to handle this case.*/
-  for (i = 0; i < nn; i++)
-  {
-    int im = (i + nn - 1) % nn, ip = (i + 1) % nn;
-    double dx = x[i] - x[im];
-    if (fabs(dx + M_PI) < SMALL_VALUE || fabs(dx - M_PI) < SMALL_VALUE)
-    {
-      double x1 = x[im];
-      double x2 = x[i];
-      double ypole = HPI;
-      if (y[i] < 0.0)
-        ypole = -HPI;
+  for (i=0;i<nn;i++) {
+    int im=(i+nn-1)%nn, ip=(i+1)%nn;
+    double dx = x[i]-x[im];
+    if(fabs(dx+M_PI)< SMALL_VALUE || fabs(dx-M_PI)< SMALL_VALUE){
+      double x1=x[im];
+      double x2=x[i];
+      double ypole= HPI;
+      if(y[i]<0.0) ypole = -HPI ;
       nn = insert_vtx(x, y, nn, i, x2, ypole);
       nn = insert_vtx(x, y, nn, i, x1, ypole);
       break;
     }
   }
-  if (nn)
-    x_sum = x[0];
-  else
-    return (0);
-  for (i = 1; i < nn; i++)
-  {
-    double dx = x[i] - x[i - 1];
+  if (nn) x_sum = x[0]; else return(0);
+  for (i=1;i<nn;i++) {
+    double dx = x[i]-x[i-1];
 
-    if (dx < -M_PI)
-      dx = dx + TPI;
-    else if (dx > M_PI)
-      dx = dx - TPI;
-    x_sum += (x[i] = x[i - 1] + dx);
+    if      (dx < -M_PI) dx = dx + TPI;
+    else if (dx >  M_PI) dx = dx - TPI;
+    x_sum += (x[i] = x[i-1] + dx);
   }
 
-  dx = (x_sum / nn) - tlon;
-  if (dx < -M_PI)
-    for (i = 0; i < nn; i++)
-      x[i] += TPI;
-  else if (dx > M_PI)
-    for (i = 0; i < nn; i++)
-      x[i] -= TPI;
+  dx = (x_sum/nn)-tlon;
+  if      (dx < -M_PI) for (i=0;i<nn;i++) x[i] += TPI;
+  else if (dx >  M_PI) for (i=0;i<nn;i++) x[i] -= TPI;
 
-  if (pole)
-  {
-    printf("area=%g\n", poly_area(x, y, nn));
+  if (0&&pole) {
+    printf("area=%g\n", poly_area(x, y,nn));
     v_print(x, y, nn);
-    printf("---------<\n");
+    printf("---------");
   }
 
   return (nn);
 } /* fix_lon */
+
 
 /*------------------------------------------------------------------------------
   double great_circle_distance()
@@ -766,39 +580,39 @@ double great_circle_distance(double *p1, double *p2)
   /* This algorithm is not accurate for small distance
   dist = RADIUS*ACOS(SIN(p1[1])*SIN(p2[1]) + COS(p1[1])*COS(p2[1])*COS(p1[0]-p2[0]));
   */
-  beta = 2. * asin(sqrt(sin((p1[1] - p2[1]) / 2.) * sin((p1[1] - p2[1]) / 2.) +
-                        cos(p1[1]) * cos(p2[1]) * (sin((p1[0] - p2[0]) / 2.) * sin((p1[0] - p2[0]) / 2.))));
-  dist = RADIUS * beta;
+  beta = 2.*asin( sqrt( sin((p1[1]-p2[1])/2.)*sin((p1[1]-p2[1])/2.) +
+                               cos(p1[1])*cos(p2[1])*(sin((p1[0]-p2[0])/2.)*sin((p1[0]-p2[0])/2.)) ) );
+  dist = RADIUS*beta;
   return dist;
 
 }; /* great_circle_distance */
 
+
 /* Compute the great circle area of a polygon on a sphere */
-double great_circle_area(int n, const double *x, const double *y, const double *z)
-{
+double great_circle_area(int n, const double *x, const double *y, const double *z) {
   int i;
   double pnt0[3], pnt1[3], pnt2[3];
   double sum, area;
 
   /* sum angles around polygon */
-  sum = 0.0;
-  for (i = 0; i < n; i++)
-  {
+  sum=0.0;
+  for ( i=0; i<n; i++) {
     /* points that make up a side of polygon */
     pnt0[0] = x[i];
     pnt0[1] = y[i];
     pnt0[2] = z[i];
-    pnt1[0] = x[(i + 1) % n];
-    pnt1[1] = y[(i + 1) % n];
-    pnt1[2] = z[(i + 1) % n];
-    pnt2[0] = x[(i + 2) % n];
-    pnt2[1] = y[(i + 2) % n];
-    pnt2[2] = z[(i + 2) % n];
+    pnt1[0] = x[(i+1)%n];
+    pnt1[1] = y[(i+1)%n];
+    pnt1[2] = z[(i+1)%n];
+    pnt2[0] = x[(i+2)%n];
+    pnt2[1] = y[(i+2)%n];
+    pnt2[2] = z[(i+2)%n];
 
     /* compute angle for pnt1 */
     sum += spherical_angle(pnt1, pnt2, pnt0);
+
   }
-  area = (sum - (n - 2.) * M_PI) * RADIUS * RADIUS;
+  area = (sum - (n-2.)*M_PI) * RADIUS* RADIUS;
   return area;
 }
 
@@ -823,34 +637,30 @@ double spherical_angle(const double *v1, const double *v2, const double *v3)
 #endif
 
   /* vector product between v1 and v2 */
-  px = v1[1] * v2[2] - v1[2] * v2[1];
-  py = v1[2] * v2[0] - v1[0] * v2[2];
-  pz = v1[0] * v2[1] - v1[1] * v2[0];
+  px = v1[1]*v2[2] - v1[2]*v2[1];
+  py = v1[2]*v2[0] - v1[0]*v2[2];
+  pz = v1[0]*v2[1] - v1[1]*v2[0];
   /* vector product between v1 and v3 */
-  qx = v1[1] * v3[2] - v1[2] * v3[1];
-  qy = v1[2] * v3[0] - v1[0] * v3[2];
-  qz = v1[0] * v3[1] - v1[1] * v3[0];
+  qx = v1[1]*v3[2] - v1[2]*v3[1];
+  qy = v1[2]*v3[0] - v1[0]*v3[2];
+  qz = v1[0]*v3[1] - v1[1]*v3[0];
 
-  ddd = (px * px + py * py + pz * pz) * (qx * qx + qy * qy + qz * qz);
-  if (ddd <= 0.0)
-    angle = 0.;
-  else
-  {
-    ddd = (px * qx + py * qy + pz * qz) / sqrt(ddd);
-    if (fabs(ddd - 1) < EPSLN30)
-      ddd = 1;
-    if (fabs(ddd + 1) < EPSLN30)
-      ddd = -1;
-    if (ddd > 1. || ddd < -1.)
-    {
+  ddd = (px*px+py*py+pz*pz)*(qx*qx+qy*qy+qz*qz);
+  if ( ddd <= 0.0 )
+    angle = 0. ;
+  else {
+    ddd = (px*qx+py*qy+pz*qz) / sqrt(ddd);
+    if( fabs(ddd-1) < EPSLN30 ) ddd = 1;
+    if( fabs(ddd+1) < EPSLN30 ) ddd = -1;
+    if ( ddd>1. || ddd<-1. ) {
       /*FIX (lmh) to correctly handle co-linear points (angle near pi or 0) */
       if (ddd < 0.)
-        angle = M_PI;
+   angle = M_PI;
       else
-        angle = 0.;
+   angle = 0.;
     }
     else
-      angle = acosl(ddd);
+      angle = acosl( ddd );
   }
 
   return angle;
@@ -862,55 +672,57 @@ double spherical_angle(const double *v1, const double *v2, const double *v3)
   on the sphere. Area is computed as the spherical excess
   [area units are m^2]
   ----------------------------------------------------------------------------*/
-double spherical_excess_area(const double *p_ll, const double *p_ul,
-                             const double *p_lr, const double *p_ur, double radius)
+double spherical_excess_area(const double* p_ll, const double* p_ul,
+              const double* p_lr, const double* p_ur, double radius)
 {
   double area, ang1, ang2, ang3, ang4;
   double v1[3], v2[3], v3[3];
 
   /*   S-W: 1   */
-  latlon2xyz(1, p_ll, p_ll + 1, v1, v1 + 1, v1 + 2);
-  latlon2xyz(1, p_lr, p_lr + 1, v2, v2 + 1, v2 + 2);
-  latlon2xyz(1, p_ul, p_ul + 1, v3, v3 + 1, v3 + 2);
+  latlon2xyz(1, p_ll, p_ll+1, v1, v1+1, v1+2);
+  latlon2xyz(1, p_lr, p_lr+1, v2, v2+1, v2+2);
+  latlon2xyz(1, p_ul, p_ul+1, v3, v3+1, v3+2);
   ang1 = spherical_angle(v1, v2, v3);
 
   /*   S-E: 2   */
-  latlon2xyz(1, p_lr, p_lr + 1, v1, v1 + 1, v1 + 2);
-  latlon2xyz(1, p_ur, p_ur + 1, v2, v2 + 1, v2 + 2);
-  latlon2xyz(1, p_ll, p_ll + 1, v3, v3 + 1, v3 + 2);
+  latlon2xyz(1, p_lr, p_lr+1, v1, v1+1, v1+2);
+  latlon2xyz(1, p_ur, p_ur+1, v2, v2+1, v2+2);
+  latlon2xyz(1, p_ll, p_ll+1, v3, v3+1, v3+2);
   ang2 = spherical_angle(v1, v2, v3);
 
   /*   N-E: 3   */
-  latlon2xyz(1, p_ur, p_ur + 1, v1, v1 + 1, v1 + 2);
-  latlon2xyz(1, p_ul, p_ul + 1, v2, v2 + 1, v2 + 2);
-  latlon2xyz(1, p_lr, p_lr + 1, v3, v3 + 1, v3 + 2);
+  latlon2xyz(1, p_ur, p_ur+1, v1, v1+1, v1+2);
+  latlon2xyz(1, p_ul, p_ul+1, v2, v2+1, v2+2);
+  latlon2xyz(1, p_lr, p_lr+1, v3, v3+1, v3+2);
   ang3 = spherical_angle(v1, v2, v3);
 
   /*   N-W: 4   */
-  latlon2xyz(1, p_ul, p_ul + 1, v1, v1 + 1, v1 + 2);
-  latlon2xyz(1, p_ur, p_ur + 1, v2, v2 + 1, v2 + 2);
-  latlon2xyz(1, p_ll, p_ll + 1, v3, v3 + 1, v3 + 2);
+  latlon2xyz(1, p_ul, p_ul+1, v1, v1+1, v1+2);
+  latlon2xyz(1, p_ur, p_ur+1, v2, v2+1, v2+2);
+  latlon2xyz(1, p_ll, p_ll+1, v3, v3+1, v3+2);
   ang4 = spherical_angle(v1, v2, v3);
 
-  area = (ang1 + ang2 + ang3 + ang4 - 2. * M_PI) * radius * radius;
+  area = (ang1 + ang2 + ang3 + ang4 - 2.*M_PI) * radius* radius;
 
   return area;
 
 }; /* spherical_excess_area */
+
 
 /*----------------------------------------------------------------------
     void vect_cross(e, p1, p2)
     Perform cross products of 3D vectors: e = P1 X P2
     -------------------------------------------------------------------*/
 
-void vect_cross(const double *p1, const double *p2, double *e)
+void vect_cross(const double *p1, const double *p2, double *e )
 {
 
-  e[0] = p1[1] * p2[2] - p1[2] * p2[1];
-  e[1] = p1[2] * p2[0] - p1[0] * p2[2];
-  e[2] = p1[0] * p2[1] - p1[1] * p2[0];
+  e[0] = p1[1]*p2[2] - p1[2]*p2[1];
+  e[1] = p1[2]*p2[0] - p1[0]*p2[2];
+  e[2] = p1[0]*p2[1] - p1[1]*p2[0];
 
 }; /* vect_cross */
+
 
 /*----------------------------------------------------------------------
     double* vect_cross(p1, p2)
@@ -920,13 +732,15 @@ void vect_cross(const double *p1, const double *p2, double *e)
 double dot(const double *p1, const double *p2)
 {
 
-  return (p1[0] * p2[0] + p1[1] * p2[1] + p1[2] * p2[2]);
+  return( p1[0]*p2[0] + p1[1]*p2[1] + p1[2]*p2[2] );
+
 }
 
-double metric(const double *p)
-{
-  return (sqrt(p[0] * p[0] + p[1] * p[1] + p[2] * p[2]));
+
+double metric(const double *p) {
+  return (sqrt(p[0]*p[0] + p[1]*p[1]+p[2]*p[2]) );
 }
+
 
 /* ----------------------------------------------------------------
    make a unit vector
@@ -936,12 +750,12 @@ void normalize_vect(double *e)
   double pdot;
   int k;
 
-  pdot = e[0] * e[0] + e[1] * e[1] + e[2] * e[2];
-  pdot = sqrt(pdot);
+  pdot = e[0]*e[0] + e[1] * e[1] + e[2] * e[2];
+  pdot = sqrt( pdot );
 
-  for (k = 0; k < 3; k++)
-    e[k] /= pdot;
+  for(k=0; k<3; k++) e[k] /= pdot;
 };
+
 
 /*------------------------------------------------------------------
   void unit_vect_latlon(int size, lon, lat, vlon, vlat)
@@ -954,22 +768,22 @@ void unit_vect_latlon(int size, const double *lon, const double *lat, double *vl
   double sin_lon, cos_lon, sin_lat, cos_lat;
   int n;
 
-  for (n = 0; n < size; n++)
-  {
+  for(n=0; n<size; n++) {
     sin_lon = sin(lon[n]);
     cos_lon = cos(lon[n]);
     sin_lat = sin(lat[n]);
     cos_lat = cos(lat[n]);
 
-    vlon[3 * n] = -sin_lon;
-    vlon[3 * n + 1] = cos_lon;
-    vlon[3 * n + 2] = 0.;
+    vlon[3*n] = -sin_lon;
+    vlon[3*n+1] =  cos_lon;
+    vlon[3*n+2] =  0.;
 
-    vlat[3 * n] = -sin_lat * cos_lon;
-    vlat[3 * n + 1] = -sin_lat * sin_lon;
-    vlat[3 * n + 2] = cos_lat;
+    vlat[3*n]   = -sin_lat*cos_lon;
+    vlat[3*n+1] = -sin_lat*sin_lon;
+    vlat[3*n+2] =  cos_lat;
   }
 }; /* unit_vect_latlon */
+
 
 /* Intersect a line and a plane
    Intersects between the plane ( three points ) (entries in counterclockwise order)
@@ -980,84 +794,80 @@ void unit_vect_latlon(int size, const double *lon, const double *lat, double *vl
    NOTE: the intersection doesn't have to be inside the tri or line for this to return true
 */
 int intersect_tri_with_line(const double *plane, const double *l1, const double *l2, double *p,
-                            double *t)
-{
+             double *t) {
 
-  long double M[3 * 3], inv_M[3 * 3];
+  long double M[3*3], inv_M[3*3];
   long double V[3];
   long double X[3];
-  int is_invert = 0;
+  int is_invert=0;
 
-  const double *pnt0 = plane;
-  const double *pnt1 = plane + 3;
-  const double *pnt2 = plane + 6;
+  const double *pnt0=plane;
+  const double *pnt1=plane+3;
+  const double *pnt2=plane+6;
 
   /* To do intersection just solve the set of linear equations for both
      Setup M
   */
-  M[0] = l1[0] - l2[0];
-  M[1] = pnt1[0] - pnt0[0];
-  M[2] = pnt2[0] - pnt0[0];
-  M[3] = l1[1] - l2[1];
-  M[4] = pnt1[1] - pnt0[1];
-  M[5] = pnt2[1] - pnt0[1];
-  M[6] = l1[2] - l2[2];
-  M[7] = pnt1[2] - pnt0[2];
-  M[8] = pnt2[2] - pnt0[2];
+  M[0]=l1[0]-l2[0]; M[1]=pnt1[0]-pnt0[0]; M[2]=pnt2[0]-pnt0[0];
+  M[3]=l1[1]-l2[1]; M[4]=pnt1[1]-pnt0[1]; M[5]=pnt2[1]-pnt0[1];
+  M[6]=l1[2]-l2[2]; M[7]=pnt1[2]-pnt0[2]; M[8]=pnt2[2]-pnt0[2];
+
 
   /* Invert M */
-  is_invert = invert_matrix_3x3(M, inv_M);
-  if (!is_invert)
-    return 0;
+  is_invert = invert_matrix_3x3(M,inv_M);
+  if (!is_invert) return 0;
 
   /* Set variable holding vector */
-  V[0] = l1[0] - pnt0[0];
-  V[1] = l1[1] - pnt0[1];
-  V[2] = l1[2] - pnt0[2];
+  V[0]=l1[0]-pnt0[0];
+  V[1]=l1[1]-pnt0[1];
+  V[2]=l1[2]-pnt0[2];
 
   /* Calculate solution */
   mult(inv_M, V, X);
 
   /* Get answer out */
-  *t = X[0];
-  p[0] = X[1];
-  p[1] = X[2];
+  *t=X[0];
+  p[0]=X[1];
+  p[1]=X[2];
 
   return 1;
 }
 
-void mult(long double m[], long double v[], long double out_v[])
-{
 
-  out_v[0] = m[0] * v[0] + m[1] * v[1] + m[2] * v[2];
-  out_v[1] = m[3] * v[0] + m[4] * v[1] + m[5] * v[2];
-  out_v[2] = m[6] * v[0] + m[7] * v[1] + m[8] * v[2];
+void mult(long double m[], long double v[], long double out_v[]) {
+
+  out_v[0]=m[0]*v[0]+m[1]*v[1]+m[2]*v[2];
+  out_v[1]=m[3]*v[0]+m[4]*v[1]+m[5]*v[2];
+  out_v[2]=m[6]*v[0]+m[7]*v[1]+m[8]*v[2];
+
 }
 
-/* returns 1 if matrix is inverted, 0 otherwise */
-int invert_matrix_3x3(long double m[], long double m_inv[])
-{
 
-  const long double det = m[0] * (m[4] * m[8] - m[5] * m[7]) - m[1] * (m[3] * m[8] - m[5] * m[6]) + m[2] * (m[3] * m[7] - m[4] * m[6]);
+/* returns 1 if matrix is inverted, 0 otherwise */
+int invert_matrix_3x3(long double m[], long double m_inv[]) {
+
+
+  const long double det =  m[0] * (m[4]*m[8] - m[5]*m[7])
+                     -m[1] * (m[3]*m[8] - m[5]*m[6])
+                     +m[2] * (m[3]*m[7] - m[4]*m[6]);
 #ifdef test_invert_matrix_3x3
   printf("det = %Lf\n", det);
 #endif
-  if (fabsl(det) < EPSLN15)
-    return 0;
+  if (fabsl(det) < EPSLN15 ) return 0;
 
-  const long double deti = 1.0 / det;
+  const long double deti = 1.0/det;
 
-  m_inv[0] = (m[4] * m[8] - m[5] * m[7]) * deti;
-  m_inv[1] = (m[2] * m[7] - m[1] * m[8]) * deti;
-  m_inv[2] = (m[1] * m[5] - m[2] * m[4]) * deti;
+  m_inv[0] = (m[4]*m[8] - m[5]*m[7]) * deti;
+  m_inv[1] = (m[2]*m[7] - m[1]*m[8]) * deti;
+  m_inv[2] = (m[1]*m[5] - m[2]*m[4]) * deti;
 
-  m_inv[3] = (m[5] * m[6] - m[3] * m[8]) * deti;
-  m_inv[4] = (m[0] * m[8] - m[2] * m[6]) * deti;
-  m_inv[5] = (m[2] * m[3] - m[0] * m[5]) * deti;
+  m_inv[3] = (m[5]*m[6] - m[3]*m[8]) * deti;
+  m_inv[4] = (m[0]*m[8] - m[2]*m[6]) * deti;
+  m_inv[5] = (m[2]*m[3] - m[0]*m[5]) * deti;
 
-  m_inv[6] = (m[3] * m[7] - m[4] * m[6]) * deti;
-  m_inv[7] = (m[1] * m[6] - m[0] * m[7]) * deti;
-  m_inv[8] = (m[0] * m[4] - m[1] * m[3]) * deti;
+  m_inv[6] = (m[3]*m[7] - m[4]*m[6]) * deti;
+  m_inv[7] = (m[1]*m[6] - m[0]*m[7]) * deti;
+  m_inv[8] = (m[0]*m[4] - m[1]*m[3]) * deti;
 
   return 1;
 }
@@ -1066,82 +876,75 @@ int invert_matrix_3x3(long double m[], long double m_inv[])
 #define MAXNODELIST 100
 #endif
 
-struct Node *nodeList = NULL;
-int curListPos = 0;
+struct Node *nodeList=NULL;
+int curListPos=0;
 
 void rewindList(void)
 {
   int n;
 
   curListPos = 0;
-  if (!nodeList)
-    nodeList = (struct Node *)malloc(MAXNODELIST * sizeof(struct Node));
-  for (n = 0; n < MAXNODELIST; n++)
-    initNode(nodeList + n);
+  if(!nodeList) nodeList = (struct Node *)malloc(MAXNODELIST*sizeof(struct Node));
+  for(n=0; n<MAXNODELIST; n++) initNode(nodeList+n);
+
 }
 
 struct Node *getNext()
 {
-  struct Node *temp = NULL;
+  struct Node *temp=NULL;
   int n;
 
-  if (!nodeList)
-  {
-    nodeList = (struct Node *)malloc(MAXNODELIST * sizeof(struct Node));
-    for (n = 0; n < MAXNODELIST; n++)
-      initNode(nodeList + n);
+  if(!nodeList) {
+    nodeList = (struct Node *)malloc(MAXNODELIST*sizeof(struct Node));
+    for(n=0; n<MAXNODELIST; n++) initNode(nodeList+n);
   }
 
-  temp = nodeList + curListPos;
+  temp = nodeList+curListPos;
   curListPos++;
-  if (curListPos > MAXNODELIST)
-    error_handler("getNext: curListPos >= MAXNODELIST");
+  if(curListPos > MAXNODELIST) error_handler("getNext: curListPos >= MAXNODELIST");
 
   return (temp);
 }
 
+
 void initNode(struct Node *node)
 {
-  node->x = 0;
-  node->y = 0;
-  node->z = 0;
-  node->u = 0;
-  node->intersect = 0;
-  node->inbound = 0;
-  node->isInside = 0;
-  node->Next = NULL;
-  node->initialized = 0;
+    node->x = 0;
+    node->y = 0;
+    node->z = 0;
+    node->u = 0;
+    node->intersect = 0;
+    node->inbound = 0;
+    node->isInside = 0;
+    node->Next = NULL;
+    node->initialized=0;
+
 }
 
 void addEnd(struct Node *list, double x, double y, double z, int intersect, double u, int inbound, int inside)
 {
 
-  struct Node *temp = NULL;
+  struct Node *temp=NULL;
 
-  if (list == NULL)
-    error_handler("addEnd: list is NULL");
+  if(list == NULL) error_handler("addEnd: list is NULL");
 
-  if (list->initialized)
-  {
+  if(list->initialized) {
 
     /* (x,y,z) might already in the list when intersect is true and u=0 or 1 */
+      temp = list;
+      while (temp) {
+        if(samePoint(temp->x, temp->y, temp->z, x, y, z)) return;
+        temp=temp->Next;
+      }
     temp = list;
-    while (temp)
-    {
-      if (samePoint(temp->x, temp->y, temp->z, x, y, z))
-        return;
-      temp = temp->Next;
-    }
-    temp = list;
-    while (temp->Next)
-      temp = temp->Next;
+    while(temp->Next)
+      temp=temp->Next;
 
     /* Append at the end of the list.  */
     temp->Next = getNext();
     temp = temp->Next;
   }
-  else
-  {
+  else {
     temp = list;
   }
 
@@ -1151,59 +954,50 @@ void addEnd(struct Node *list, double x, double y, double z, int intersect, doub
   temp->u = u;
   temp->intersect = intersect;
   temp->inbound = inbound;
-  temp->initialized = 1;
+  temp->initialized=1;
   temp->isInside = inside;
 }
 
 /* return 1 if the point (x,y,z) is added in the list, return 0 if it is already in the list */
 
 int addIntersect(struct Node *list, double x, double y, double z, int intersect, double u1, double u2, int inbound,
-                 int is1, int ie1, int is2, int ie2)
+       int is1, int ie1, int is2, int ie2)
 {
 
   double u1_cur, u2_cur;
-  int i1_cur, i2_cur;
-  struct Node *temp = NULL;
+  int    i1_cur, i2_cur;
+  struct Node *temp=NULL;
 
-  if (list == NULL)
-    error_handler("addEnd: list is NULL");
+  if(list == NULL) error_handler("addEnd: list is NULL");
 
   /* first check to make sure this point is not in the list */
   u1_cur = u1;
   i1_cur = is1;
   u2_cur = u2;
   i2_cur = is2;
-  if (u1_cur == 1)
-  {
+  if(u1_cur == 1) {
     u1_cur = 0;
     i1_cur = ie1;
   }
-  if (u2_cur == 1)
-  {
+  if(u2_cur == 1) {
     u2_cur = 0;
     i2_cur = ie2;
   }
 
-  if (list->initialized)
-  {
+  if(list->initialized) {
     temp = list;
-    while (temp)
-    {
-      if (temp->u == u1_cur && temp->subj_index == i1_cur)
-        return 0;
-      if (temp->u_clip == u2_cur && temp->clip_index == i2_cur)
-        return 0;
-      if (!temp->Next)
-        break;
-      temp = temp->Next;
+    while(temp) {
+      if( temp->u == u1_cur && temp->subj_index == i1_cur) return 0;
+      if( temp->u_clip == u2_cur && temp->clip_index == i2_cur) return 0;
+      if( !temp->Next ) break;
+      temp=temp->Next;
     }
 
     /* Append at the end of the list.  */
     temp->Next = getNext();
     temp = temp->Next;
   }
-  else
-  {
+  else {
     temp = list;
   }
 
@@ -1212,7 +1006,7 @@ int addIntersect(struct Node *list, double x, double y, double z, int intersect,
   temp->z = z;
   temp->intersect = intersect;
   temp->inbound = inbound;
-  temp->initialized = 1;
+  temp->initialized=1;
   temp->isInside = 0;
   temp->u = u1_cur;
   temp->subj_index = i1_cur;
@@ -1222,56 +1016,58 @@ int addIntersect(struct Node *list, double x, double y, double z, int intersect,
   return 1;
 }
 
+
 int length(struct Node *list)
 {
-  struct Node *cur_ptr = NULL;
-  int count = 0;
+   struct Node *cur_ptr=NULL;
+   int count=0;
 
-  cur_ptr = list;
+   cur_ptr=list;
 
-  while (cur_ptr)
-  {
-    if (cur_ptr->initialized == 0)
-      break;
-    cur_ptr = cur_ptr->Next;
-    count++;
-  }
-  return (count);
+   while(cur_ptr)
+   {
+     if(cur_ptr->initialized ==0) break;
+      cur_ptr=cur_ptr->Next;
+      count++;
+   }
+   return(count);
 }
 
 /* two points are the same if there are close enough */
 int samePoint(double x1, double y1, double z1, double x2, double y2, double z2)
 {
-  if (fabs(x1 - x2) > EPSLN10 || fabs(y1 - y2) > EPSLN10 || fabs(z1 - z2) > EPSLN10)
-    return 0;
-  else
-    return 1;
+    if( fabs(x1-x2) > EPSLN10 || fabs(y1-y2) > EPSLN10 || fabs(z1-z2) > EPSLN10 )
+      return 0;
+    else
+      return 1;
 }
+
+
 
 int sameNode(struct Node node1, struct Node node2)
 {
-  if (node1.x == node2.x && node1.y == node2.y && node1.z == node2.z)
+  if( node1.x == node2.x && node1.y == node2.y && node1.z==node2.z )
     return 1;
   else
     return 0;
 }
+
 
 void addNode(struct Node *list, struct Node inNode)
 {
 
   addEnd(list, inNode.x, inNode.y, inNode.z, inNode.intersect, inNode.u, inNode.inbound, inNode.isInside);
+
 }
 
 struct Node *getNode(struct Node *list, struct Node inNode)
 {
-  struct Node *thisNode = NULL;
-  struct Node *temp = NULL;
+  struct Node *thisNode=NULL;
+  struct Node *temp=NULL;
 
   temp = list;
-  while (temp)
-  {
-    if (sameNode(*temp, inNode))
-    {
+  while( temp ) {
+    if( sameNode( *temp, inNode ) ) {
       thisNode = temp;
       temp = NULL;
       break;
@@ -1295,7 +1091,7 @@ void copyNode(struct Node *node_out, struct Node node_in)
   node_out->z = node_in.z;
   node_out->u = node_in.u;
   node_out->intersect = node_in.intersect;
-  node_out->inbound = node_in.inbound;
+  node_out->inbound   = node_in.inbound;
   node_out->Next = NULL;
   node_out->initialized = node_in.initialized;
   node_out->isInside = node_in.isInside;
@@ -1305,17 +1101,13 @@ void printNode(struct Node *list, char *str)
 {
   struct Node *temp;
 
-  if (list == NULL)
-    error_handler("printNode: list is NULL");
-  if (str)
-    printf("  %s \n", str);
+  if(list == NULL) error_handler("printNode: list is NULL");
+  if(str) printf("  %s \n", str);
   temp = list;
-  while (temp)
-  {
-    if (temp->initialized == 0)
-      break;
+  while(temp) {
+    if(temp->initialized ==0) break;
     printf(" (x, y, z, interset, inbound, isInside) = (%19.15f,%19.15f,%19.15f,%d,%d,%d)\n",
-           temp->x, temp->y, temp->z, temp->intersect, temp->inbound, temp->isInside);
+      temp->x, temp->y, temp->z, temp->intersect, temp->inbound, temp->isInside);
     temp = temp->Next;
   }
   printf("\n");
@@ -1324,26 +1116,25 @@ void printNode(struct Node *list, char *str)
 int intersectInList(struct Node *list, double x, double y, double z)
 {
   struct Node *temp;
-  int found = 0;
+  int found=0;
 
   temp = list;
   found = 0;
-  while (temp)
-  {
-    if (temp->x == x && temp->y == y && temp->z == z)
-    {
+  while ( temp ) {
+    if( temp->x == x && temp->y == y && temp->z == z ) {
       found = 1;
       break;
     }
-    temp = temp->Next;
+    temp=temp->Next;
   }
-  if (!found)
-    error_handler("intersectInList: point (x,y,z) is not found in the list");
-  if (temp->intersect == 2)
+  if (!found) error_handler("intersectInList: point (x,y,z) is not found in the list");
+  if( temp->intersect == 2 )
     return 1;
   else
     return 0;
+
 }
+
 
 /* The following insert a intersection after non-intersect point (x2,y2,z2), if the point
    after (x2,y2,z2) is an intersection, if u is greater than the u value of the intersection,
@@ -1352,36 +1143,30 @@ int intersectInList(struct Node *list, double x, double y, double z)
 void insertIntersect(struct Node *list, double x, double y, double z, double u1, double u2, int inbound,
                      double x2, double y2, double z2)
 {
-  struct Node *temp1 = NULL, *temp2 = NULL;
+  struct Node *temp1=NULL, *temp2=NULL;
   struct Node *temp;
   double u_cur;
-  int found = 0;
+  int found=0;
 
   temp1 = list;
   found = 0;
-  while (temp1)
-  {
-    if (temp1->x == x2 && temp1->y == y2 && temp1->z == z2)
-    {
+  while ( temp1 ) {
+    if( temp1->x == x2 && temp1->y == y2 && temp1->z == z2 ) {
       found = 1;
       break;
     }
-    temp1 = temp1->Next;
+    temp1=temp1->Next;
   }
-  if (!found)
-    error_handler("inserAfter: point (x,y,z) is not found in the list");
+  if (!found) error_handler("inserAfter: point (x,y,z) is not found in the list");
 
   /* when u = 0 or u = 1, set the grid point to be the intersection point to solve truncation error isuse */
   u_cur = u1;
-  if (u1 == 1)
-  {
+  if(u1 == 1) {
     u_cur = 0;
     temp1 = temp1->Next;
-    if (!temp1)
-      temp1 = list;
+    if(!temp1) temp1 = list;
   }
-  if (u_cur == 0)
-  {
+  if(u_cur==0) {
     temp1->intersect = 2;
     temp1->isInside = 1;
     temp1->u = u_cur;
@@ -1392,37 +1177,28 @@ void insertIntersect(struct Node *list, double x, double y, double z, double u1,
   }
 
   /* when u2 != 0 and u2 !=1, can decide if one end of the point is outside depending on inbound value */
-  if (u2 != 0 && u2 != 1)
-  {
-    if (inbound == 1)
-    { /* goes outside, then temp1->Next is an outside point */
+  if(u2 != 0 && u2 != 1) {
+    if(inbound == 1) { /* goes outside, then temp1->Next is an outside point */
       /* find the next non-intersect point */
       temp2 = temp1->Next;
-      if (!temp2)
-        temp2 = list;
-      while (temp2->intersect)
-      {
-        temp2 = temp2->Next;
-        if (!temp2)
-          temp2 = list;
+      if(!temp2) temp2 = list;
+      while(temp2->intersect) {
+         temp2=temp2->Next;
+         if(!temp2) temp2 = list;
       }
 
       temp2->isInside = 0;
     }
-    else if (inbound == 2)
-    { /* goes inside, then temp1 is an outside point */
+    else if(inbound ==2) { /* goes inside, then temp1 is an outside point */
       temp1->isInside = 0;
     }
   }
 
   temp2 = temp1->Next;
-  while (temp2)
-  {
-    if (temp2->intersect == 1)
-    {
-      if (temp2->u > u_cur)
-      {
-        break;
+  while ( temp2 ) {
+    if( temp2->intersect == 1 ) {
+      if( temp2->u > u_cur ) {
+   break;
       }
     }
     else
@@ -1443,19 +1219,18 @@ void insertIntersect(struct Node *list, double x, double y, double z, double u1,
   temp->initialized = 1;
   temp1->Next = temp;
   temp->Next = temp2;
+
 }
 
-double gridArea(struct Node *grid)
-{
+double gridArea(struct Node *grid) {
   double x[20], y[20], z[20];
-  struct Node *temp = NULL;
+  struct Node *temp=NULL;
   double area;
   int n;
 
   temp = grid;
   n = 0;
-  while (temp)
-  {
+  while( temp ) {
     x[n] = temp->x;
     y[n] = temp->y;
     z[n] = temp->z;
@@ -1466,15 +1241,17 @@ double gridArea(struct Node *grid)
   area = great_circle_area(n, x, y, z);
 
   return area;
+
 }
 
-int isIntersect(struct Node node)
-{
+int isIntersect(struct Node node) {
 
   return node.intersect;
+
 }
 
-int getInbound(struct Node node)
+
+int getInbound( struct Node node )
 {
   return node.inbound;
 }
@@ -1484,10 +1261,8 @@ struct Node *getLast(struct Node *list)
   struct Node *temp1;
 
   temp1 = list;
-  if (temp1)
-  {
-    while (temp1->Next)
-    {
+  if( temp1 ) {
+    while( temp1->Next ) {
       temp1 = temp1->Next;
     }
   }
@@ -1495,20 +1270,19 @@ struct Node *getLast(struct Node *list)
   return temp1;
 }
 
-int getFirstInbound(struct Node *list, struct Node *nodeOut)
+
+int getFirstInbound( struct Node *list, struct Node *nodeOut)
 {
-  struct Node *temp = NULL;
+  struct Node *temp=NULL;
 
-  temp = list;
+  temp=list;
 
-  while (temp)
-  {
-    if (temp->inbound == 2)
-    {
+  while(temp) {
+    if( temp->inbound == 2 ) {
       copyNode(nodeOut, *temp);
       return 1;
     }
-    temp = temp->Next;
+    temp=temp->Next;
   }
 
   return 0;
@@ -1517,25 +1291,31 @@ int getFirstInbound(struct Node *list, struct Node *nodeOut)
 void getCoordinate(struct Node node, double *x, double *y, double *z)
 {
 
+
   *x = node.x;
   *y = node.y;
   *z = node.z;
+
 }
 
 void getCoordinates(struct Node *node, double *p)
 {
 
+
   p[0] = node->x;
   p[1] = node->y;
   p[2] = node->z;
+
 }
 
 void setCoordinate(struct Node *node, double x, double y, double z)
 {
 
+
   node->x = x;
   node->y = y;
   node->z = z;
+
 }
 
 /* set inbound value for the points in interList that has inbound =0,
@@ -1545,68 +1325,59 @@ void setCoordinate(struct Node *node, double x, double y, double z)
 void setInbound(struct Node *interList, struct Node *list)
 {
 
-  struct Node *temp1 = NULL, *temp = NULL;
-  struct Node *temp1_prev = NULL, *temp1_next = NULL;
+  struct Node *temp1=NULL, *temp=NULL;
+  struct Node *temp1_prev=NULL, *temp1_next=NULL;
   int prev_is_inside, next_is_inside;
 
   /* for each point in interList, search through list to decide the inbound value the interList point */
   /* For each inbound point, the prev node should be outside and the next is inside. */
-  if (length(interList) == 0)
-    return;
+  if(length(interList) == 0) return;
 
   temp = interList;
 
-  while (temp)
-  {
-    if (!temp->inbound)
-    {
+  while(temp) {
+    if( !temp->inbound) {
       /* search in grid1 to find the prev and next point of temp, when prev point is outside and next point is inside
     inbound = 2, else inbound = 1*/
       temp1 = list;
       temp1_prev = NULL;
       temp1_next = NULL;
-      while (temp1)
-      {
-        if (sameNode(*temp1, *temp))
-        {
-          if (!temp1_prev)
-            temp1_prev = getLast(list);
-          temp1_next = temp1->Next;
-          if (!temp1_next)
-            temp1_next = list;
-          break;
-        }
-        temp1_prev = temp1;
-        temp1 = temp1->Next;
+      while(temp1) {
+   if(sameNode(*temp1, *temp)) {
+     if(!temp1_prev) temp1_prev = getLast(list);
+     temp1_next = temp1->Next;
+     if(!temp1_next) temp1_next = list;
+     break;
+   }
+   temp1_prev = temp1;
+   temp1 = temp1->Next;
       }
-      if (!temp1_next)
-        error_handler("Error from create_xgrid.c: temp is not in list1");
-      if (temp1_prev->isInside == 0 && temp1_next->isInside == 1)
-        temp->inbound = 2; /* go inside */
+      if(!temp1_next) error_handler("Error from create_xgrid.c: temp is not in list1");
+      if( temp1_prev->isInside == 0 && temp1_next->isInside == 1)
+   temp->inbound = 2;   /* go inside */
       else
-        temp->inbound = 1;
+   temp->inbound = 1;
     }
-    temp = temp->Next;
+    temp=temp->Next;
   }
 }
 
-int isInside(struct Node *node)
-{
+int isInside(struct Node *node) {
 
-  if (node->isInside == -1)
-    error_handler("Error from mosaic_util.c: node->isInside is not set");
-  return (node->isInside);
+  if(node->isInside == -1) error_handler("Error from mosaic_util.c: node->isInside is not set");
+  return(node->isInside);
+
 }
 
 /*  #define debug_test_create_xgrid */
 
 /* check if node is inside polygon list or not */
-int insidePolygon(struct Node *node, struct Node *list)
+ int insidePolygon( struct Node *node, struct Node *list)
 {
   int i, ip, is_inside;
   double pnt0[3], pnt1[3], pnt2[3];
   double anglesum;
-  struct Node *p1 = NULL, *p2 = NULL;
+  struct Node *p1=NULL, *p2=NULL;
 
   anglesum = 0;
 
@@ -1618,33 +1389,32 @@ int insidePolygon(struct Node *node, struct Node *list)
   p2 = list->Next;
   is_inside = 0;
 
-  while (p1)
-  {
+
+  while(p1) {
     pnt1[0] = p1->x;
     pnt1[1] = p1->y;
     pnt1[2] = p1->z;
     pnt2[0] = p2->x;
     pnt2[1] = p2->y;
     pnt2[2] = p2->z;
-    if (samePoint(pnt0[0], pnt0[1], pnt0[2], pnt1[0], pnt1[1], pnt1[2]))
-      return 1;
+    if(samePoint(pnt0[0], pnt0[1], pnt0[2], pnt1[0], pnt1[1], pnt1[2])) return 1;
     anglesum += spherical_angle(pnt0, pnt2, pnt1);
     p1 = p1->Next;
     p2 = p2->Next;
-    if (p2 == NULL)
-      p2 = list;
+    if(p2==NULL)p2 = list;
   }
 
-  if (fabs(anglesum - 2 * M_PI) < EPSLN8)
+  if( fabs(anglesum - 2*M_PI) < EPSLN8 )
     is_inside = 1;
   else
     is_inside = 0;
 
 #ifdef debug_test_create_xgrid
-  printf("anglesum-2PI is %19.15f, is_inside = %d\n", anglesum - 2 * M_PI, is_inside);
+  printf("anglesum-2PI is %19.15f, is_inside = %d\n", anglesum- 2*M_PI, is_inside);
 #endif
 
   return is_inside;
+
 }
 
 int inside_a_polygon(double *lon1, double *lat1, int *npts, double *lon2, double *lat2)
@@ -1655,32 +1425,27 @@ int inside_a_polygon(double *lon1, double *lat1, int *npts, double *lon2, double
   double min_x2, max_x2, min_y2, max_y2, min_z2, max_z2;
   int isinside, i;
 
-  struct Node *grid1 = NULL, *grid2 = NULL;
+  struct Node *grid1=NULL, *grid2=NULL;
 
   /* first convert to cartesian grid */
   latlon2xyz(*npts, lon2, lat2, x2, y2, z2);
   latlon2xyz(1, lon1, lat1, &x1, &y1, &z1);
 
   max_x2 = maxval_double(*npts, x2);
-  if (x1 >= max_x2 + RANGE_CHECK_CRITERIA)
-    return 0;
+  if(x1 >= max_x2+RANGE_CHECK_CRITERIA) return 0;
   min_x2 = minval_double(*npts, x2);
-  if (min_x2 >= x1 + RANGE_CHECK_CRITERIA)
-    return 0;
+  if(min_x2 >= x1+RANGE_CHECK_CRITERIA) return 0;
 
   max_y2 = maxval_double(*npts, y2);
-  if (y1 >= max_y2 + RANGE_CHECK_CRITERIA)
-    return 0;
+  if(y1 >= max_y2+RANGE_CHECK_CRITERIA) return 0;
   min_y2 = minval_double(*npts, y2);
-  if (min_y2 >= y1 + RANGE_CHECK_CRITERIA)
-    return 0;
+  if(min_y2 >= y1+RANGE_CHECK_CRITERIA) return 0;
 
   max_z2 = maxval_double(*npts, z2);
-  if (z1 >= max_z2 + RANGE_CHECK_CRITERIA)
-    return 0;
+  if(z1 >= max_z2+RANGE_CHECK_CRITERIA) return 0;
   min_z2 = minval_double(*npts, z2);
-  if (min_z2 >= z1 + RANGE_CHECK_CRITERIA)
-    return 0;
+  if(min_z2 >= z1+RANGE_CHECK_CRITERIA) return 0;
+
 
   /* add x2,y2,z2 to a Node */
   rewindList();
@@ -1688,12 +1453,12 @@ int inside_a_polygon(double *lon1, double *lat1, int *npts, double *lon2, double
   grid2 = getNext();
 
   addEnd(grid1, x1, y1, z1, 0, 0, 0, -1);
-  for (i = 0; i < *npts; i++)
-    addEnd(grid2, x2[i], y2[i], z2[i], 0, 0, 0, -1);
+  for(i=0; i<*npts; i++) addEnd(grid2, x2[i], y2[i], z2[i], 0, 0, 0, -1);
 
   isinside = insidePolygon(grid1, grid2);
 
   return isinside;
+
 }
 
 #ifndef __AIX
@@ -1705,5 +1470,6 @@ int inside_a_polygon_(double *lon1, double *lat1, int *npts, double *lon2, doubl
   isinside = inside_a_polygon(lon1, lat1, npts, lon2, lat2);
 
   return isinside;
+
 }
 #endif

--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -32,9 +32,9 @@
 #include <mpi.h>
 #endif
 
-#define R2D (180./M_PI)
-#define HPI (0.5*M_PI)
-#define TPI (2.0*M_PI)
+#define R2D (180. / M_PI)
+#define HPI (0.5 * M_PI)
+#define TPI (2.0 * M_PI)
 #define TOLORENCE (1.e-6)
 #define EPSLN8 (1.e-8)
 #define EPSLN10 (1.e-10)
@@ -44,7 +44,12 @@
     void error_handler(char *str)
     error handler: will print out error message and then abort
 ***********************************************************/
+
+//PolyAreaStrategy fix_lon_strategy = ORIG_LON_FIX; //Needs original_lon_fix or no_lon_fix
+PolyAreaStrategy fix_lon_strategy = NO_LON_FIX; //Needs original_lon_fix or no_lon_fix
+
 int reproduce_siena = 0;
+
 
 void set_reproduce_siena_true(void)
 {
@@ -53,13 +58,22 @@ void set_reproduce_siena_true(void)
 
 void error_handler(const char *msg)
 {
-  fprintf(stderr, "FATAL Error: %s\n", msg );
+  fprintf(stderr, "FATAL Error: %s\n", msg);
 #ifdef use_libMPI
   MPI_Abort(MPI_COMM_WORLD, -1);
 #else
   exit(1);
 #endif
-}; /* error_handler */
+} /* error_handler */
+
+int areApproxEqual(double a, double b, double delta){
+  if(fabs( a - b) <= delta){
+    return 1;
+  }else{
+    return 0;
+  }
+}
+
 
 /*********************************************************************
 
@@ -80,71 +94,84 @@ int nearest_index(double value, const double *array, int ia)
   int index, i;
   int keep_going;
 
-  for(i=1; i<ia; i++){
-    if (array[i] < array[i-1])
+  for (i = 1; i < ia; i++)
+  {
+    if (array[i] < array[i - 1])
       error_handler("nearest_index: array must be monotonically increasing");
   }
-  if (value < array[0] )
+  if (value < array[0])
     index = 0;
-  else if ( value > array[ia-1])
-    index = ia-1;
+  else if (value > array[ia - 1])
+    index = ia - 1;
   else
+  {
+    i = 0;
+    keep_going = 1;
+    while (i < ia && keep_going)
     {
-      i=0;
-      keep_going = 1;
-      while (i < ia && keep_going) {
-   i = i+1;
-   if (value <= array[i]) {
-     index = i;
-     if (array[i]-value > value-array[i-1]) index = i-1;
-     keep_going = 0;
-   }
+      i = i + 1;
+      if (value <= array[i])
+      {
+        index = i;
+        if (array[i] - value > value - array[i - 1])
+          index = i - 1;
+        keep_going = 0;
       }
     }
+  }
   return index;
-
 };
 
 /******************************************************************/
 
-void tokenize(const char * const string, const char *tokens, unsigned int varlen,
-         unsigned int maxvar, char * pstring, unsigned int * const nstr)
+void tokenize(const char *const string, const char *tokens, unsigned int varlen,
+              unsigned int maxvar, char *pstring, unsigned int *const nstr)
 {
   size_t i, j, nvar, len, ntoken;
   int found, n;
 
-  nvar = 0; j = 0;
+  nvar = 0;
+  j = 0;
   len = strlen(string);
   ntoken = strlen(tokens);
   /* here we use the fact that C array [][] is contiguous in memory */
-  if(string[0] == 0)error_handler("Error from tokenize: to-be-parsed string is empty");
+  if (string[0] == 0)
+    error_handler("Error from tokenize: to-be-parsed string is empty");
 
-  for(i = 0; i < len; i ++){
-    if(string[i] != ' ' && string[i] != '\t'){
+  for (i = 0; i < len; i++)
+  {
+    if (string[i] != ' ' && string[i] != '\t')
+    {
       found = 0;
-      for(n=0; n<ntoken; n++) {
-   if(string[i] == tokens[n] ) {
-     found = 1;
-     break;
-   }
+      for (n = 0; n < ntoken; n++)
+      {
+        if (string[i] == tokens[n])
+        {
+          found = 1;
+          break;
+        }
       }
-      if(found) {
-   if( j != 0) { /* remove :: */
-     *(pstring + (nvar++)*varlen + j) = 0;
-     j = 0;
-     if(nvar >= maxvar) error_handler("Error from tokenize: number of variables exceeds limit");
-   }
+      if (found)
+      {
+        if (j != 0)
+        { /* remove :: */
+          *(pstring + (nvar++) * varlen + j) = 0;
+          j = 0;
+          if (nvar >= maxvar)
+            error_handler("Error from tokenize: number of variables exceeds limit");
+        }
       }
-      else {
-        *(pstring + nvar*varlen + j++) = string[i];
-        if(j >= varlen ) error_handler("error from tokenize: variable name length exceeds limit during tokenization");
+      else
+      {
+        *(pstring + nvar * varlen + j++) = string[i];
+        if (j >= varlen)
+          error_handler("error from tokenize: variable name length exceeds limit during tokenization");
       }
     }
   }
-  *(pstring + nvar*varlen + j) = 0;
+  *(pstring + nvar * varlen + j) = 0;
 
   *nstr = ++nvar;
-
 }
 
 /*******************************************************************************
@@ -157,14 +184,15 @@ double maxval_double(int size, const double *data)
   double maxval;
 
   maxval = data[0];
-  for(n=1; n<size; n++){
-    if( data[n] > maxval ) maxval = data[n];
+  for (n = 1; n < size; n++)
+  {
+    if (data[n] > maxval)
+      maxval = data[n];
   }
 
   return maxval;
 
 }; /* maxval_double */
-
 
 /*******************************************************************************
   double minval_double(int size, double *data)
@@ -176,8 +204,10 @@ double minval_double(int size, const double *data)
   double minval;
 
   minval = data[0];
-  for(n=1; n<size; n++){
-    if( data[n] < minval ) minval = data[n];
+  for (n = 1; n < size; n++)
+  {
+    if (data[n] < minval)
+      minval = data[n];
   }
 
   return minval;
@@ -194,13 +224,13 @@ double avgval_double(int size, const double *data)
   double avgval;
 
   avgval = 0;
-  for(n=0; n<size; n++) avgval += data[n];
+  for (n = 0; n < size; n++)
+    avgval += data[n];
   avgval /= size;
 
   return avgval;
 
 }; /* avgval_double */
-
 
 /*******************************************************************************
   void latlon2xyz
@@ -210,9 +240,10 @@ void latlon2xyz(int size, const double *lon, const double *lat, double *x, doubl
 {
   int n;
 
-  for(n=0; n<size; n++) {
-    x[n] = cos(lat[n])*cos(lon[n]);
-    y[n] = cos(lat[n])*sin(lon[n]);
+  for (n = 0; n < size; n++)
+  {
+    x[n] = cos(lat[n]) * cos(lon[n]);
+    y[n] = cos(lat[n]) * sin(lon[n]);
     z[n] = sin(lat[n]);
   }
 
@@ -222,29 +253,31 @@ void latlon2xyz(int size, const double *lon, const double *lat, double *x, doubl
        void xyz2laton(np, p, xs, ys)
    Transfer cartesian coordinates to spherical coordinates
    ----------------------------------------------------------*/
-void xyz2latlon( int np, const double *x, const double *y, const double *z, double *lon, double *lat)
+void xyz2latlon(int np, const double *x, const double *y, const double *z, double *lon, double *lat)
 {
 
   double xx, yy, zz;
   double dist, sinp;
   int i;
 
-  for(i=0; i<np; i++) {
+  for (i = 0; i < np; i++)
+  {
     xx = x[i];
     yy = y[i];
     zz = z[i];
-    dist = sqrt(xx*xx+yy*yy+zz*zz);
+    dist = sqrt(xx * xx + yy * yy + zz * zz);
     xx /= dist;
     yy /= dist;
     zz /= dist;
 
-    if ( fabs(xx)+fabs(yy)  < EPSLN10 )
-       lon[i] = 0;
-     else
-       lon[i] = atan2(yy, xx);
-     lat[i] = asin(zz);
+    if (fabs(xx) + fabs(yy) < EPSLN10)
+      lon[i] = 0;
+    else
+      lon[i] = atan2(yy, xx);
+    lat[i] = asin(zz);
 
-     if ( lon[i] < 0.) lon[i] = 2.*M_PI + lon[i];
+    if (lon[i] < 0.)
+      lon[i] = 2. * M_PI + lon[i];
   }
 
 } /* xyz2latlon */
@@ -255,16 +288,17 @@ void xyz2latlon( int np, const double *x, const double *y, const double *z, doub
   ----------------------------------------------------------------------------*/
 double box_area(double ll_lon, double ll_lat, double ur_lon, double ur_lat)
 {
-  double dx = ur_lon-ll_lon;
+  double dx = ur_lon - ll_lon;
   double area;
 
-  if(dx > M_PI)  dx = dx - 2.0*M_PI;
-  if(dx < -M_PI) dx = dx + 2.0*M_PI;
+  if (dx > M_PI)
+    dx = dx - 2.0 * M_PI;
+  if (dx < -M_PI)
+    dx = dx + 2.0 * M_PI;
 
-  return (dx*(sin(ur_lat)-sin(ll_lat))*RADIUS*RADIUS ) ;
+  return (dx * (sin(ur_lat) - sin(ll_lat)) * RADIUS * RADIUS);
 
 }; /* box_area */
-
 
 /*------------------------------------------------------------------------------
   double poly_area(const x[], const y[], int n)
@@ -276,37 +310,44 @@ double box_area(double ll_lon, double ll_lat, double ur_lon, double ur_lat)
 double poly_area_dimensionless(const double x[], const double y[], int n)
 {
   double area = 0.0;
-  int    i;
+  int i;
 
-  for (i=0;i<n;i++) {
-    int ip = (i+1) % n;
-    double dx = (x[ip]-x[i]);
+  for (i = 0; i < n; i++)
+  {
+    int ip = (i + 1) % n;
+    double dx = (x[ip] - x[i]);
     double lat1, lat2;
     double dy, dat;
 
     lat1 = y[ip];
     lat2 = y[i];
-    if(dx > M_PI)  dx = dx - 2.0*M_PI;
-    if(dx < -M_PI) dx = dx + 2.0*M_PI;
-    if (dx==0.0) continue;
+    if (dx > M_PI)
+      dx = dx - 2.0 * M_PI;
+    if (dx < -M_PI)
+      dx = dx + 2.0 * M_PI;
+    if (dx == 0.0)
+      continue;
 
-    if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
-      area -= dx*sin(0.5*(lat1+lat2));
-    else {
-      if(reproduce_siena) {
-   area += dx*(cos(lat1)-cos(lat2))/(lat1-lat2);
+    if (fabs(lat1 - lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
+      area -= dx * sin(0.5 * (lat1 + lat2));
+    else
+    {
+      if (reproduce_siena)
+      {
+        area += dx * (cos(lat1) - cos(lat2)) / (lat1 - lat2);
       }
-      else {
-   dy = 0.5*(lat1-lat2);
-   dat = sin(dy)/dy;
-   area -= dx*sin(0.5*(lat1+lat2))*dat;
+      else
+      {
+        dy = 0.5 * (lat1 - lat2);
+        dat = sin(dy) / dy;
+        area -= dx * sin(0.5 * (lat1 + lat2)) * dat;
       }
     }
   }
-  if(area < 0)
-    return (-area/(4*M_PI));
+  if (area < 0)
+    return (-area / (4 * M_PI));
   else
-    return (area/(4*M_PI));
+    return (area / (4 * M_PI));
 
 }; /* poly_area */
 
@@ -389,21 +430,45 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
       Ir_thru_pole = Il_thru_pole = pi  
     where Ir_thru_pole is the integral over the segment passing through the pole.
    ----------------------------------------------------------------------------*/
-double poly_area(const double x[], const double y[], int n)
-{
+double poly_area(const double xo[], const double yo[], int n ) {
   double area = 0.0;
-  int    i;
+  double area_se = 0.0;
+  double da = 0;
+  int dflag = 0;
+  int pole = 0;
+  double xr[4]; //rotated lon
+  double yr[4]; //rotated lat
+  double x[4], y[4];
 
-  for (i=0;i<n;i++) {
-    int ip = (i+1) % n;
-    double dx = (x[ip]-x[i]);
+  if(n == 4){
+    for (int i = 0; i<4; i++){
+        x[i] = xo[i];
+        y[i] = yo[i];
+    }
+  }
+
+  //If the code is set to call the origin fix_lon function. then just proceed as normal.
+  //Otherwise we can call various methods to compare.
+  pole = at_pole(x, y, n); 
+   if (pole == 1) { 
+    area_se = se_area(x, y, n);   
+    if (fix_lon_strategy != ORIG_LON_FIX){  
+      rotate_poly(x, y, n, xr, yr);  
+     }
+   }
+  
+  for (int i = 0; i < n; i++){
+    int ip = (i + 1) % n;
+    double dx = (x[ip] - x[i]);
     double lat1, lat2;
     double dy, dat;
 
     lat1 = y[ip];
     lat2 = y[i];
-    if(dx > M_PI)  dx = dx - 2.0*M_PI;
-    if(dx <= -M_PI) dx = dx + 2.0*M_PI;
+    if (dx > M_PI)
+      dx = dx - 2.0 * M_PI;
+    if (dx <= -M_PI)
+      dx = dx + 2.0 * M_PI;
     /*When the path goes through a Pole the line integral cannot be
       approximated by the fomula below. But we can show for these
       special grid cells the contribution of such paths to the area is pi.
@@ -412,160 +477,281 @@ double poly_area(const double x[], const double y[], int n)
       Note in that situation we should extend the if(dx < -M_PI) to if(dx <= -M_PI)
       so the resulting contribution to area is positive.
     */
-    if(fabs(dx+M_PI)< SMALL_VALUE || fabs(dx-M_PI)< SMALL_VALUE){
+    if (fabs(dx + M_PI) < SMALL_VALUE || fabs(dx - M_PI) < SMALL_VALUE){
       area += M_PI;
       continue; //next i
     }
 
-    if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
-      area -= dx*sin(0.5*(lat1+lat2));
-    else {
-      if(reproduce_siena) {
-	area += dx*(cos(lat1)-cos(lat2))/(lat1-lat2);
+    if (fabs(lat1 - lat2) < SMALL_VALUE){ /* cheap area calculation along latitude */
+      da = dx * sin(0.5 * (lat1 + lat2));
+      area -= da;
+    }else{
+      if (reproduce_siena){
+        area += dx * (cos(lat1) - cos(lat2)) / (lat1 - lat2);
       }
-      else {
-	//This expression is a trig identity with the above reproduce_siena case
-	dy = 0.5*(lat1-lat2);
-	dat = sin(dy)/dy;
-	area -= dx*sin(0.5*(lat1+lat2))*dat; 
+      else{
+        //This expression is a trig identity with the above reproduce_siena case
+        dy = 0.5 * (lat1 - lat2);
+        dat = sin(dy) / dy;
+        da = dx * sin(0.5 * (lat1 + lat2)) * dat;
+        area -= da;
       }
     }
   }
-  if(area < 0)
-     return -area*RADIUS*RADIUS;
-  else
-     return area*RADIUS*RADIUS;
+  if (area < 0){
+    area=  -area * RADIUS * RADIUS;
+  }else{
+    area =  area * RADIUS * RADIUS;
+  }
 
-}; /* poly_area */
+  if (pole == 1){
+    printf("poly_area : poly had pole. Poly was:\n");
+    v_print(x, y, n);
+    printf("--------->\n");
+    printf(" strategy se_area area : %d %g %g", fix_lon_strategy , area_se, area);
+  }
+    return area;
+}
 
-double poly_area_no_adjust(const double x[], const double y[], int n)
-{
+double poly_area_no_adjust(const double x[], const double y[], int n){
   double area = 0.0;
-  int    i;
 
-  for (i=0;i<n;i++) {
-    int ip = (i+1) % n;
-    double dx = (x[ip]-x[i]);
+  for (int i = 0; i < n; i++){
+    int ip = (i + 1) % n;
+    double dx = (x[ip] - x[i]);
     double lat1, lat2;
 
     lat1 = y[ip];
     lat2 = y[i];
-    if (dx==0.0) continue;
+    if (dx == 0.0)
+      continue;
 
-    if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
-      area -= dx*sin(0.5*(lat1+lat2));
+    if (fabs(lat1 - lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
+      area -= dx * sin(0.5 * (lat1 + lat2));
     else
-      area += dx*(cos(lat1)-cos(lat2))/(lat1-lat2);
+      area += dx * (cos(lat1) - cos(lat2)) / (lat1 - lat2);
   }
-  if(area < 0)
-     return area*RADIUS*RADIUS;
+  if (area < 0)
+    return -area * RADIUS * RADIUS;
   else
-     return area*RADIUS*RADIUS;
-}; /* poly_area_no_adjust */
+    return area * RADIUS * RADIUS;
+} 
 
-int delete_vtx(double x[], double y[], int n, int n_del)
-{
-  for (;n_del<n-1;n_del++) {
-    x[n_del] = x[n_del+1];
-    y[n_del] = y[n_del+1];
+int delete_vtx(double x[], double y[], int n, int n_del){
+  for (; n_del < n - 1; n_del++){
+    x[n_del] = x[n_del + 1];
+    y[n_del] = y[n_del + 1];
   }
-
-  return (n-1);
-} /* delete_vtx */
+  return (n - 1);
+}
 
 int insert_vtx(double x[], double y[], int n, int n_ins, double lon_in, double lat_in)
 {
-  int i;
-
-  for (i=n-1;i>=n_ins;i--) {
-    x[i+1] = x[i];
-    y[i+1] = y[i];
+  for (int i = n - 1; i >= n_ins; i--){
+    x[i + 1] = x[i];
+    y[i + 1] = y[i];
   }
 
   x[n_ins] = lon_in;
   y[n_ins] = lat_in;
-  return (n+1);
+  return (n + 1);
 } /* insert_vtx */
 
-void v_print(double x[], double y[], int n)
-{
-  int i;
+void v_print(double x[], double y[], int n){
+  for (int i = 0; i < n; i++){
+    printf(" %20g   %20g\n", x[i] * R2D, y[i] * R2D);
+  }
+}
 
-  for (i=0;i<n;i++) printf(" %20g   %20g\n", x[i]*R2D, y[i]*R2D);
-} /* v_print */
+int fix_lon_v2(double x[], double y[], int n){
+  for (int i = 0; i < n; i++){
+    if (y[i] >= HPI - TOLORENCE)
+      {
+        y[i] -= (TOLORENCE * 1.01);
+      }
+    else if (y[i] <= HPI - TOLORENCE)
+      {
+        y[i] += (TOLORENCE * 1.01);
+      }
+  }
+  return n;
+}
+
+int at_pole(const double x[], const double y[], int n)
+{
+  int pole = 0;
+  for (int i = 0; i < n; i++) {
+    if (fabs(y[i]) >= M_PI_2 - TOLORENCE){
+      pole = 1;
+    }
+  }
+  return pole;
+}
+
+double se_area(const double x[], const double y[], const int n){
+  int i;  
+  double area;
+  double v1[3], v2[3], v3[3];
+  double p_ll[2],  p_ul[2], p_lr[2], p_ur[2];
+  double radius = RADIUS;
+
+  i = 3;
+  p_ll[0] = x[i];
+  p_ll[1] = y[i];
+  i = 2;
+  p_ul[0] = x[i];
+  p_ul[1] = y[i];
+  i = 0;
+  p_lr[0] = x[i];
+  p_lr[1] = y[i];
+  i = 1;
+  p_ur[0] = x[i];
+  p_ur[1] = y[i];
+
+  area = spherical_excess_area(p_ll, p_ul, p_lr, p_ur, radius);
+  return area;
+
+}
+
+ /* Rotate 45 degrees bout axis <1,1,1>/sqrt(3) */
+void rotate_point_ra( double rv[]){
+  double m [3][3];
+  double v[3];
+
+  m[0][0] = 0.8047;
+  m[0][1] = -0.31;
+  m[0][2] = 0.5058;
+  m[1][0] =0.5058;
+  m[1][1] = 0.8047;
+  m[1][2] = -0.31;
+  m[2][0] = -0.31;
+  m[2][1] =0.5058;
+  m[2][2] = 0.8047;
+
+  for(int i = 0; i < 3; i++){
+    v[i] = 0.0;
+    for (int j = 0; j<3; j++){
+      v[i] += m[i][j] * rv[j];
+    }
+  }
+  for(int i = 0; i < 3; i++){
+    rv[i] = v[i];
+  }
+}
+
+double rotate_poly(const double x[], const double y[], const int n, double xr[], double yr[]){
+  double area;
+  double sv[2]; //a rotated lat/lon
+  double rv[3]; //rotated xyz point
+  
+  for(int i = 0; i < n; i++){
+    latlon2xyz(1, &x[i], &y[i], &rv[0], &rv[1], &rv[2]);
+    rotate_point_ra(rv);
+    xyz2latlon(1, &rv[0], &rv[1], &rv[2], &sv[0], &sv[1]);
+    xr[i] = sv[0];
+    yr[i] = sv[1];
+  }
+}
 
 int fix_lon(double x[], double y[], int n, double tlon)
+{
+  int  nn = n;
+
+  if(fix_lon_strategy != ORIG_LON_FIX){
+    return nn;
+  }else{
+    nn = fix_lon_pas(x, y, n, tlon, ORIG_LON_FIX );
+    return nn;
+  }
+}
+
+int fix_lon_pas(double x[], double y[], int n, double tlon, PolyAreaStrategy pas)
 {
   double x_sum, dx;
   int i, nn = n, pole = 0;
 
-  for (i=0;i<nn;i++) if (fabs(y[i])>=HPI-TOLORENCE) pole = 1;
-  if (0&&pole) {
-    printf("fixing pole cell\n");
-    v_print(x, y, nn);
-    printf("---------");
+  if(pas != ORIG_LON_FIX){
+    return n;
   }
 
   /* all pole points must be paired */
   /* The reason is poly_area() function needs a contribution equal to the angle (in radians) 
      between the sides that connect to the pole. */
-  for (i=0;i<nn;i++) if (fabs(y[i])>=HPI-TOLORENCE) {
-    int im=(i+nn-1)%nn, ip=(i+1)%nn;
+  for (i = 0; i < nn; i++)
+    if (fabs(y[i]) >= HPI - TOLORENCE) {
+      int im = (i + nn - 1) % nn, ip = (i + 1) % nn;
 
-    if (y[im]==y[i] && y[ip]==y[i]) {
-      nn = delete_vtx(x, y, nn, i);
-      i--;
-    } else if (y[im]!=y[i] && y[ip]!=y[i]) {
-      nn = insert_vtx(x, y, nn, i, x[i], y[i]);
-      i++;
+      if (y[im] == y[i] && y[ip] == y[i]){
+        nn = delete_vtx(x, y, nn, i);
+        i--;
+      }else if (y[im] != y[i] && y[ip] != y[i]){
+        nn = insert_vtx(x, y, nn, i, x[i], y[i]);
+        i++;
+      }
     }
-  }
   /* first of pole pair has longitude of previous vertex */
   /* second of pole pair has longitude of subsequent vertex */
-  for (i=0;i<nn;i++) if (fabs(y[i])>=HPI-TOLORENCE) {
-    int im=(i+nn-1)%nn, ip=(i+1)%nn;
+  for (i = 0; i < nn; i++)
+    if (fabs(y[i]) >= HPI - TOLORENCE)
+    {
+      int im = (i + nn - 1) % nn, ip = (i + 1) % nn;
 
-    if (y[im]!=y[i]) x[i] = x[im];
-    if (y[ip]!=y[i]) x[i] = x[ip];
-  }
+      if (y[im] != y[i])
+        x[i] = x[im];
+      if (y[ip] != y[i])
+        x[i] = x[ip];
+    }
 
   /*If a polygon side passes through a Pole insert twin vertices at the Pole*/
   /*A fix is also directly applied to poly_area to handle this case.*/
-  for (i=0;i<nn;i++) {
-    int im=(i+nn-1)%nn, ip=(i+1)%nn;
-    double dx = x[i]-x[im];
-    if(fabs(dx+M_PI)< SMALL_VALUE || fabs(dx-M_PI)< SMALL_VALUE){
-      double x1=x[im];
-      double x2=x[i];
-      double ypole= HPI;
-      if(y[i]<0.0) ypole = -HPI ;
+  for (i = 0; i < nn; i++)
+  {
+    int im = (i + nn - 1) % nn, ip = (i + 1) % nn;
+    double dx = x[i] - x[im];
+    if (fabs(dx + M_PI) < SMALL_VALUE || fabs(dx - M_PI) < SMALL_VALUE)
+    {
+      double x1 = x[im];
+      double x2 = x[i];
+      double ypole = HPI;
+      if (y[i] < 0.0)
+        ypole = -HPI;
       nn = insert_vtx(x, y, nn, i, x2, ypole);
       nn = insert_vtx(x, y, nn, i, x1, ypole);
       break;
     }
   }
-  if (nn) x_sum = x[0]; else return(0);
-  for (i=1;i<nn;i++) {
-    double dx = x[i]-x[i-1];
+  if (nn)
+    x_sum = x[0];
+  else
+    return (0);
+  for (i = 1; i < nn; i++)
+  {
+    double dx = x[i] - x[i - 1];
 
-    if      (dx < -M_PI) dx = dx + TPI;
-    else if (dx >  M_PI) dx = dx - TPI;
-    x_sum += (x[i] = x[i-1] + dx);
+    if (dx < -M_PI)
+      dx = dx + TPI;
+    else if (dx > M_PI)
+      dx = dx - TPI;
+    x_sum += (x[i] = x[i - 1] + dx);
   }
 
-  dx = (x_sum/nn)-tlon;
-  if      (dx < -M_PI) for (i=0;i<nn;i++) x[i] += TPI;
-  else if (dx >  M_PI) for (i=0;i<nn;i++) x[i] -= TPI;
+  dx = (x_sum / nn) - tlon;
+  if (dx < -M_PI)
+    for (i = 0; i < nn; i++)
+      x[i] += TPI;
+  else if (dx > M_PI)
+    for (i = 0; i < nn; i++)
+      x[i] -= TPI;
 
-  if (0&&pole) {
-    printf("area=%g\n", poly_area(x, y,nn));
+  if (pole)
+  {
+    printf("area=%g\n", poly_area(x, y, nn));
     v_print(x, y, nn);
-    printf("---------");
+    printf("---------<\n");
   }
 
   return (nn);
 } /* fix_lon */
-
 
 /*------------------------------------------------------------------------------
   double great_circle_distance()
@@ -580,39 +766,39 @@ double great_circle_distance(double *p1, double *p2)
   /* This algorithm is not accurate for small distance
   dist = RADIUS*ACOS(SIN(p1[1])*SIN(p2[1]) + COS(p1[1])*COS(p2[1])*COS(p1[0]-p2[0]));
   */
-  beta = 2.*asin( sqrt( sin((p1[1]-p2[1])/2.)*sin((p1[1]-p2[1])/2.) +
-                               cos(p1[1])*cos(p2[1])*(sin((p1[0]-p2[0])/2.)*sin((p1[0]-p2[0])/2.)) ) );
-  dist = RADIUS*beta;
+  beta = 2. * asin(sqrt(sin((p1[1] - p2[1]) / 2.) * sin((p1[1] - p2[1]) / 2.) +
+                        cos(p1[1]) * cos(p2[1]) * (sin((p1[0] - p2[0]) / 2.) * sin((p1[0] - p2[0]) / 2.))));
+  dist = RADIUS * beta;
   return dist;
 
 }; /* great_circle_distance */
 
-
 /* Compute the great circle area of a polygon on a sphere */
-double great_circle_area(int n, const double *x, const double *y, const double *z) {
+double great_circle_area(int n, const double *x, const double *y, const double *z)
+{
   int i;
   double pnt0[3], pnt1[3], pnt2[3];
   double sum, area;
 
   /* sum angles around polygon */
-  sum=0.0;
-  for ( i=0; i<n; i++) {
+  sum = 0.0;
+  for (i = 0; i < n; i++)
+  {
     /* points that make up a side of polygon */
     pnt0[0] = x[i];
     pnt0[1] = y[i];
     pnt0[2] = z[i];
-    pnt1[0] = x[(i+1)%n];
-    pnt1[1] = y[(i+1)%n];
-    pnt1[2] = z[(i+1)%n];
-    pnt2[0] = x[(i+2)%n];
-    pnt2[1] = y[(i+2)%n];
-    pnt2[2] = z[(i+2)%n];
+    pnt1[0] = x[(i + 1) % n];
+    pnt1[1] = y[(i + 1) % n];
+    pnt1[2] = z[(i + 1) % n];
+    pnt2[0] = x[(i + 2) % n];
+    pnt2[1] = y[(i + 2) % n];
+    pnt2[2] = z[(i + 2) % n];
 
     /* compute angle for pnt1 */
     sum += spherical_angle(pnt1, pnt2, pnt0);
-
   }
-  area = (sum - (n-2.)*M_PI) * RADIUS* RADIUS;
+  area = (sum - (n - 2.) * M_PI) * RADIUS * RADIUS;
   return area;
 }
 
@@ -637,30 +823,34 @@ double spherical_angle(const double *v1, const double *v2, const double *v3)
 #endif
 
   /* vector product between v1 and v2 */
-  px = v1[1]*v2[2] - v1[2]*v2[1];
-  py = v1[2]*v2[0] - v1[0]*v2[2];
-  pz = v1[0]*v2[1] - v1[1]*v2[0];
+  px = v1[1] * v2[2] - v1[2] * v2[1];
+  py = v1[2] * v2[0] - v1[0] * v2[2];
+  pz = v1[0] * v2[1] - v1[1] * v2[0];
   /* vector product between v1 and v3 */
-  qx = v1[1]*v3[2] - v1[2]*v3[1];
-  qy = v1[2]*v3[0] - v1[0]*v3[2];
-  qz = v1[0]*v3[1] - v1[1]*v3[0];
+  qx = v1[1] * v3[2] - v1[2] * v3[1];
+  qy = v1[2] * v3[0] - v1[0] * v3[2];
+  qz = v1[0] * v3[1] - v1[1] * v3[0];
 
-  ddd = (px*px+py*py+pz*pz)*(qx*qx+qy*qy+qz*qz);
-  if ( ddd <= 0.0 )
-    angle = 0. ;
-  else {
-    ddd = (px*qx+py*qy+pz*qz) / sqrt(ddd);
-    if( fabs(ddd-1) < EPSLN30 ) ddd = 1;
-    if( fabs(ddd+1) < EPSLN30 ) ddd = -1;
-    if ( ddd>1. || ddd<-1. ) {
+  ddd = (px * px + py * py + pz * pz) * (qx * qx + qy * qy + qz * qz);
+  if (ddd <= 0.0)
+    angle = 0.;
+  else
+  {
+    ddd = (px * qx + py * qy + pz * qz) / sqrt(ddd);
+    if (fabs(ddd - 1) < EPSLN30)
+      ddd = 1;
+    if (fabs(ddd + 1) < EPSLN30)
+      ddd = -1;
+    if (ddd > 1. || ddd < -1.)
+    {
       /*FIX (lmh) to correctly handle co-linear points (angle near pi or 0) */
       if (ddd < 0.)
-   angle = M_PI;
+        angle = M_PI;
       else
-   angle = 0.;
+        angle = 0.;
     }
     else
-      angle = acosl( ddd );
+      angle = acosl(ddd);
   }
 
   return angle;
@@ -672,57 +862,55 @@ double spherical_angle(const double *v1, const double *v2, const double *v3)
   on the sphere. Area is computed as the spherical excess
   [area units are m^2]
   ----------------------------------------------------------------------------*/
-double spherical_excess_area(const double* p_ll, const double* p_ul,
-              const double* p_lr, const double* p_ur, double radius)
+double spherical_excess_area(const double *p_ll, const double *p_ul,
+                             const double *p_lr, const double *p_ur, double radius)
 {
   double area, ang1, ang2, ang3, ang4;
   double v1[3], v2[3], v3[3];
 
   /*   S-W: 1   */
-  latlon2xyz(1, p_ll, p_ll+1, v1, v1+1, v1+2);
-  latlon2xyz(1, p_lr, p_lr+1, v2, v2+1, v2+2);
-  latlon2xyz(1, p_ul, p_ul+1, v3, v3+1, v3+2);
+  latlon2xyz(1, p_ll, p_ll + 1, v1, v1 + 1, v1 + 2);
+  latlon2xyz(1, p_lr, p_lr + 1, v2, v2 + 1, v2 + 2);
+  latlon2xyz(1, p_ul, p_ul + 1, v3, v3 + 1, v3 + 2);
   ang1 = spherical_angle(v1, v2, v3);
 
   /*   S-E: 2   */
-  latlon2xyz(1, p_lr, p_lr+1, v1, v1+1, v1+2);
-  latlon2xyz(1, p_ur, p_ur+1, v2, v2+1, v2+2);
-  latlon2xyz(1, p_ll, p_ll+1, v3, v3+1, v3+2);
+  latlon2xyz(1, p_lr, p_lr + 1, v1, v1 + 1, v1 + 2);
+  latlon2xyz(1, p_ur, p_ur + 1, v2, v2 + 1, v2 + 2);
+  latlon2xyz(1, p_ll, p_ll + 1, v3, v3 + 1, v3 + 2);
   ang2 = spherical_angle(v1, v2, v3);
 
   /*   N-E: 3   */
-  latlon2xyz(1, p_ur, p_ur+1, v1, v1+1, v1+2);
-  latlon2xyz(1, p_ul, p_ul+1, v2, v2+1, v2+2);
-  latlon2xyz(1, p_lr, p_lr+1, v3, v3+1, v3+2);
+  latlon2xyz(1, p_ur, p_ur + 1, v1, v1 + 1, v1 + 2);
+  latlon2xyz(1, p_ul, p_ul + 1, v2, v2 + 1, v2 + 2);
+  latlon2xyz(1, p_lr, p_lr + 1, v3, v3 + 1, v3 + 2);
   ang3 = spherical_angle(v1, v2, v3);
 
   /*   N-W: 4   */
-  latlon2xyz(1, p_ul, p_ul+1, v1, v1+1, v1+2);
-  latlon2xyz(1, p_ur, p_ur+1, v2, v2+1, v2+2);
-  latlon2xyz(1, p_ll, p_ll+1, v3, v3+1, v3+2);
+  latlon2xyz(1, p_ul, p_ul + 1, v1, v1 + 1, v1 + 2);
+  latlon2xyz(1, p_ur, p_ur + 1, v2, v2 + 1, v2 + 2);
+  latlon2xyz(1, p_ll, p_ll + 1, v3, v3 + 1, v3 + 2);
   ang4 = spherical_angle(v1, v2, v3);
 
-  area = (ang1 + ang2 + ang3 + ang4 - 2.*M_PI) * radius* radius;
+  area = (ang1 + ang2 + ang3 + ang4 - 2. * M_PI) * radius * radius;
 
   return area;
 
 }; /* spherical_excess_area */
-
 
 /*----------------------------------------------------------------------
     void vect_cross(e, p1, p2)
     Perform cross products of 3D vectors: e = P1 X P2
     -------------------------------------------------------------------*/
 
-void vect_cross(const double *p1, const double *p2, double *e )
+void vect_cross(const double *p1, const double *p2, double *e)
 {
 
-  e[0] = p1[1]*p2[2] - p1[2]*p2[1];
-  e[1] = p1[2]*p2[0] - p1[0]*p2[2];
-  e[2] = p1[0]*p2[1] - p1[1]*p2[0];
+  e[0] = p1[1] * p2[2] - p1[2] * p2[1];
+  e[1] = p1[2] * p2[0] - p1[0] * p2[2];
+  e[2] = p1[0] * p2[1] - p1[1] * p2[0];
 
 }; /* vect_cross */
-
 
 /*----------------------------------------------------------------------
     double* vect_cross(p1, p2)
@@ -732,15 +920,13 @@ void vect_cross(const double *p1, const double *p2, double *e )
 double dot(const double *p1, const double *p2)
 {
 
-  return( p1[0]*p2[0] + p1[1]*p2[1] + p1[2]*p2[2] );
-
+  return (p1[0] * p2[0] + p1[1] * p2[1] + p1[2] * p2[2]);
 }
 
-
-double metric(const double *p) {
-  return (sqrt(p[0]*p[0] + p[1]*p[1]+p[2]*p[2]) );
+double metric(const double *p)
+{
+  return (sqrt(p[0] * p[0] + p[1] * p[1] + p[2] * p[2]));
 }
-
 
 /* ----------------------------------------------------------------
    make a unit vector
@@ -750,12 +936,12 @@ void normalize_vect(double *e)
   double pdot;
   int k;
 
-  pdot = e[0]*e[0] + e[1] * e[1] + e[2] * e[2];
-  pdot = sqrt( pdot );
+  pdot = e[0] * e[0] + e[1] * e[1] + e[2] * e[2];
+  pdot = sqrt(pdot);
 
-  for(k=0; k<3; k++) e[k] /= pdot;
+  for (k = 0; k < 3; k++)
+    e[k] /= pdot;
 };
-
 
 /*------------------------------------------------------------------
   void unit_vect_latlon(int size, lon, lat, vlon, vlat)
@@ -768,22 +954,22 @@ void unit_vect_latlon(int size, const double *lon, const double *lat, double *vl
   double sin_lon, cos_lon, sin_lat, cos_lat;
   int n;
 
-  for(n=0; n<size; n++) {
+  for (n = 0; n < size; n++)
+  {
     sin_lon = sin(lon[n]);
     cos_lon = cos(lon[n]);
     sin_lat = sin(lat[n]);
     cos_lat = cos(lat[n]);
 
-    vlon[3*n] = -sin_lon;
-    vlon[3*n+1] =  cos_lon;
-    vlon[3*n+2] =  0.;
+    vlon[3 * n] = -sin_lon;
+    vlon[3 * n + 1] = cos_lon;
+    vlon[3 * n + 2] = 0.;
 
-    vlat[3*n]   = -sin_lat*cos_lon;
-    vlat[3*n+1] = -sin_lat*sin_lon;
-    vlat[3*n+2] =  cos_lat;
+    vlat[3 * n] = -sin_lat * cos_lon;
+    vlat[3 * n + 1] = -sin_lat * sin_lon;
+    vlat[3 * n + 2] = cos_lat;
   }
 }; /* unit_vect_latlon */
-
 
 /* Intersect a line and a plane
    Intersects between the plane ( three points ) (entries in counterclockwise order)
@@ -794,80 +980,84 @@ void unit_vect_latlon(int size, const double *lon, const double *lat, double *vl
    NOTE: the intersection doesn't have to be inside the tri or line for this to return true
 */
 int intersect_tri_with_line(const double *plane, const double *l1, const double *l2, double *p,
-             double *t) {
+                            double *t)
+{
 
-  long double M[3*3], inv_M[3*3];
+  long double M[3 * 3], inv_M[3 * 3];
   long double V[3];
   long double X[3];
-  int is_invert=0;
+  int is_invert = 0;
 
-  const double *pnt0=plane;
-  const double *pnt1=plane+3;
-  const double *pnt2=plane+6;
+  const double *pnt0 = plane;
+  const double *pnt1 = plane + 3;
+  const double *pnt2 = plane + 6;
 
   /* To do intersection just solve the set of linear equations for both
      Setup M
   */
-  M[0]=l1[0]-l2[0]; M[1]=pnt1[0]-pnt0[0]; M[2]=pnt2[0]-pnt0[0];
-  M[3]=l1[1]-l2[1]; M[4]=pnt1[1]-pnt0[1]; M[5]=pnt2[1]-pnt0[1];
-  M[6]=l1[2]-l2[2]; M[7]=pnt1[2]-pnt0[2]; M[8]=pnt2[2]-pnt0[2];
-
+  M[0] = l1[0] - l2[0];
+  M[1] = pnt1[0] - pnt0[0];
+  M[2] = pnt2[0] - pnt0[0];
+  M[3] = l1[1] - l2[1];
+  M[4] = pnt1[1] - pnt0[1];
+  M[5] = pnt2[1] - pnt0[1];
+  M[6] = l1[2] - l2[2];
+  M[7] = pnt1[2] - pnt0[2];
+  M[8] = pnt2[2] - pnt0[2];
 
   /* Invert M */
-  is_invert = invert_matrix_3x3(M,inv_M);
-  if (!is_invert) return 0;
+  is_invert = invert_matrix_3x3(M, inv_M);
+  if (!is_invert)
+    return 0;
 
   /* Set variable holding vector */
-  V[0]=l1[0]-pnt0[0];
-  V[1]=l1[1]-pnt0[1];
-  V[2]=l1[2]-pnt0[2];
+  V[0] = l1[0] - pnt0[0];
+  V[1] = l1[1] - pnt0[1];
+  V[2] = l1[2] - pnt0[2];
 
   /* Calculate solution */
   mult(inv_M, V, X);
 
   /* Get answer out */
-  *t=X[0];
-  p[0]=X[1];
-  p[1]=X[2];
+  *t = X[0];
+  p[0] = X[1];
+  p[1] = X[2];
 
   return 1;
 }
 
+void mult(long double m[], long double v[], long double out_v[])
+{
 
-void mult(long double m[], long double v[], long double out_v[]) {
-
-  out_v[0]=m[0]*v[0]+m[1]*v[1]+m[2]*v[2];
-  out_v[1]=m[3]*v[0]+m[4]*v[1]+m[5]*v[2];
-  out_v[2]=m[6]*v[0]+m[7]*v[1]+m[8]*v[2];
-
+  out_v[0] = m[0] * v[0] + m[1] * v[1] + m[2] * v[2];
+  out_v[1] = m[3] * v[0] + m[4] * v[1] + m[5] * v[2];
+  out_v[2] = m[6] * v[0] + m[7] * v[1] + m[8] * v[2];
 }
 
-
 /* returns 1 if matrix is inverted, 0 otherwise */
-int invert_matrix_3x3(long double m[], long double m_inv[]) {
+int invert_matrix_3x3(long double m[], long double m_inv[])
+{
 
-
-  const long double det =  m[0] * (m[4]*m[8] - m[5]*m[7])
-                     -m[1] * (m[3]*m[8] - m[5]*m[6])
-                     +m[2] * (m[3]*m[7] - m[4]*m[6]);
+  const long double det = m[0] * (m[4] * m[8] - m[5] * m[7]) - m[1] * (m[3] * m[8] - m[5] * m[6]) + m[2] * (m[3] * m[7] - m[4] * m[6]);
 #ifdef test_invert_matrix_3x3
   printf("det = %Lf\n", det);
 #endif
-  if (fabsl(det) < EPSLN15 ) return 0;
+  if (fabsl(det) < EPSLN15)
+    return 0;
 
-  const long double deti = 1.0/det;
+  const long double deti = 1.0 / det;
 
-  m_inv[0] = (m[4]*m[8] - m[5]*m[7]) * deti;
-  m_inv[1] = (m[2]*m[7] - m[1]*m[8]) * deti;
-  m_inv[2] = (m[1]*m[5] - m[2]*m[4]) * deti;
+  m_inv[0] = (m[4] * m[8] - m[5] * m[7]) * deti;
+  m_inv[1] = (m[2] * m[7] - m[1] * m[8]) * deti;
+  m_inv[2] = (m[1] * m[5] - m[2] * m[4]) * deti;
 
-  m_inv[3] = (m[5]*m[6] - m[3]*m[8]) * deti;
-  m_inv[4] = (m[0]*m[8] - m[2]*m[6]) * deti;
-  m_inv[5] = (m[2]*m[3] - m[0]*m[5]) * deti;
+  m_inv[3] = (m[5] * m[6] - m[3] * m[8]) * deti;
+  m_inv[4] = (m[0] * m[8] - m[2] * m[6]) * deti;
+  m_inv[5] = (m[2] * m[3] - m[0] * m[5]) * deti;
 
-  m_inv[6] = (m[3]*m[7] - m[4]*m[6]) * deti;
-  m_inv[7] = (m[1]*m[6] - m[0]*m[7]) * deti;
-  m_inv[8] = (m[0]*m[4] - m[1]*m[3]) * deti;
+  m_inv[6] = (m[3] * m[7] - m[4] * m[6]) * deti;
+  m_inv[7] = (m[1] * m[6] - m[0] * m[7]) * deti;
+  m_inv[8] = (m[0] * m[4] - m[1] * m[3]) * deti;
 
   return 1;
 }
@@ -876,75 +1066,82 @@ int invert_matrix_3x3(long double m[], long double m_inv[]) {
 #define MAXNODELIST 100
 #endif
 
-struct Node *nodeList=NULL;
-int curListPos=0;
+struct Node *nodeList = NULL;
+int curListPos = 0;
 
 void rewindList(void)
 {
   int n;
 
   curListPos = 0;
-  if(!nodeList) nodeList = (struct Node *)malloc(MAXNODELIST*sizeof(struct Node));
-  for(n=0; n<MAXNODELIST; n++) initNode(nodeList+n);
-
+  if (!nodeList)
+    nodeList = (struct Node *)malloc(MAXNODELIST * sizeof(struct Node));
+  for (n = 0; n < MAXNODELIST; n++)
+    initNode(nodeList + n);
 }
 
 struct Node *getNext()
 {
-  struct Node *temp=NULL;
+  struct Node *temp = NULL;
   int n;
 
-  if(!nodeList) {
-    nodeList = (struct Node *)malloc(MAXNODELIST*sizeof(struct Node));
-    for(n=0; n<MAXNODELIST; n++) initNode(nodeList+n);
+  if (!nodeList)
+  {
+    nodeList = (struct Node *)malloc(MAXNODELIST * sizeof(struct Node));
+    for (n = 0; n < MAXNODELIST; n++)
+      initNode(nodeList + n);
   }
 
-  temp = nodeList+curListPos;
+  temp = nodeList + curListPos;
   curListPos++;
-  if(curListPos > MAXNODELIST) error_handler("getNext: curListPos >= MAXNODELIST");
+  if (curListPos > MAXNODELIST)
+    error_handler("getNext: curListPos >= MAXNODELIST");
 
   return (temp);
 }
 
-
 void initNode(struct Node *node)
 {
-    node->x = 0;
-    node->y = 0;
-    node->z = 0;
-    node->u = 0;
-    node->intersect = 0;
-    node->inbound = 0;
-    node->isInside = 0;
-    node->Next = NULL;
-    node->initialized=0;
-
+  node->x = 0;
+  node->y = 0;
+  node->z = 0;
+  node->u = 0;
+  node->intersect = 0;
+  node->inbound = 0;
+  node->isInside = 0;
+  node->Next = NULL;
+  node->initialized = 0;
 }
 
 void addEnd(struct Node *list, double x, double y, double z, int intersect, double u, int inbound, int inside)
 {
 
-  struct Node *temp=NULL;
+  struct Node *temp = NULL;
 
-  if(list == NULL) error_handler("addEnd: list is NULL");
+  if (list == NULL)
+    error_handler("addEnd: list is NULL");
 
-  if(list->initialized) {
+  if (list->initialized)
+  {
 
     /* (x,y,z) might already in the list when intersect is true and u=0 or 1 */
-      temp = list;
-      while (temp) {
-        if(samePoint(temp->x, temp->y, temp->z, x, y, z)) return;
-        temp=temp->Next;
-      }
     temp = list;
-    while(temp->Next)
-      temp=temp->Next;
+    while (temp)
+    {
+      if (samePoint(temp->x, temp->y, temp->z, x, y, z))
+        return;
+      temp = temp->Next;
+    }
+    temp = list;
+    while (temp->Next)
+      temp = temp->Next;
 
     /* Append at the end of the list.  */
     temp->Next = getNext();
     temp = temp->Next;
   }
-  else {
+  else
+  {
     temp = list;
   }
 
@@ -954,50 +1151,59 @@ void addEnd(struct Node *list, double x, double y, double z, int intersect, doub
   temp->u = u;
   temp->intersect = intersect;
   temp->inbound = inbound;
-  temp->initialized=1;
+  temp->initialized = 1;
   temp->isInside = inside;
 }
 
 /* return 1 if the point (x,y,z) is added in the list, return 0 if it is already in the list */
 
 int addIntersect(struct Node *list, double x, double y, double z, int intersect, double u1, double u2, int inbound,
-       int is1, int ie1, int is2, int ie2)
+                 int is1, int ie1, int is2, int ie2)
 {
 
   double u1_cur, u2_cur;
-  int    i1_cur, i2_cur;
-  struct Node *temp=NULL;
+  int i1_cur, i2_cur;
+  struct Node *temp = NULL;
 
-  if(list == NULL) error_handler("addEnd: list is NULL");
+  if (list == NULL)
+    error_handler("addEnd: list is NULL");
 
   /* first check to make sure this point is not in the list */
   u1_cur = u1;
   i1_cur = is1;
   u2_cur = u2;
   i2_cur = is2;
-  if(u1_cur == 1) {
+  if (u1_cur == 1)
+  {
     u1_cur = 0;
     i1_cur = ie1;
   }
-  if(u2_cur == 1) {
+  if (u2_cur == 1)
+  {
     u2_cur = 0;
     i2_cur = ie2;
   }
 
-  if(list->initialized) {
+  if (list->initialized)
+  {
     temp = list;
-    while(temp) {
-      if( temp->u == u1_cur && temp->subj_index == i1_cur) return 0;
-      if( temp->u_clip == u2_cur && temp->clip_index == i2_cur) return 0;
-      if( !temp->Next ) break;
-      temp=temp->Next;
+    while (temp)
+    {
+      if (temp->u == u1_cur && temp->subj_index == i1_cur)
+        return 0;
+      if (temp->u_clip == u2_cur && temp->clip_index == i2_cur)
+        return 0;
+      if (!temp->Next)
+        break;
+      temp = temp->Next;
     }
 
     /* Append at the end of the list.  */
     temp->Next = getNext();
     temp = temp->Next;
   }
-  else {
+  else
+  {
     temp = list;
   }
 
@@ -1006,7 +1212,7 @@ int addIntersect(struct Node *list, double x, double y, double z, int intersect,
   temp->z = z;
   temp->intersect = intersect;
   temp->inbound = inbound;
-  temp->initialized=1;
+  temp->initialized = 1;
   temp->isInside = 0;
   temp->u = u1_cur;
   temp->subj_index = i1_cur;
@@ -1016,58 +1222,56 @@ int addIntersect(struct Node *list, double x, double y, double z, int intersect,
   return 1;
 }
 
-
 int length(struct Node *list)
 {
-   struct Node *cur_ptr=NULL;
-   int count=0;
+  struct Node *cur_ptr = NULL;
+  int count = 0;
 
-   cur_ptr=list;
+  cur_ptr = list;
 
-   while(cur_ptr)
-   {
-     if(cur_ptr->initialized ==0) break;
-      cur_ptr=cur_ptr->Next;
-      count++;
-   }
-   return(count);
+  while (cur_ptr)
+  {
+    if (cur_ptr->initialized == 0)
+      break;
+    cur_ptr = cur_ptr->Next;
+    count++;
+  }
+  return (count);
 }
 
 /* two points are the same if there are close enough */
 int samePoint(double x1, double y1, double z1, double x2, double y2, double z2)
 {
-    if( fabs(x1-x2) > EPSLN10 || fabs(y1-y2) > EPSLN10 || fabs(z1-z2) > EPSLN10 )
-      return 0;
-    else
-      return 1;
+  if (fabs(x1 - x2) > EPSLN10 || fabs(y1 - y2) > EPSLN10 || fabs(z1 - z2) > EPSLN10)
+    return 0;
+  else
+    return 1;
 }
-
-
 
 int sameNode(struct Node node1, struct Node node2)
 {
-  if( node1.x == node2.x && node1.y == node2.y && node1.z==node2.z )
+  if (node1.x == node2.x && node1.y == node2.y && node1.z == node2.z)
     return 1;
   else
     return 0;
 }
 
-
 void addNode(struct Node *list, struct Node inNode)
 {
 
   addEnd(list, inNode.x, inNode.y, inNode.z, inNode.intersect, inNode.u, inNode.inbound, inNode.isInside);
-
 }
 
 struct Node *getNode(struct Node *list, struct Node inNode)
 {
-  struct Node *thisNode=NULL;
-  struct Node *temp=NULL;
+  struct Node *thisNode = NULL;
+  struct Node *temp = NULL;
 
   temp = list;
-  while( temp ) {
-    if( sameNode( *temp, inNode ) ) {
+  while (temp)
+  {
+    if (sameNode(*temp, inNode))
+    {
       thisNode = temp;
       temp = NULL;
       break;
@@ -1091,7 +1295,7 @@ void copyNode(struct Node *node_out, struct Node node_in)
   node_out->z = node_in.z;
   node_out->u = node_in.u;
   node_out->intersect = node_in.intersect;
-  node_out->inbound   = node_in.inbound;
+  node_out->inbound = node_in.inbound;
   node_out->Next = NULL;
   node_out->initialized = node_in.initialized;
   node_out->isInside = node_in.isInside;
@@ -1101,13 +1305,17 @@ void printNode(struct Node *list, char *str)
 {
   struct Node *temp;
 
-  if(list == NULL) error_handler("printNode: list is NULL");
-  if(str) printf("  %s \n", str);
+  if (list == NULL)
+    error_handler("printNode: list is NULL");
+  if (str)
+    printf("  %s \n", str);
   temp = list;
-  while(temp) {
-    if(temp->initialized ==0) break;
+  while (temp)
+  {
+    if (temp->initialized == 0)
+      break;
     printf(" (x, y, z, interset, inbound, isInside) = (%19.15f,%19.15f,%19.15f,%d,%d,%d)\n",
-      temp->x, temp->y, temp->z, temp->intersect, temp->inbound, temp->isInside);
+           temp->x, temp->y, temp->z, temp->intersect, temp->inbound, temp->isInside);
     temp = temp->Next;
   }
   printf("\n");
@@ -1116,25 +1324,26 @@ void printNode(struct Node *list, char *str)
 int intersectInList(struct Node *list, double x, double y, double z)
 {
   struct Node *temp;
-  int found=0;
+  int found = 0;
 
   temp = list;
   found = 0;
-  while ( temp ) {
-    if( temp->x == x && temp->y == y && temp->z == z ) {
+  while (temp)
+  {
+    if (temp->x == x && temp->y == y && temp->z == z)
+    {
       found = 1;
       break;
     }
-    temp=temp->Next;
+    temp = temp->Next;
   }
-  if (!found) error_handler("intersectInList: point (x,y,z) is not found in the list");
-  if( temp->intersect == 2 )
+  if (!found)
+    error_handler("intersectInList: point (x,y,z) is not found in the list");
+  if (temp->intersect == 2)
     return 1;
   else
     return 0;
-
 }
-
 
 /* The following insert a intersection after non-intersect point (x2,y2,z2), if the point
    after (x2,y2,z2) is an intersection, if u is greater than the u value of the intersection,
@@ -1143,30 +1352,36 @@ int intersectInList(struct Node *list, double x, double y, double z)
 void insertIntersect(struct Node *list, double x, double y, double z, double u1, double u2, int inbound,
                      double x2, double y2, double z2)
 {
-  struct Node *temp1=NULL, *temp2=NULL;
+  struct Node *temp1 = NULL, *temp2 = NULL;
   struct Node *temp;
   double u_cur;
-  int found=0;
+  int found = 0;
 
   temp1 = list;
   found = 0;
-  while ( temp1 ) {
-    if( temp1->x == x2 && temp1->y == y2 && temp1->z == z2 ) {
+  while (temp1)
+  {
+    if (temp1->x == x2 && temp1->y == y2 && temp1->z == z2)
+    {
       found = 1;
       break;
     }
-    temp1=temp1->Next;
+    temp1 = temp1->Next;
   }
-  if (!found) error_handler("inserAfter: point (x,y,z) is not found in the list");
+  if (!found)
+    error_handler("inserAfter: point (x,y,z) is not found in the list");
 
   /* when u = 0 or u = 1, set the grid point to be the intersection point to solve truncation error isuse */
   u_cur = u1;
-  if(u1 == 1) {
+  if (u1 == 1)
+  {
     u_cur = 0;
     temp1 = temp1->Next;
-    if(!temp1) temp1 = list;
+    if (!temp1)
+      temp1 = list;
   }
-  if(u_cur==0) {
+  if (u_cur == 0)
+  {
     temp1->intersect = 2;
     temp1->isInside = 1;
     temp1->u = u_cur;
@@ -1177,28 +1392,37 @@ void insertIntersect(struct Node *list, double x, double y, double z, double u1,
   }
 
   /* when u2 != 0 and u2 !=1, can decide if one end of the point is outside depending on inbound value */
-  if(u2 != 0 && u2 != 1) {
-    if(inbound == 1) { /* goes outside, then temp1->Next is an outside point */
+  if (u2 != 0 && u2 != 1)
+  {
+    if (inbound == 1)
+    { /* goes outside, then temp1->Next is an outside point */
       /* find the next non-intersect point */
       temp2 = temp1->Next;
-      if(!temp2) temp2 = list;
-      while(temp2->intersect) {
-         temp2=temp2->Next;
-         if(!temp2) temp2 = list;
+      if (!temp2)
+        temp2 = list;
+      while (temp2->intersect)
+      {
+        temp2 = temp2->Next;
+        if (!temp2)
+          temp2 = list;
       }
 
       temp2->isInside = 0;
     }
-    else if(inbound ==2) { /* goes inside, then temp1 is an outside point */
+    else if (inbound == 2)
+    { /* goes inside, then temp1 is an outside point */
       temp1->isInside = 0;
     }
   }
 
   temp2 = temp1->Next;
-  while ( temp2 ) {
-    if( temp2->intersect == 1 ) {
-      if( temp2->u > u_cur ) {
-   break;
+  while (temp2)
+  {
+    if (temp2->intersect == 1)
+    {
+      if (temp2->u > u_cur)
+      {
+        break;
       }
     }
     else
@@ -1219,18 +1443,19 @@ void insertIntersect(struct Node *list, double x, double y, double z, double u1,
   temp->initialized = 1;
   temp1->Next = temp;
   temp->Next = temp2;
-
 }
 
-double gridArea(struct Node *grid) {
+double gridArea(struct Node *grid)
+{
   double x[20], y[20], z[20];
-  struct Node *temp=NULL;
+  struct Node *temp = NULL;
   double area;
   int n;
 
   temp = grid;
   n = 0;
-  while( temp ) {
+  while (temp)
+  {
     x[n] = temp->x;
     y[n] = temp->y;
     z[n] = temp->z;
@@ -1241,17 +1466,15 @@ double gridArea(struct Node *grid) {
   area = great_circle_area(n, x, y, z);
 
   return area;
-
 }
 
-int isIntersect(struct Node node) {
+int isIntersect(struct Node node)
+{
 
   return node.intersect;
-
 }
 
-
-int getInbound( struct Node node )
+int getInbound(struct Node node)
 {
   return node.inbound;
 }
@@ -1261,8 +1484,10 @@ struct Node *getLast(struct Node *list)
   struct Node *temp1;
 
   temp1 = list;
-  if( temp1 ) {
-    while( temp1->Next ) {
+  if (temp1)
+  {
+    while (temp1->Next)
+    {
       temp1 = temp1->Next;
     }
   }
@@ -1270,19 +1495,20 @@ struct Node *getLast(struct Node *list)
   return temp1;
 }
 
-
-int getFirstInbound( struct Node *list, struct Node *nodeOut)
+int getFirstInbound(struct Node *list, struct Node *nodeOut)
 {
-  struct Node *temp=NULL;
+  struct Node *temp = NULL;
 
-  temp=list;
+  temp = list;
 
-  while(temp) {
-    if( temp->inbound == 2 ) {
+  while (temp)
+  {
+    if (temp->inbound == 2)
+    {
       copyNode(nodeOut, *temp);
       return 1;
     }
-    temp=temp->Next;
+    temp = temp->Next;
   }
 
   return 0;
@@ -1291,31 +1517,25 @@ int getFirstInbound( struct Node *list, struct Node *nodeOut)
 void getCoordinate(struct Node node, double *x, double *y, double *z)
 {
 
-
   *x = node.x;
   *y = node.y;
   *z = node.z;
-
 }
 
 void getCoordinates(struct Node *node, double *p)
 {
 
-
   p[0] = node->x;
   p[1] = node->y;
   p[2] = node->z;
-
 }
 
 void setCoordinate(struct Node *node, double x, double y, double z)
 {
 
-
   node->x = x;
   node->y = y;
   node->z = z;
-
 }
 
 /* set inbound value for the points in interList that has inbound =0,
@@ -1325,59 +1545,68 @@ void setCoordinate(struct Node *node, double x, double y, double z)
 void setInbound(struct Node *interList, struct Node *list)
 {
 
-  struct Node *temp1=NULL, *temp=NULL;
-  struct Node *temp1_prev=NULL, *temp1_next=NULL;
+  struct Node *temp1 = NULL, *temp = NULL;
+  struct Node *temp1_prev = NULL, *temp1_next = NULL;
   int prev_is_inside, next_is_inside;
 
   /* for each point in interList, search through list to decide the inbound value the interList point */
   /* For each inbound point, the prev node should be outside and the next is inside. */
-  if(length(interList) == 0) return;
+  if (length(interList) == 0)
+    return;
 
   temp = interList;
 
-  while(temp) {
-    if( !temp->inbound) {
+  while (temp)
+  {
+    if (!temp->inbound)
+    {
       /* search in grid1 to find the prev and next point of temp, when prev point is outside and next point is inside
     inbound = 2, else inbound = 1*/
       temp1 = list;
       temp1_prev = NULL;
       temp1_next = NULL;
-      while(temp1) {
-   if(sameNode(*temp1, *temp)) {
-     if(!temp1_prev) temp1_prev = getLast(list);
-     temp1_next = temp1->Next;
-     if(!temp1_next) temp1_next = list;
-     break;
-   }
-   temp1_prev = temp1;
-   temp1 = temp1->Next;
+      while (temp1)
+      {
+        if (sameNode(*temp1, *temp))
+        {
+          if (!temp1_prev)
+            temp1_prev = getLast(list);
+          temp1_next = temp1->Next;
+          if (!temp1_next)
+            temp1_next = list;
+          break;
+        }
+        temp1_prev = temp1;
+        temp1 = temp1->Next;
       }
-      if(!temp1_next) error_handler("Error from create_xgrid.c: temp is not in list1");
-      if( temp1_prev->isInside == 0 && temp1_next->isInside == 1)
-   temp->inbound = 2;   /* go inside */
+      if (!temp1_next)
+        error_handler("Error from create_xgrid.c: temp is not in list1");
+      if (temp1_prev->isInside == 0 && temp1_next->isInside == 1)
+        temp->inbound = 2; /* go inside */
       else
-   temp->inbound = 1;
+        temp->inbound = 1;
     }
-    temp=temp->Next;
+    temp = temp->Next;
   }
 }
 
-int isInside(struct Node *node) {
+int isInside(struct Node *node)
+{
 
-  if(node->isInside == -1) error_handler("Error from mosaic_util.c: node->isInside is not set");
-  return(node->isInside);
-
+  if (node->isInside == -1)
+    error_handler("Error from mosaic_util.c: node->isInside is not set");
+  return (node->isInside);
 }
 
 /*  #define debug_test_create_xgrid */
 
 /* check if node is inside polygon list or not */
- int insidePolygon( struct Node *node, struct Node *list)
+int insidePolygon(struct Node *node, struct Node *list)
 {
   int i, ip, is_inside;
   double pnt0[3], pnt1[3], pnt2[3];
   double anglesum;
-  struct Node *p1=NULL, *p2=NULL;
+  struct Node *p1 = NULL, *p2 = NULL;
 
   anglesum = 0;
 
@@ -1389,32 +1618,33 @@ int isInside(struct Node *node) {
   p2 = list->Next;
   is_inside = 0;
 
-
-  while(p1) {
+  while (p1)
+  {
     pnt1[0] = p1->x;
     pnt1[1] = p1->y;
     pnt1[2] = p1->z;
     pnt2[0] = p2->x;
     pnt2[1] = p2->y;
     pnt2[2] = p2->z;
-    if(samePoint(pnt0[0], pnt0[1], pnt0[2], pnt1[0], pnt1[1], pnt1[2])) return 1;
+    if (samePoint(pnt0[0], pnt0[1], pnt0[2], pnt1[0], pnt1[1], pnt1[2]))
+      return 1;
     anglesum += spherical_angle(pnt0, pnt2, pnt1);
     p1 = p1->Next;
     p2 = p2->Next;
-    if(p2==NULL)p2 = list;
+    if (p2 == NULL)
+      p2 = list;
   }
 
-  if( fabs(anglesum - 2*M_PI) < EPSLN8 )
+  if (fabs(anglesum - 2 * M_PI) < EPSLN8)
     is_inside = 1;
   else
     is_inside = 0;
 
 #ifdef debug_test_create_xgrid
-  printf("anglesum-2PI is %19.15f, is_inside = %d\n", anglesum- 2*M_PI, is_inside);
+  printf("anglesum-2PI is %19.15f, is_inside = %d\n", anglesum - 2 * M_PI, is_inside);
 #endif
 
   return is_inside;
-
 }
 
 int inside_a_polygon(double *lon1, double *lat1, int *npts, double *lon2, double *lat2)
@@ -1425,27 +1655,32 @@ int inside_a_polygon(double *lon1, double *lat1, int *npts, double *lon2, double
   double min_x2, max_x2, min_y2, max_y2, min_z2, max_z2;
   int isinside, i;
 
-  struct Node *grid1=NULL, *grid2=NULL;
+  struct Node *grid1 = NULL, *grid2 = NULL;
 
   /* first convert to cartesian grid */
   latlon2xyz(*npts, lon2, lat2, x2, y2, z2);
   latlon2xyz(1, lon1, lat1, &x1, &y1, &z1);
 
   max_x2 = maxval_double(*npts, x2);
-  if(x1 >= max_x2+RANGE_CHECK_CRITERIA) return 0;
+  if (x1 >= max_x2 + RANGE_CHECK_CRITERIA)
+    return 0;
   min_x2 = minval_double(*npts, x2);
-  if(min_x2 >= x1+RANGE_CHECK_CRITERIA) return 0;
+  if (min_x2 >= x1 + RANGE_CHECK_CRITERIA)
+    return 0;
 
   max_y2 = maxval_double(*npts, y2);
-  if(y1 >= max_y2+RANGE_CHECK_CRITERIA) return 0;
+  if (y1 >= max_y2 + RANGE_CHECK_CRITERIA)
+    return 0;
   min_y2 = minval_double(*npts, y2);
-  if(min_y2 >= y1+RANGE_CHECK_CRITERIA) return 0;
+  if (min_y2 >= y1 + RANGE_CHECK_CRITERIA)
+    return 0;
 
   max_z2 = maxval_double(*npts, z2);
-  if(z1 >= max_z2+RANGE_CHECK_CRITERIA) return 0;
+  if (z1 >= max_z2 + RANGE_CHECK_CRITERIA)
+    return 0;
   min_z2 = minval_double(*npts, z2);
-  if(min_z2 >= z1+RANGE_CHECK_CRITERIA) return 0;
-
+  if (min_z2 >= z1 + RANGE_CHECK_CRITERIA)
+    return 0;
 
   /* add x2,y2,z2 to a Node */
   rewindList();
@@ -1453,12 +1688,12 @@ int inside_a_polygon(double *lon1, double *lat1, int *npts, double *lon2, double
   grid2 = getNext();
 
   addEnd(grid1, x1, y1, z1, 0, 0, 0, -1);
-  for(i=0; i<*npts; i++) addEnd(grid2, x2[i], y2[i], z2[i], 0, 0, 0, -1);
+  for (i = 0; i < *npts; i++)
+    addEnd(grid2, x2[i], y2[i], z2[i], 0, 0, 0, -1);
 
   isinside = insidePolygon(grid1, grid2);
 
   return isinside;
-
 }
 
 #ifndef __AIX
@@ -1470,6 +1705,5 @@ int inside_a_polygon_(double *lon1, double *lat1, int *npts, double *lon2, doubl
   isinside = inside_a_polygon(lon1, lat1, npts, lon2, lat2);
 
   return isinside;
-
 }
 #endif

--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -32,9 +32,6 @@
 #include <mpi.h>
 #endif
 
-#define R2D (180./M_PI)
-#define HPI (0.5*M_PI)
-#define TPI (2.0*M_PI)
 #define TOLORENCE (1.e-6)
 #define EPSLN8 (1.e-8)
 #define EPSLN10 (1.e-10)

--- a/tools/libfrencutils/mosaic_util.h
+++ b/tools/libfrencutils/mosaic_util.h
@@ -37,8 +37,6 @@
 #define min(a,b) (a<b ? a:b)
 #define max(a,b) (a>b ? a:b)
 #define SMALL_VALUE ( 1.e-10 )
-typedef enum {ORIG_LON_FIX = 1, NO_LON_FIX, ROTATE, SPHERE_EXCESS} PolyAreaStrategy;
-
 struct Node{
   double x, y, z, u, u_clip;
   int intersect; /* indicate if this point is an intersection, 0 = no, 1= yes, 2=both intersect and vertices */
@@ -113,15 +111,7 @@ void getCoordinates(struct Node *node, double *p);
 void setCoordinate(struct Node *node, double x, double y, double z);
 void setInbound(struct Node *interList, struct Node *list);
 int isInside(struct Node *node);
-int areApproxEqual(double a, double b, double delta);
-int at_pole(const double x[], const double y[], int n);
-double se_area(const double x[], const double y[], const int n);
-void rotate_point_ra( double rv[]);
-double rotate_poly(const double x[], const double y[], const int n, 
-  double xr[], double yr[]);
-int lon_fix_pas(double *x, double *y, int n_in, double tlon, PolyAreaStrategy pas); 
 void set_reproduce_siena_true(void);
-
 
 
 #endif

--- a/tools/libfrencutils/mosaic_util.h
+++ b/tools/libfrencutils/mosaic_util.h
@@ -37,6 +37,8 @@
 #define min(a,b) (a<b ? a:b)
 #define max(a,b) (a>b ? a:b)
 #define SMALL_VALUE ( 1.e-10 )
+typedef enum {ORIG_LON_FIX = 1, NO_LON_FIX, ROTATE, SPHERE_EXCESS} PolyAreaStrategy;
+
 struct Node{
   double x, y, z, u, u_clip;
   int intersect; /* indicate if this point is an intersection, 0 = no, 1= yes, 2=both intersect and vertices */
@@ -111,7 +113,15 @@ void getCoordinates(struct Node *node, double *p);
 void setCoordinate(struct Node *node, double x, double y, double z);
 void setInbound(struct Node *interList, struct Node *list);
 int isInside(struct Node *node);
+int areApproxEqual(double a, double b, double delta);
+int at_pole(const double x[], const double y[], int n);
+double se_area(const double x[], const double y[], const int n);
+void rotate_point_ra( double rv[]);
+double rotate_poly(const double x[], const double y[], const int n, 
+  double xr[], double yr[]);
+int lon_fix_pas(double *x, double *y, int n_in, double tlon, PolyAreaStrategy pas); 
 void set_reproduce_siena_true(void);
+
 
 
 #endif

--- a/tools/libfrencutils/mpp.c
+++ b/tools/libfrencutils/mpp.c
@@ -31,11 +31,12 @@
 #endif
 #include "mpp.h"
 
+//These four fields are defined in the file of mpp_domain.c.
+extern int npes, root_pe, pe; 
 
 /****************************************************
          global variables
 *****************************************************/
-int npes, root_pe, pe;
 int *pelist=NULL;
 const int tag = 1;
 #ifdef use_libMPI

--- a/tools/libfrencutils/tool_util.c
+++ b/tools/libfrencutils/tool_util.c
@@ -31,8 +31,7 @@
 #include "interp.h"
 #include "mpp.h"
 #include "mpp_io.h"
-#define  D2R (M_PI/180.)
-#define  R2D (180./M_PI)
+
 
 const double SMALL = 1.0e-4;
 double distant(double a, double b, double met1, double met2);

--- a/tools/make_hgrid/create_conformal_cubic_grid.c
+++ b/tools/make_hgrid/create_conformal_cubic_grid.c
@@ -27,8 +27,7 @@
 #include "tool_util.h"
 #include "constant.h"
 #include "create_hgrid.h"
-#define  D2R (M_PI/180.)
-#define  R2D (180./M_PI)
+
 /*********************************************************************************
    some private routines used in this file
 *********************************************************************************/

--- a/tools/make_hgrid/create_gnomonic_cubic_grid.c
+++ b/tools/make_hgrid/create_gnomonic_cubic_grid.c
@@ -54,8 +54,7 @@
 #include "mosaic_util.h"
 #include "tool_util.h"
 #include "create_hgrid.h"
-#define  D2R (M_PI/180.)
-#define  R2D (180./M_PI)
+
 #define  EPSLN10 (1.e-10)
 #define  EPSLN4 (1.e-4)
 #define  EPSLN5 (1.e-5)

--- a/tools/make_hgrid/create_grid_from_file.c
+++ b/tools/make_hgrid/create_grid_from_file.c
@@ -32,8 +32,6 @@
 #include "mpp_io.h"
 #include "create_hgrid.h"
 #include "gradient_c2l.h" //includes declaration of function mid_pt_sphere()
-#define  D2R (M_PI/180.)
-#define  R2D (180./M_PI)
 
 void create_grid_from_text_file( char *file, int *nlon, int *nlat, double *x, double *y, double *dx, double *dy,
 				 double *area, double *angle_dx );

--- a/tools/make_hgrid/create_lonlat_grid.c
+++ b/tools/make_hgrid/create_lonlat_grid.c
@@ -29,8 +29,7 @@
 #include "constant.h"
 #include "create_hgrid.h"
 #include "create_xgrid.h"
-#define  D2R (M_PI/180.)
-#define  R2D (180./M_PI)
+
 
 /*********************************************************************************
    some private routines used in this file

--- a/tools/make_topog/make_topog.c
+++ b/tools/make_topog/make_topog.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <getopt.h>
 #include <string.h>
+#include "constant.h"
 #include "mpp.h"
 #include "mpp_domain.h"
 #include "mpp_io.h"
@@ -631,7 +632,6 @@ int main(int argc, char* argv[])
   }
 
   {
-    const int STRING = 255;
     int m_fid, g_fid, vid;
     int ntiles, fid, dim_ntiles, n, dims[2];
     size_t start[4], nread[4], nwrite[4];

--- a/tools/make_topog/topog.c
+++ b/tools/make_topog/topog.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+#include "constant.h"
 #include "create_xgrid.h"
 #include "mosaic_util.h"
 #include "interp.h"
@@ -28,7 +29,6 @@
 #include "mpp_domain.h"
 #include "topog.h"
 
-#define D2R (M_PI/180.)
 
 const double deg2metre=111.324e3;
 void filter_topo( int nx, int ny, int num_pass, int smooth_topo_allow_deepening, double *depth, domain2D domain);

--- a/tools/ncexists/ncexists.c
+++ b/tools/ncexists/ncexists.c
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include "getopt.h"
 
 void handle_error(int status);
 

--- a/tools/remap_land/remap_land.c
+++ b/tools/remap_land/remap_land.c
@@ -24,6 +24,8 @@
 #include <math.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <time.h>
+#include <limits.h>
 #include "read_mosaic.h"
 #include "mosaic_util.h"
 #include "tool_util.h"
@@ -51,8 +53,6 @@
 #define  LEVEL_NAME "zfull"
 #define  N_ACCUM_NAME "n_accum"
 #define  NMN_ACM_NAME "nmn_acm"
-#define  D2R (M_PI/180.)
-#define  R2D (180./M_PI)
 #define  FNAME_MAXSIZE 512
 #define  VNAME_MAXSIZE 64
 
@@ -2792,8 +2792,10 @@ int partition(int v[], int v2[], int low, int high){
 
 //random pivot partition
 int partition_rp(int v[], int v2[], int low, int high)
-{
-  srand(time(NULL));
+{  
+  time_t ltime = time(NULL);
+  unsigned int itime = ltime & UINT_MAX;
+  srand(itime);
   int random = low + rand() % (high - low);
   swap_vals(&(v[random]), &(v[high]));
   if(v2 != NULL) {

--- a/tools/river_regrid/river_regrid.c
+++ b/tools/river_regrid/river_regrid.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <math.h>
+#include "constant.h"
 #include "mpp.h"
 #include "mpp_io.h"
 #include "create_xgrid.h"
@@ -90,7 +91,6 @@ const int    x_refine          = 2;
 const int    y_refine          = 2;
 const double EPSLN             = 1.e-4;
 const double MIN_AREA_RATIO    = 1.e-6;
-const double D2R               = M_PI/180.;
 const char   subA_name[]       = "subA";
 const char   tocell_name[]     = "tocell";
 const char   travel_name[]     = "travel";

--- a/tools/runoff_regrid/runoff_regrid.c
+++ b/tools/runoff_regrid/runoff_regrid.c
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <math.h>
+#include "constant.h"
 #include "mpp.h"
 #include "mpp_io.h"
 #include "mpp_domain.h"


### PR DESCRIPTION
This PR includes several types of changes for successfully compiling with some recent c99 compliant compilers. Teach of these compilers forced one or more of the  forced the changes listed below : gcc 11.1,  Intel 2021.5 and Apple clang version 13.0.0  see (issue https://github.com/NOAA-GFDL/FRE-NCtools/issues/143 ) when used with CFLAG -std=c99. We checked resultant code now compiles with or without the -std=c99 flag with these three compilers, and also with gcc 11.2 and gcc 9.3.

I.1). Constant M_PI is defined in file constant.h after a “#define check” to verify its not already defined. This is because M_PI is not defined in standard C. BTW, the check allows default (non-standard or non c99) compilation. 
I.2)  Since numerous .c files had Pi related constants redefined, these were removed from the .c files and also added to the constant.h file.
II)  Include files time.h and unistd.h were added to remap_land.c to avoid the 
 “implicit declaration of function 'time'” errorIII)File is-compressed.c was doing an array access without initializing the array index.
III)Some files needed the inclusion of getopt.h, also to avoid an implicit declaration function error.
IV)Both mpp.c and mpp_domain.c had a definition of npes, root_pe, and pe. This was  at the “global” or file level. The linker step could not complete. Now they are defined only in mpp_domain.c with mpp.c declaring these three variables as external.
I consider this problem IV) particularly troublesome and I don’t quite know how the previous linkers worked with this.
