### PR TITLE
Suggest target latitudes so that stretched grid would have both NS poles

### DIFF
--- a/tools/make_hgrid/create_gnomonic_cubic_grid.c
+++ b/tools/make_hgrid/create_gnomonic_cubic_grid.c
@@ -388,9 +388,11 @@ void create_gnomonic_cubic_grid( char* grid_type, int *nlon, int *nlat, double *
 
   /* Schmidt transformation */
   if ( do_schmidt ) {
-    /*Search for target latitudes close to the specified one that would allow both North and South poles
-      to be included in the stretched grid. Using such targets could avoid later issues with the exchange grids 
-      such as tiling errors and missing or wrong exchange grid cells.
+    /*In general for a given stretch factor and target latitude the resulting stretch grid will not have the poles as grid points.
+      This may cause issues later with other tools such as exchange grid generator manifested as tiling errors and cells with a wrong land mask.
+      The following call searches for target latitudes close to the specified one that would allow both North and South poles
+      to be grid points in the resulting stretched grid. 
+      Currently this just prints the advisory target latitude values and will not change the grid in any way. It is possible to add an option later to use the adjusted value.  
     */
     suggest_target_lats(stretch_factor, 0, ni, 0, ni, target_lon*D2R, target_lat*D2R, ntiles, xc, yc);
 
@@ -1248,7 +1250,7 @@ void direct_transform(double stretch_factor, int i1, int i2, int j1, int j2, dou
       if ( (1.-fabs(sin_o)) < EPSLN7 ) {    /* poles */
         lon[l] = 0.;
         lat[l] = (sin_o < 0) ? -p2:p2;
-        printf("Generated grid has the pole at %g\n",R2D*lat[l]);
+        printf("Generated grid has a pole at %g\n",R2D*lat[l]);
       }
       else {
         lat[l] = asin( sin_o );
@@ -1266,25 +1268,27 @@ void direct_transform(double stretch_factor, int i1, int i2, int j1, int j2, dou
                          double *lon, double *lat)
   
   This subroutine suggests values for target latitude close to the desired ones
-  so that the stretched grid would include the North pole or the South pole as a point.
+  so that the stretched grid would include the North pole and/or the South pole as grid points.
   
-  South pole is a fixed point of the stretch transformation:
+  South pole is a fixed point of the stretching transformation:
        inter_lat   = asin( (c2m1+c2p1*sin(init_lat))/(c2p1+c2m1*sin(init_lat)) ); 
   After stretching the intermediate grid is rotated so that the South pole
   shifts to the target point of the final stretched grid:
        final_latitude = -asin(sin_p*sin(inetr_lat) + cos_p*cos(inter_lat)*cos(init_lon[l]));    
        final_longitude= lon_p + atan(-cos(inter_lat)*sin(init_lon) / -sin(inter_lat)*cos_p+cos(inter_lat)*sin_p*cos(init_lon));
-  We can optionally restrict the final grid to include the North pole by 
-  slightly adjusting the target latitude. Since the intermediate grid is roateted
-  by 90+lat_p to shift the intemediate South pole to target point, 
-  the intermediate point with (lon,lat)=(180,-lat_p) would rotate to the North pole.
-  So if such a point is in the intermediate grid it would generate the North pole in the final grid.
+  Generally for a given target latitude the final grid will not have the N or S poles (they are not rotated into grid points).  
+  But it is possible to restrict the final grid to include one or both poles by slightly adjusting the target latitude. 
+  In the generating algorithm the intermediate grid is roateted by 90+lat_p, to shift the intemediate South pole to the target point. 
+  Hence the intermediate point with (lon,lat)=(180,-lat_p) would rotate to the North pole and (lon,lat)=(180,180-lat_p) would rotate to the South pole.  
+  So if such points are in the intermediate grid they would generate the N&S poles in the final grid.
   There is no guarantee that (180,-lat_p) with arbitrary lat_p would be in the intermedaite grid.
   But, we can adjust lat_p a little to have the pre-image of the North pole in the intermedaite grid.
   We first find the latitude of the pre-image in the inital grid by inverting the formula for the stretch transformation:
        lam_North_pre=-asin((c2m1-c2p1*sin_p)/(c2p1-c2m1*sin_p))
   Then we find the closest point in the initial grid  with (lon,lat)=(180,lam_North_pre)
   Then we find the target point latitude that would generate the pre-image of North pole in intermediate grid. 
+  A similar formula applies to generate the South pole.
+  To have both poles as grid points an intermediate value for target can be found so that both N&S conditions hold. 
 */    
 void suggest_target_lats(double stretch_factor, int i1, int i2, int j1, int j2, double lon_p, double lat_p, int ntiles,
                          double *lon, double *lat)


### PR DESCRIPTION
In general for a given stretch factor and target latitude the resulting stretch grid will not have the poles as grid points.
This may cause issues later with other tools such as exchange grid generator manifested as tiling errors and cells with a wrong land mask.
- Work related to issue https://github.com/NOAA-GFDL/FMS/issues/621 in FMS repo (wrong repo for that issue)
- Implement the condition for the stretched grid to have both poles as grid points for a give stretch factor.
- This subroutine lists possible target latitudes for a given stretch factor close to the requested target latitude such that the final grid has both poles as grid points.
- Having a grid that includes both poles potentially avoids later issues with exchange grids. After using the suggested values from this update no such issues were found. 

