### PR TITLE
Updates for deploying updates for GFDL sites

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,9 +7,11 @@ before_script:
 
 variables:
   buildDir: build.${FRE_SITE}.${CI_COMMIT_REF_SLUG}
+  GIT_STRATEGY: clone
+  GIT_SUBMODULE_STRATEGY: recursive
 .buildScript: &buildScript
   script:
-    - if [[ -n ${CI_COMMIT_TAG} ]]; then installLabel=CI_COMMIT_TAG; else installLabel=$CI_COMMIT_BRANCH; fi
+    - if [[ -n ${CI_COMMIT_TAG} ]]; then installLabel=${CI_COMMIT_TAG}; else installLabel=${CI_COMMIT_BRANCH}; fi
     - eval `${CI_PROJECT_DIR}/site-configs/${FRE_SITE}/env.sh`
     - autoreconf -i
     - mkdir ${buildDir}
@@ -35,8 +37,6 @@ build:gfdl-ws:
   tags:
     - gfdl-ws
   variables:
-    GIT_STRATEGY: clone
-    GIT_SUBMODULE_STRATEGY: recursive
     FRE_SITE: gfdl-ws
     FMS_HOME: /home/fms
   <<: *buildScript
@@ -46,8 +46,6 @@ build:gfdl:
   tags:
     - gfdl
   variables:
-    GIT_STRATEGY: clone
-    GIT_SUBMODULE_STRATEGY: recursive
     FRE_SITE: gfdl
     FMS_HOME: /home/fms
   <<: *buildScript
@@ -57,8 +55,6 @@ build:ncrc:
   tags:
     - ncrc
   variables:
-    GIT_STRATEGY: clone
-    GIT_SUBMODULE_STRATEGY: recursive
     FRE_SITE: ncrc
     FMS_HOME: /ncrc/home2/fms
     SKIP_MPI_TEST: 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,11 +9,12 @@ variables:
   buildDir: build.${FRE_SITE}.${CI_COMMIT_REF_SLUG}
 .buildScript: &buildScript
   script:
+    - if [[ -n ${CI_COMMIT_TAG} ]]; then installLabel=CI_COMMIT_TAG; else installLabel=$CI_COMMIT_BRANCH; fi
     - eval `${CI_PROJECT_DIR}/site-configs/${FRE_SITE}/env.sh`
     - autoreconf -i
     - mkdir ${buildDir}
     - cd ${buildDir}
-    - ../configure --prefix=${FMS_HOME}/local/opt/fre-nctools/test/${FRE_SITE}
+    - ../configure --prefix=${FMS_HOME}/local/opt/fre-nctools/${installLabel}/${FRE_SITE}
     - make
     - make -j check
   artifacts:
@@ -60,6 +61,7 @@ build:ncrc:
     GIT_SUBMODULE_STRATEGY: recursive
     FRE_SITE: ncrc
     FMS_HOME: /ncrc/home2/fms
+    SKIP_MPI_TEST: 1
   <<: *buildScript
 
 deploy:gfdl-ws:
@@ -73,6 +75,7 @@ deploy:gfdl-ws:
     FMS_HOME: /home/fms
   only:
     - master
+    - tags
   dependencies:
     - build:gfdl-ws
   <<: *deployScript
@@ -88,6 +91,7 @@ deploy:gfdl:
     FMS_HOME: /home/fms
   only:
     - master
+    - tags
   dependencies:
     - build:gfdl
   <<: *deployScript
@@ -103,6 +107,7 @@ deploy:ncrc:
     FMS_HOME: /ncrc/home2/fms
   only:
     - master
+    - tags
   dependencies:
     - build:ncrc
   <<: *deployScript


### PR DESCRIPTION
1. Deploy for master branch or tags
2. Deploy location includes tag name if it exists, branch name otherwise
3. Do not test parallel updates on gaea login nodes as mpirun is not allowed

Related to GFDL site config files for release 2022.01 (#99)