### PR TITLE
Remove LD_RUN_PATH env var from GFDL site files

### DIFF
--- a/site-configs/gfdl-ws/env.sh
+++ b/site-configs/gfdl-ws/env.sh
@@ -56,6 +56,3 @@ module load mpich/$mpi_version
 
 # Set CONFIG_SITE to the correct config.site file for the system
 setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site
-
-# Include the netcdf-c/netcdf-fortran library paths during linking
-setenv LD_RUN_PATH \$LD_LIBRARY_PATH

--- a/site-configs/gfdl/env.sh
+++ b/site-configs/gfdl/env.sh
@@ -59,6 +59,3 @@ module load mpich/$mpi_version
 
 # Set CONFIG_SITE to the correct config.site file for the system
 setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site
-
-# Include the netcdf-c/netcdf-fortran library paths during linking
-setenv LD_RUN_PATH \$LD_LIBRARY_PATH

--- a/site-configs/ncrc/env.sh
+++ b/site-configs/ncrc/env.sh
@@ -54,6 +54,3 @@ setenv NC_BLKSZ 64K
 
 # Set CONFIG_SITE to the correct config.site file for the system
 setenv CONFIG_SITE $( dirname $(readlink -f $0) )/config.site
-
-# Include the netcdf-c/netcdf-fortran library paths during linking
-setenv LD_RUN_PATH \$LD_LIBRARY_PATH


### PR DESCRIPTION
With the Intel compiler, this was used to include
the netcdf-c and netcdf-fortran library paths during linking.
This does not work for the GCC compiler, so should be removed
in case it has unintended consequences.

#87