### PR TITLE
Minor changes to remove two newer compiler warnings

### DIFF
--- a/tools/libfrencutils/tool_util.c
+++ b/tools/libfrencutils/tool_util.c
@@ -777,7 +777,7 @@ void get_boundary_type( const char *grid_file, int grid_version, int *cyclic_x, 
   - grid version is written if passed in as not null.
   - gca_flag is the great circle algorithm flag.
   */
-void print_provenance_gv_gca(int fid, char *history, char *grid_version, int gca_flag) {
+void print_provenance_gv_gca(int fid, const char *history, char *grid_version, int gca_flag) {
   char hostname[128];
   gethostname(hostname, 128);
 
@@ -807,11 +807,11 @@ void print_provenance_gv_gca(int fid, char *history, char *grid_version, int gca
   }
 }
 
-void print_provenance_gv(int fid, char * history, char * grid_version){
+void print_provenance_gv(int fid, const char * history, char * grid_version){
   print_provenance_gv_gca(fid, history, grid_version, 0 );
 }
 
-void print_provenance(int fid,  char * history){
+void print_provenance(int fid,  const char * history){
   print_provenance_gv_gca(fid, history, NULL, 0 );
 }
 

--- a/tools/libfrencutils/tool_util.h
+++ b/tools/libfrencutils/tool_util.h
@@ -44,7 +44,7 @@ double* compute_grid_bound_legacy(int nb, const double *bnds, const double *dbnd
 int get_legacy_grid_size(int nb, const double *bnds, const double *dbnds);
 void get_boundary_type( const char *grid_file, int grid_version, int *cyclic_x, int *cyclic_y, int *is_tripolar );
 
-void print_provenance_gv_gca(int fid,  char * history, char * grid_version, int gca_flag);
-void print_provenance_gv(int fid,  char * history, char * grid_version);
-void print_provenance(int fid, char * history);
+void print_provenance_gv_gca(int fid,  const char * history, char * grid_version, int gca_flag);
+void print_provenance_gv(int fid,  const char * history, char * grid_version);
+void print_provenance(int fid, const char * history);
 #endif

--- a/tools/make_coupler_mosaic/make_coupler_mosaic.c
+++ b/tools/make_coupler_mosaic/make_coupler_mosaic.c
@@ -141,8 +141,6 @@ char *usage[] = {
   "",
   NULL };
 
-#define D2R (M_PI/180.)
-#define R2D (180./M_PI)
 #define MAXXGRIDFILE 100
 #define MX 2000
 #define TINY_VALUE (1.e-7)


### PR DESCRIPTION
This PR is for two minor changes to the code to remove new compiler warnings from two recent  code changes. First,  the redefinition of constants R2D and D2R are removed from make_coupler mosaic since they are already defined in the included constant.h file. This change was missed in an earlier merge.
Second, print_provenance_info functions are getting a const qualifier to "char * history" 
argument.  This does not have a functional effect but removed a warning introduced within the 
last year.