### PR TITLE
Suggest target latitudes so that stretched grid would have both NS poles

### DIFF
--- a/tools/make_hgrid/create_gnomonic_cubic_grid.c
+++ b/tools/make_hgrid/create_gnomonic_cubic_grid.c
@@ -54,8 +54,6 @@
 #include "mosaic_util.h"
 #include "tool_util.h"
 #include "create_hgrid.h"
-#define  D2R (M_PI/180.)
-#define  R2D (180./M_PI)
 #define  EPSLN10 (1.e-10)
 #define  EPSLN4 (1.e-4)
 #define  EPSLN5 (1.e-5)


### PR DESCRIPTION
- Implement the condition for the stretched grid to have both poles as grid
  points for a give stretch factor.
- This subroutine lists possible target latitudes for a given stretch factor
  close to the requested target latitude such that the final grid has both
  poles as grid points.
- Having a grid that includes both poles potentially avoids later issues with
  exchange grids.
- CI tests pass