### PR TITLE
iargc replacement in Fortran apps.

### DIFF
--- a/postprocessing/land_utils/combine-ncc.F90
+++ b/postprocessing/land_utils/combine-ncc.F90
@@ -436,9 +436,7 @@ subroutine parse_command_line()
   logical :: do_interpret_arguments
   integer :: i, iostat
 
-  !integer, external :: iargc
-
-  nargs = iargc()
+  nargs = command_argument_count()
   if(nargs==0) then
      call usage()
      call exit(1)

--- a/postprocessing/land_utils/decompress-ncc.F90
+++ b/postprocessing/land_utils/decompress-ncc.F90
@@ -221,9 +221,8 @@ subroutine parse_command_line()
   logical :: do_interpret_arguments
   integer :: i, iostat
 
-  !integer, external :: iargc
+  nargs = command_argument_count()
 
-  nargs = iargc()
   if(nargs==0) then
      call usage()
      call exit(1)

--- a/postprocessing/land_utils/scatter-ncc.F90
+++ b/postprocessing/land_utils/scatter-ncc.F90
@@ -322,9 +322,8 @@ subroutine parse_command_line()
   logical :: do_interpret_arguments
   integer :: i, iostat
 
-  !integer, external :: iargc
+  nargs = command_argument_count()
 
-  nargs = iargc()
   if(nargs==0) then
      call usage()
      call exit(1)


### PR DESCRIPTION
This PR is for the replacement of the use of iargc in NCtools Fortran programs to allow for compiling with certain modern
compilers on ARM. Certain compiler do not (or no longer) support iargc, and even some compilers that currently support it now recommend the use of function command_argument_count() instead . E.g. the GNU Fortran manual states :
" This (iargc) intrinsic routine is provided for backwards compatibility with GNU Fortran 77. In new code, programmers should consider the use of the COMMAND_ARGUMENT_COUNT intrinsic defined by the Fortran 2003 standard."

The issue was discoverer compiling with recent NVidia compilers on Raspberry Pi. The changed was tested with NVidia, GNU, and Intel compilers on linux.

There is a related PR (https://github.com/NOAA-GFDL/FRE-NCtools/pull/183) targeting changes that allow compiling on ARM Mac.

Also, note. This is a replacement of PR 187, which would have inadvertently added an extra commit.