### PR TITLE
build: add _Generic selection test to autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,8 @@ AS_IF([test ${enable_quad_precision:-no} = no],
 
 AC_PROG_CC([icc gcc])
 AM_PROG_CC_C_O
+## When autoconf v2.70 is more available, this can be replaced with:
+##AC_C__GENERIC
 GX_C__GENERIC
 AS_IF([test $gx_cv_c__Generic = no],
   AC_MSG_ERROR([The C compiler does not support the generic selection C-11 standard.  Please use a C-11 compliant compiler.])

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,10 @@ AS_IF([test ${enable_quad_precision:-no} = no],
 
 AC_PROG_CC([icc gcc])
 AM_PROG_CC_C_O
+GX_C__GENERIC
+AS_IF([test $gx_cv_c__Generic = no],
+  AC_MSG_ERROR([The C compiler does not support the generic selection C-11 standard.  Please use a C-11 compliant compiler.])
+)
 
 AC_PROG_FC([ifort gfortran])
 AC_PROG_FC_C_O

--- a/m4/gx_c__generic.m4
+++ b/m4/gx_c__generic.m4
@@ -1,0 +1,26 @@
+# GX_C__GENERIC
+# -------------
+# Define HAVE_C__GENERIC if _Generic works, a la C11.
+AN_IDENTIFIER([_Generic], [GX_C__GENERIC])
+AC_DEFUN([GX_C__GENERIC],
+[AC_CACHE_CHECK([for _Generic], gx_cv_c__Generic,
+[AC_COMPILE_IFELSE(
+   [AC_LANG_SOURCE(
+      [[int
+         main (int argc, char **argv)
+         {
+           int a = _Generic (argc, int: argc = 1);
+           int *b = &_Generic (argc, default: argc);
+           char ***c = _Generic (argv, int: argc, default: argv ? &argv : 0);
+           _Generic (1 ? 0 : b, int: a, default: b) = &argc;
+           _Generic (a = 1, default: a) = 3;
+           return a + !b + !c;
+         }
+      ]])],
+   [gx_cv_c__Generic=yes],
+   [gx_cv_c__Generic=no])])
+if test $gx_cv_c__Generic = yes; then
+  AC_DEFINE([HAVE_C__GENERIC], 1,
+            [Define to 1 if C11-style _Generic works.])
+fi
+])# GX_C__GENERIC


### PR DESCRIPTION
configure will fail with a note if the C compiler does not support the _Generic selection introduced in C11 - https://en.cppreference.com/w/c/language/generic

Fixes #102