### PR TITLE
Turn off ocean-model-grid-generator subtool for GFDL PPAN site

### DIFF
--- a/site-configs/gfdl/config.site
+++ b/site-configs/gfdl/config.site
@@ -21,7 +21,8 @@
 #
 # configure options
 test -z "$with_mpi" && with_mpi=yes
-test -z "$enable_venv" && enable_venv=yes
+test -z "$enable_ocean_model_grid_generator" && enable_ocean_model_grid_generator=no
+test -z "$enable_venv" && enable_venv=no
 # Standard prefix location for FRE distribution
 test "$prefix" = NONE && prefix=/home/fms/local/opt/fre-nctools/${PACKAGE_VERSION}/gfdl
 


### PR DESCRIPTION
PP/AN does not have open Internet access needed for virtual envcreating and testing.

Related to GFDL site file adjustments for 2022.01 (#99 )