### PR TITLE
Remove shared global vars npes, pe, root_pe

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,22 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/opt/homebrew/Cellar/netcdf/4.9.0/include"
+            ],
+            "defines": [
+                
+            ],
+            "macFrameworkPath": [
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "macos-clang-arm64"
+        }
+    ],
+    "version": 4
+}

--- a/tools/libfrencutils/mpp.c
+++ b/tools/libfrencutils/mpp.c
@@ -32,7 +32,7 @@
 #include "mpp.h"
 
 //These four fields are defined in the file of mpp_domain.c.
-extern int npes, root_pe, pe; 
+static int npes, root_pe, pe; 
 
 /****************************************************
          global variables

--- a/tools/libfrencutils/mpp_domain.c
+++ b/tools/libfrencutils/mpp_domain.c
@@ -32,7 +32,7 @@
 /***********************************************************
    global variables
 ***********************************************************/
-int pe, npes, root_pe;
+static int pe, npes, root_pe;
 #define MAX_BUFFER_SIZE 10000000
 double rBuffer[MAX_BUFFER_SIZE];
 double sBuffer[MAX_BUFFER_SIZE];
@@ -823,9 +823,7 @@ void mpp_gather_field_double_root(int lsize, double *ldata, double *gdata)
   /* all other pe except root pe will send data to root pe */
   if( pe != root_pe) {
       mpp_send_int(&lsize, 1, root_pe);
-  }
-
-  else {
+  } else {
     for(p = 0; p<npes; p++) {
        if(root_pe != p) mpp_recv_int(rsize+p, 1, p);
     }
@@ -835,26 +833,24 @@ void mpp_gather_field_double_root(int lsize, double *ldata, double *gdata)
 
   if( pe != root_pe) {
       if(lsize>0) mpp_send_double(ldata, lsize, root_pe);
-  }  
-  else {
+  } else {
     int cur_size;
     n = 0;
     cur_size = 0;
     /* receive from other pe and fill the gdata */
     for(p = 0; p<npes; p++) {
       if(root_pe != p) { /* recv from other pe. */
-	if(rsize[p]>0) {
-	  if( rsize[p] > cur_size ) {
-	    if( rbuffer ) free(rbuffer);
-	    rbuffer = ( double *) malloc(rsize[p]*sizeof(double));
-	    cur_size = rsize[p];
-	  }
-	  mpp_recv_double(rbuffer, rsize[p], p );
-	  for(i=0; i<rsize[p]; i++) gdata[n++] = rbuffer[i];
-	}
-      }
-      else {
-	for(i=0; i<lsize; i++) gdata[n++] = ldata[i];
+	      if(rsize[p]>0) {
+	        if( rsize[p] > cur_size ) {
+	          if( rbuffer ) free(rbuffer);
+	          rbuffer = ( double *) malloc(rsize[p]*sizeof(double));
+	          cur_size = rsize[p];
+	        }
+	        mpp_recv_double(rbuffer, rsize[p], p );
+	        for(i=0; i<rsize[p]; i++) gdata[n++] = rbuffer[i];
+	      }
+      } else {
+	      for(i=0; i<lsize; i++) gdata[n++] = ldata[i];
       }
     }
     if(rbuffer) free(rbuffer);
@@ -862,7 +858,6 @@ void mpp_gather_field_double_root(int lsize, double *ldata, double *gdata)
 
   mpp_sync_self();
   free(rsize);
-  
 }; /* mpp_gather_field_double_root */
 
 

--- a/tools/make_hgrid/make_hgrid.c
+++ b/tools/make_hgrid/make_hgrid.c
@@ -1089,7 +1089,7 @@ int main(int argc, char* argv[])
     }
     }
 
-    if (verbose) fprintf(stderr, "[INFO] Allocating arrays of size %d for x, y based on nxp: %d nyp: %d ntiles: %d\n", size1, nxp, nyp, ntiles);
+    if (verbose) fprintf(stderr, "[INFO] Allocating arrays of size %lu for x, y based on nxp: %d nyp: %d ntiles: %d\n", size1, nxp, nyp, ntiles);
     x        = (double *) malloc(size1*sizeof(double));
     y        = (double *) malloc(size1*sizeof(double));
     area     = (double *) malloc(size4*sizeof(double));
