### PR TITLE
Fixing test_utils.bash to be POSIX safe

### DIFF
--- a/t/test_utils.bash
+++ b/t/test_utils.bash
@@ -44,7 +44,7 @@ setup(){
 
 teardown(){
   cd $BASE_TEST_DIR
-  #rm -rf $testDir
+  rm -rf $testDir
 }
 
 skip_test(){

--- a/t/test_utils.bash
+++ b/t/test_utils.bash
@@ -27,11 +27,11 @@
 # to be skipped during make check
 
 testDir="$( basename $BATS_TEST_FILENAME .sh )"
-testDir="`expr substr $testDir 1 6`"
+testDir=${testDir%-*}
 
 setup(){
   BASE_TEST_DIR=$( pwd )
-  TEST_NUM="`expr substr $(basename $BATS_TEST_FILENAME .sh) 5 2`"
+  TEST_NUM="${testDir:4:2}"
 
   # check if test is to be skipped first
   [[ ! -z $SKIP_TESTS ]] && skip_test $SKIP_TESTS
@@ -44,7 +44,7 @@ setup(){
 
 teardown(){
   cd $BASE_TEST_DIR
-  rm -rf $testDir
+  #rm -rf $testDir
 }
 
 skip_test(){

--- a/t/test_utils.bash
+++ b/t/test_utils.bash
@@ -27,6 +27,7 @@
 # to be skipped during make check
 
 testDir="$( basename $BATS_TEST_FILENAME .sh )"
+# expr subtr not POSIX-safe, this should be however
 testDir=${testDir%-*}
 
 setup(){


### PR DESCRIPTION
test_utils.bash contained POSIX unsafe 'expr substr', replaced with shell parameter expansion to grab test directory numbers.