@@ -1248,7 +1248,7 @@ int main(int argc, char* argv[])
 
       if(out_halo ==0) {
         if (verbose) {
-          fprintf(stderr, "[INFO] START NC XARRAY write out_halo=0 tile number = n: %d offset = pos_c: %d\n", n, pos_c);
+          fprintf(stderr, "[INFO] START NC XARRAY write out_halo=0 tile number = n: %d offset = pos_c: %ld\n", n, pos_c);
           fprintf(stderr, "[INFO] XARRAY: n: %d x[0]: %f x[1]: %f x[2]: %f x[3]: %f x[4]: %f x[5]: %f x[10]: %f\n",
                   n, x[pos_c], x[pos_c+1], x[pos_c+2], x[pos_c+3], x[pos_c+4], x[pos_c+5], x[pos_c+10]);
           if (n > 0) fprintf(stderr, "[INFO] XARRAY: n: %d x[0]: %f x[-1]: %f x[-2]: %f x[-3]: %f x[-4]: %f x[-5]: %f x[-10]: %f\n",
@@ -1309,9 +1309,9 @@ int main(int argc, char* argv[])
       nxp = nx + 1;
       nyp = ny + 1;
 
-      if (verbose) fprintf(stderr, "[INFO] INDEX Before increment n: %d pos_c %d nxp %d nyp %d nxp*nyp %d\n", n, pos_c, nxp, nyp, nxp*nyp);
+      if (verbose) fprintf(stderr, "[INFO] INDEX Before increment n: %d pos_c %ld nxp %d nyp %d nxp*nyp %d\n", n, pos_c, nxp, nyp, nxp*nyp);
       pos_c += nxp*nyp;
-      if (verbose) fprintf(stderr, "[INFO] INDEX After increment n: %d pos_c %d.\n", n, pos_c);
+      if (verbose) fprintf(stderr, "[INFO] INDEX After increment n: %d pos_c %ld.\n", n, pos_c);
       pos_e += nxp*ny;
       pos_n += nx*nyp;
       pos_t += nx*ny;

--- a/tools/remap_land/remap_land.c
+++ b/tools/remap_land/remap_land.c
@@ -180,9 +180,9 @@ void search_nearest_sface(const int npts_src, const double *lon_src, const doubl
                           const int *mask_src, int npts_dst, const double *lon_dst, const double *lat_dst,
                           const int *mask_dst, const int *idx_map, const int *face_map, const int iface_dst, int *idx_map_sf);
 
-void gather_compressed_double_data(int npts, const double *data, double *data_global);
-void gather_compressed_int_data(int npts, const int *data, int *data_global);
-void gather_sort_compressed_int_data(int npts, const int *data, int npts_global,  int *data_global,  int * ori_pos_global);
+void gather_compressed_double_data(int npts, double *data, double *data_global);
+void gather_compressed_int_data(int npts, int *data, int *data_global);
+void gather_sort_compressed_int_data(int npts, int *data, int npts_global,  int *data_global,  int * ori_pos_global);
 
 void quick_sort(int v[], int v2[], int n);
 bool is_sorted(int v[], int n);
@@ -2683,14 +2683,14 @@ void search_nearest_sface(const int npts_src, const double *lon_src, const doubl
     void gather_compressed_data ()
     NOTE: simple function that seems superflous but used in debugging
     ------------------------------------------------------------------------*/
-  void gather_compressed_double_data(int npts, const double *data, double *data_global) {
+  void gather_compressed_double_data(int npts, double *data, double *data_global) {
       mpp_gather_field_double_root(npts, data, data_global);
   }
 
   /*-------------------------------------------------------------------------
     void gather_compressed_int_data ()
    ------------------------------------------------------------------------*/
-  void gather_compressed_int_data(int npts, const int *data, int *data_global) {
+  void gather_compressed_int_data(int npts, int *data, int *data_global) {
     mpp_gather_field_int_root(npts, data, data_global);
   }
 
@@ -2703,7 +2703,7 @@ void search_nearest_sface(const int npts_src, const double *lon_src, const doubl
   is finished, the value orig_pos_global[j] is the original (pre-sort) array position of data_global[j].
   TODO: See if data can be gatherd so that its in order of pe number, then such data does notneed to be sorted?
 */
-void gather_sort_compressed_int_data(int npts, const int *data, int npts_global, int *data_global, int * orig_pos_global) {
+void gather_sort_compressed_int_data(int npts, int *data, int npts_global, int *data_global, int * orig_pos_global) {
     mpp_gather_field_int_root(npts, data, data_global);
      if (mpp_pe() == mpp_root_pe()) {
        for(int i = 0; i< npts_global; i++){


### PR DESCRIPTION
The files mpp.c and mpp_domain.c shared three variables.  This sharing is removed.  Both files now have `static` global variables.

Cleaned up a few error messages in make_hgrid.c and remap_land.c

Added .vscode mac configuration.

fixes #182 