### PR TITLE
add initial openacc work

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
         MPI: ${{ matrix.with_mpi }}
         QUAD_P: ${{ matrix.enable_quad_precision }}
     steps:
+    - name: install autoconf dependency
+      run: apt update && apt install autoconf-archive
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,17 @@ GX_C__GENERIC
 AS_IF([test $gx_cv_c__Generic = no],
   AC_MSG_ERROR([The C compiler does not support the generic selection C-11 standard.  Please use a C-11 compliant compiler.])
 )
+# openacc support, simple check for working (nvc)openacc flag and allows for disabling if desired
+# TODO this should really be added as an m4 macro, surprised there wasn't a existing one in the archives
+AC_ARG_WITH([openacc],
+  [AS_HELP_STRING([--with-openacc],
+    [Builds with openacc flags if available (default yes)])])
+AS_IF([test ${with_openacc:-yes} = yes],
+  [with_openacc=yes],
+  [with_openacc=no])
+AS_IF([test ${with_openacc} = yes],
+  AX_CHECK_COMPILE_FLAG( [-acc], [CFLAGS="-acc -tp haswell -ta=tesla -Minfo -Mbounds -Mnoinline"]))
+
 
 AC_PROG_FC([ifort gfortran])
 AC_PROG_FC_C_O

--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ AS_IF([test ${with_openacc:-yes} = yes],
   [with_openacc=yes],
   [with_openacc=no])
 AS_IF([test ${with_openacc} = yes],
-  AX_CHECK_COMPILE_FLAG( [-acc], [CFLAGS="-acc -tp haswell -ta=tesla -Minfo -Mbounds -Mnoinline"]))
+  AX_CHECK_COMPILE_FLAG( [-acc], [CFLAGS="-acc -tp haswell -gpu=cc70 -Minfo -Mbounds -Mnoinline"]))
 
 
 AC_PROG_FC([ifort gfortran])

--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ AS_IF([test ${with_openacc:-yes} = yes],
   [with_openacc=yes],
   [with_openacc=no])
 AS_IF([test ${with_openacc} = yes],
-  AX_CHECK_COMPILE_FLAG( [-acc], [CFLAGS="-acc -tp haswell -gpu=cc70 -Minfo -Mbounds -Mnoinline"]))
+  [AX_CHECK_COMPILE_FLAG( [-acc], [CFLAGS="-acc -tp haswell -gpu=cc70 -Minfo -Mbounds -Mnoinline"])])
 
 
 AC_PROG_FC([ifort gfortran])

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <netcdf.h>
 #include <math.h>
+#include <time.h>
 #include "constant.h"
 #include "globals.h"
 #include "create_xgrid.h"
@@ -56,6 +57,9 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
     double *clat;
   } CellStruct;
   CellStruct *cell_in;
+
+  double time_nxgrid=0;
+  clock_t time_start, time_end;
 
   garea = 4*M_PI*RADIUS*RADIUS;
 
@@ -194,9 +198,14 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 	    int    *g_i_in, *g_j_in;
 	    double *g_area, *g_clon, *g_clat;
 
+   time_start = clock();
 	    nxgrid = create_xgrid_2dx2d_order2(&nx_in, &ny_now, &nx_out, &ny_out, grid_in[m].lonc+jstart*(nx_in+1),
 					       grid_in[m].latc+jstart*(nx_in+1),  grid_out[n].lonc,  grid_out[n].latc,
 					       mask, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+   printf("nxgrid, m, & n is: %d %d %d\n",nxgrid, m, n);
+   time_end = clock();
+   time_nxgrid += 1.0 * (time_end - time_start)/CLOCKS_PER_SEC;
+
 	    for(i=0; i<nxgrid; i++) j_in[i] += jstart;
 
 	    /* For the purpose of bitiwise reproducing, the following operation is needed. */
@@ -316,6 +325,8 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 	}  /* if(nxgrid>0) */
       }
     }
+    print_time("time_nxgrid", time_nxgrid);
+
     if(opcode & CONSERVE_ORDER2) {
       /* subtrack the grid_in clon and clat to get the distance between xgrid and grid_in */
       for(n=0; n<ntiles_in; n++) {
@@ -821,11 +832,11 @@ void do_scalar_conserve_interp(Interp_config *interp, int varid, int ntiles_in, 
     if ( cell_methods == CELL_METHODS_SUM ) {
       for(i=0; i<nx2*ny2*nz; i++) {
         if(out_area[i] == 0) {
-          if(out_miss[i] == 0)
-            for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = missing;
-          else
-            for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = 0.0;
-        }
+	  	  if(out_miss[i] ==0)
+	        for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = missing;
+	      else
+	        for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = 0.0;
+		}
       }
     }
     else {

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -33,6 +33,8 @@
 #include "mpp_io.h"
 #include "read_mosaic.h"
 
+#define DEBUG 0
+
 #define  AREA_RATIO (1.e-3)
 #define  MAXVAL (1.e20)
 #define  TOLERANCE  (1.e-10)
@@ -202,7 +204,7 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 	    nxgrid = create_xgrid_2dx2d_order2(&nx_in, &ny_now, &nx_out, &ny_out, grid_in[m].lonc+jstart*(nx_in+1),
 					       grid_in[m].latc+jstart*(nx_in+1),  grid_out[n].lonc,  grid_out[n].latc,
 					       mask, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
-   printf("nxgrid, m, & n is: %d %d %d\n",nxgrid, m, n);
+   if(DEBUG) printf("nxgrid, m, & n is: %d %d %d\n",nxgrid, m, n);
    time_end = clock();
    time_nxgrid += 1.0 * (time_end - time_start)/CLOCKS_PER_SEC;
 
@@ -325,7 +327,7 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 	}  /* if(nxgrid>0) */
       }
     }
-    print_time("time_nxgrid", time_nxgrid);
+    if(DEBUG) print_time("time_nxgrid", time_nxgrid);
 
     if(opcode & CONSERVE_ORDER2) {
       /* subtrack the grid_in clon and clat to get the distance between xgrid and grid_in */
@@ -832,12 +834,12 @@ void do_scalar_conserve_interp(Interp_config *interp, int varid, int ntiles_in, 
     if ( cell_methods == CELL_METHODS_SUM ) {
       for(i=0; i<nx2*ny2*nz; i++) {
         if(out_area[i] == 0) {
-	  if(out_miss[i] ==0)
+          if(out_miss[i] ==0)
             for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = missing;
           else
             for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = 0.0;
-	}
-     }
+        }
+      }
     }
     else {
       for(i=0; i<nx2*ny2*nz; i++) {

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -832,12 +832,12 @@ void do_scalar_conserve_interp(Interp_config *interp, int varid, int ntiles_in, 
     if ( cell_methods == CELL_METHODS_SUM ) {
       for(i=0; i<nx2*ny2*nz; i++) {
         if(out_area[i] == 0) {
-	  	  if(out_miss[i] ==0)
-	        for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = missing;
-	      else
-	        for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = 0.0;
-		}
-      }
+	  if(out_miss[i] ==0)
+            for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = missing;
+          else
+            for(k=0; k<nz; k++) field_out[m].data[k*nx2*ny2+i] = 0.0;
+	}
+     }
     }
     else {
       for(i=0; i<nx2*ny2*nz; i++) {

--- a/tools/libfrencutils/constant.h
+++ b/tools/libfrencutils/constant.h
@@ -21,7 +21,7 @@
 #ifndef NCTOOLS_CONSTANT_H
 #define NCTOOLS_CONSTANT_H
 
-#define RADIUS        (6371000.)
+#define RADIUS        (6371000.d)
 #define STRING        255
 
 #ifndef M_PI

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -1,22 +1,3 @@
-/***********************************************************************
- *                   GNU Lesser General Public License
- *
- * This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
- *
- * FRE-NCtools is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at
- * your option) any later version.
- *
- * FRE-NCtools is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with FRE-NCTools.  If not, see
- * <http://www.gnu.org/licenses/>.
- **********************************************************************/
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
@@ -24,12 +5,13 @@
 #include "create_xgrid.h"
 #include "constant.h"
 
-#define AREA_RATIO_THRESH (1.e-6)
+#define AREA_RATIO_THRESH (1.e-6)  
 #define MASK_THRESH       (0.5)
 #define EPSLN8            (1.e-8)
 #define EPSLN30           (1.0e-30)
 #define EPSLN10           (1.0e-10)
-
+#define R2D (180/M_PI)
+#define TPI (2.0*M_PI)
 double grid_box_radius(const double *x, const double *y, const double *z, int n);
 double dist_between_boxes(const double *x1, const double *y1, const double *z1, int n1,
 			  const double *x2, const double *y2, const double *z2, int n2);
@@ -42,7 +24,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   int get_maxxgrid
   return constants MAXXGRID.
 *******************************************************************************/
-int get_maxxgrid(void)
+int get_maxxgrid(void)  
 {
   return MAXXGRID;
 }
@@ -67,7 +49,7 @@ void get_grid_area(const int *nlon, const int *nlat, const double *lon, const do
 {
   int nx, ny, nxp, i, j, n_in;
   double x_in[20], y_in[20];
-
+  
   nx = *nlon;
   ny = *nlat;
   nxp = nx + 1;
@@ -81,7 +63,7 @@ void get_grid_area(const int *nlon, const int *nlat, const double *lon, const do
     y_in[1] = lat[j*nxp+i+1];
     y_in[2] = lat[(j+1)*nxp+i+1];
     y_in[3] = lat[(j+1)*nxp+i];
-    n_in = fix_lon(x_in, y_in, 4, M_PI);
+    n_in = fix_lon(x_in, y_in, 4, M_PI);    
     area[j*nx+i] = poly_area(x_in, y_in, n_in);
   }
 
@@ -97,9 +79,8 @@ void get_grid_great_circle_area_(const int *nlon, const int *nlat, const double 
 
 void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area)
 {
-  int nx, ny, nxp, nyp, i, j, n_in;
+  int nx, ny, nxp, nyp, i, j;
   int n0, n1, n2, n3;
-  double x_in[20], y_in[20], z_in[20];
   struct Node *grid=NULL;
   double *x=NULL, *y=NULL, *z=NULL;
 
@@ -114,7 +95,7 @@ void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *
   z = (double *)malloc(nxp*nyp*sizeof(double));
 
   latlon2xyz(nxp*nyp, lon, lat, x, y, z);
-
+  
   for(j=0; j<ny; j++) for(i=0; i < nx; i++) {
     /* clockwise */
     n0 = j*nxp+i;
@@ -133,7 +114,7 @@ void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *
   free(x);
   free(y);
   free(z);
-
+  
 };  /* get_grid_great_circle_area */
 
 
@@ -141,7 +122,7 @@ void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double 
 {
   int nx, ny, nxp, i, j, n_in;
   double x_in[20], y_in[20];
-
+  
   nx = *nlon;
   ny = *nlat;
   nxp = nx + 1;
@@ -155,7 +136,7 @@ void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double 
     y_in[1] = lat[j*nxp+i+1];
     y_in[2] = lat[(j+1)*nxp+i+1];
     y_in[3] = lat[(j+1)*nxp+i];
-    n_in = fix_lon(x_in, y_in, 4, M_PI);
+    n_in = fix_lon(x_in, y_in, 4, M_PI);    
     area[j*nx+i] = poly_area_dimensionless(x_in, y_in, n_in);
   }
 
@@ -167,7 +148,7 @@ void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon
 {
   int nx, ny, nxp, i, j, n_in;
   double x_in[20], y_in[20];
-
+  
   nx = *nlon;
   ny = *nlat;
   nxp = nx + 1;
@@ -191,19 +172,19 @@ void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon
   void create_xgrid_1dx2d_order1
   This routine generate exchange grids between two grids for the first order
   conservative interpolation. nlon_in,nlat_in,nlon_out,nlat_out are the size of the grid cell
-  and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds.
+  and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds. 
 *******************************************************************************/
 int create_xgrid_1dx2d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
 			       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out, double *xgrid_area)
 {
   int nxgrid;
-
+  
   nxgrid = create_xgrid_1dx2d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
 			       i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
-
-};
+    
+};  
 
 int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
 			      const double *lat_in, const double *lon_out, const double *lat_out,
@@ -216,7 +197,7 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
   double ll_lon, ll_lat, ur_lon, ur_lat, x_in[MV], y_in[MV], x_out[MV], y_out[MV];
   double *area_in, *area_out, min_area;
   double *tmpx, *tmpy;
-
+  
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
@@ -239,10 +220,10 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
      get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);
   else
     get_grid_area_no_adjust(nlon_in, nlat_in, tmpx, tmpy, area_in);
-
-  get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);
+  
+  get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);  
   free(tmpx);
-  free(tmpy);
+  free(tmpy);  
 
   for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
 
@@ -251,7 +232,7 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
       int n_in, n_out;
       double Xarea;
-
+      
       y_in[0] = lat_out[j2*nx2p+i2];
       y_in[1] = lat_out[j2*nx2p+i2+1];
       y_in[2] = lat_out[(j2+1)*nx2p+i2+1];
@@ -266,7 +247,7 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
       x_in[2] = lon_out[(j2+1)*nx2p+i2+1];
       x_in[3] = lon_out[(j2+1)*nx2p+i2];
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
-
+      
       if ( (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
 	Xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
 	min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
@@ -285,9 +266,9 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
 
   free(area_in);
   free(area_out);
-
+  
   return nxgrid;
-
+  
 }; /* create_xgrid_1dx2d_order1 */
 
 
@@ -315,11 +296,11 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
-  int i1, j1, i2, j2, nxgrid, n;
+  int i1, j1, i2, j2, nxgrid;
   double ll_lon, ll_lat, ur_lon, ur_lat, x_in[MV], y_in[MV], x_out[MV], y_out[MV];
   double *area_in, *area_out, min_area;
   double *tmpx, *tmpy;
-
+  
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
@@ -337,11 +318,11 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
     tmpx[j1*nx1p+i1] = lon_in[i1];
     tmpy[j1*nx1p+i1] = lat_in[j1];
   }
-  get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);
-  get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);
+  get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);     
+  get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);  
   free(tmpx);
-  free(tmpy);
-
+  free(tmpy);    
+  
   for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
 
     ll_lon = lon_in[i1];   ll_lat = lat_in[j1];
@@ -349,7 +330,7 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
     for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
       int n_in, n_out;
       double xarea, lon_in_avg;
-
+      
       y_in[0] = lat_out[j2*nx2p+i2];
       y_in[1] = lat_out[j2*nx2p+i2+1];
       y_in[2] = lat_out[(j2+1)*nx2p+i2+1];
@@ -365,11 +346,11 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
       x_in[3] = lon_out[(j2+1)*nx2p+i2];
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
       lon_in_avg = avgval_double(n_in, x_in);
-
+      
       if (  (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];	
         min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	if(xarea/min_area > AREA_RATIO_THRESH ) {
+	if(xarea/min_area > AREA_RATIO_THRESH ) {	  
 	  xgrid_area[nxgrid] = xarea;
 	  xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
 	  xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
@@ -385,9 +366,9 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   }
   free(area_in);
   free(area_out);
-
+  
   return nxgrid;
-
+  
 }; /* create_xgrid_1dx2d_order2 */
 
 /*******************************************************************************
@@ -395,7 +376,7 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   This routine generate exchange grids between two grids for the first order
   conservative interpolation. nlon_in,nlat_in,nlon_out,nlat_out are the size of the grid cell
   and lon_out,lat_out are 1-D grid bounds, lon_in,lat_in are geographic grid location of grid cell bounds.
-  mask is on grid lon_in/lat_in.
+  mask is on grid lon_in/lat_in. 
 *******************************************************************************/
 int create_xgrid_2dx1d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
@@ -403,12 +384,12 @@ int create_xgrid_2dx1d_order1_(const int *nlon_in, const int *nlat_in, const int
 			       int *j_out, double *xgrid_area)
 {
   int nxgrid;
-
+  
   nxgrid = create_xgrid_2dx1d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
 			       i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
-
-};
+    
+};  
 int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
 			      const double *lat_in, const double *lon_out, const double *lat_out,
 			      const double *mask_in, int *i_in, int *j_in, int *i_out,
@@ -420,7 +401,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
   double ll_lon, ll_lat, ur_lon, ur_lat, x_in[MV], y_in[MV], x_out[MV], y_out[MV];
   double *area_in, *area_out, min_area;
   double *tmpx, *tmpy;
-
+  
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
@@ -437,12 +418,12 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
     tmpx[j2*nx2p+i2] = lon_out[i2];
     tmpy[j2*nx2p+i2] = lat_out[j2];
   }
-  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);
-  get_grid_area(nlon_out, nlat_out, tmpx, tmpy, area_out);
+  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);     
+  get_grid_area(nlon_out, nlat_out, tmpx, tmpy, area_out);  
 
   free(tmpx);
   free(tmpy);
-
+  
   for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
 
     ll_lon = lon_out[i2];   ll_lat = lat_out[j2];
@@ -450,7 +431,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n_in, n_out;
       double Xarea;
-
+      
       y_in[0] = lat_in[j1*nx1p+i1];
       y_in[1] = lat_in[j1*nx1p+i1+1];
       y_in[2] = lat_in[(j1+1)*nx1p+i1+1];
@@ -466,7 +447,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
       x_in[3] = lon_in[(j1+1)*nx1p+i1];
 
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
-
+      
       if ( (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
 	Xarea = poly_area ( x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
 	min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
@@ -485,9 +466,9 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
 
   free(area_in);
   free(area_out);
-
+  
   return nxgrid;
-
+  
 }; /* create_xgrid_2dx1d_order1 */
 
 
@@ -496,7 +477,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
   This routine generate exchange grids between two grids for the second order
   conservative interpolation. nlon_in,nlat_in,nlon_out,nlat_out are the size of the grid cell
   and lon_out,lat_out are 1-D grid bounds, lon_in,lat_in are geographic grid location of grid cell bounds.
-  mask is on grid lon_in/lat_in.
+  mask is on grid lon_in/lat_in. 
 ********************************************************************************/
 int create_xgrid_2dx1d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
@@ -517,12 +498,12 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
-  int i1, j1, i2, j2, nxgrid, n;
+  int i1, j1, i2, j2, nxgrid;
   double ll_lon, ll_lat, ur_lon, ur_lat, x_in[MV], y_in[MV], x_out[MV], y_out[MV];
   double *tmpx, *tmpy;
   double *area_in, *area_out, min_area;
   double  lon_in_avg;
-
+  
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
@@ -540,12 +521,12 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
     tmpx[j2*nx2p+i2] = lon_out[i2];
     tmpy[j2*nx2p+i2] = lat_out[j2];
   }
-  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);
-  get_grid_area(nlon_out, nlat_out, tmpx, tmpy, area_out);
+  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);     
+  get_grid_area(nlon_out, nlat_out, tmpx, tmpy, area_out);  
 
   free(tmpx);
-  free(tmpy);
-
+  free(tmpy);  
+  
   for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
 
     ll_lon = lon_out[i2];   ll_lat = lat_out[j2];
@@ -553,7 +534,7 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n_in, n_out;
       double xarea;
-
+      
       y_in[0] = lat_in[j1*nx1p+i1];
       y_in[1] = lat_in[j1*nx1p+i1+1];
       y_in[2] = lat_in[(j1+1)*nx1p+i1+1];
@@ -570,11 +551,11 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
 
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
       lon_in_avg = avgval_double(n_in, x_in);
-
+      
       if (  (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];	
 	min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	if(xarea/min_area > AREA_RATIO_THRESH ) {
+	if(xarea/min_area > AREA_RATIO_THRESH ) {	  
 	  xgrid_area[nxgrid] = xarea;
 	  xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
 	  xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
@@ -590,10 +571,10 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
   }
 
   free(area_in);
-  free(area_out);
-
+  free(area_out);  
+  
   return nxgrid;
-
+  
 }; /* create_xgrid_2dx1d_order2 */
 
 /*******************************************************************************
@@ -610,12 +591,12 @@ int create_xgrid_2dx2d_order1_(const int *nlon_in, const int *nlat_in, const int
 			       int *j_out, double *xgrid_area)
 {
   int nxgrid;
-
+  
   nxgrid = create_xgrid_2dx2d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
 			       i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
-
-};
+    
+};  
 #endif
 int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
@@ -623,37 +604,37 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
 			      int *j_out, double *xgrid_area)
 {
 
-#define MAX_V 8
+#define MAX_V 8  
   int nx1, nx2, ny1, ny2, nx1p, nx2p, nxgrid;
   double *area_in, *area_out;
   int nblocks =1;
   int *istart2=NULL, *iend2=NULL;
   int npts_left, nblks_left, pos, m, npts_my, ij;
-  double *lon_out_min_list,*lon_out_max_list,*lon_out_avg,*lat_out_min_list,*lat_out_max_list;
+  double *lon_out_min_list,*lon_out_max_list,*lon_out_avg,*lat_out_min_list,*lat_out_max_list;  
   double *lon_out_list, *lat_out_list;
   int *pnxgrid=NULL, *pstart;
   int *pi_in=NULL, *pj_in=NULL, *pi_out=NULL, *pj_out=NULL;
   double *pxgrid_area=NULL;
   int    *n2_list;
   int nthreads, nxgrid_block_max;
-
+  
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
-  ny2 = *nlat_out;
+  ny2 = *nlat_out;  
   nx1p = nx1 + 1;
   nx2p = nx2 + 1;
 
   area_in  = (double *)malloc(nx1*ny1*sizeof(double));
   area_out = (double *)malloc(nx2*ny2*sizeof(double));
-  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);
+  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);     
   get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);
 
   nthreads = 1;
 #if defined(_OPENMP)
 #pragma omp parallel
   nthreads = omp_get_num_threads();
-#endif
+#endif  
 
   nblocks = nthreads;
 
@@ -664,7 +645,7 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
   pnxgrid = (int *)malloc(nblocks*sizeof(int));
 
   nxgrid_block_max = MAXXGRID/nblocks;
-
+  
   for(m=0; m<nblocks; m++) {
     pnxgrid[m] = 0;
     pstart[m] = m*nxgrid_block_max;
@@ -684,7 +665,7 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     pj_out = (int *)malloc(MAXXGRID*sizeof(int));
     pxgrid_area = (double *)malloc(MAXXGRID*sizeof(double));
   }
-
+  
   npts_left = nx2*ny2;
   nblks_left = nblocks;
   pos = 0;
@@ -708,8 +689,8 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) shared(nx2,ny2,nx2p,lon_out,lat_out,lat_out_min_list, \
                                               lat_out_max_list,lon_out_min_list,lon_out_max_list, \
-                                              lon_out_avg,n2_list,lon_out_list,lat_out_list)
-#endif
+                                              lon_out_avg,n2_list,lon_out_list,lat_out_list) 
+#endif                        
   for(ij=0; ij<nx2*ny2; ij++){
     int i2, j2, n, n0, n1, n2, n3, n2_in, l;
     double x2_in[MV], y2_in[MV];
@@ -722,7 +703,7 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     x2_in[1] = lon_out[n1]; y2_in[1] = lat_out[n1];
     x2_in[2] = lon_out[n2]; y2_in[2] = lat_out[n2];
     x2_in[3] = lon_out[n3]; y2_in[3] = lat_out[n3];
-
+    
     lat_out_min_list[n] = minval_double(4, y2_in);
     lat_out_max_list[n] = maxval_double(4, y2_in);
     n2_in = fix_lon(x2_in, y2_in, 4, M_PI);
@@ -734,7 +715,7 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     for(l=0; l<n2_in; l++) {
       lon_out_list[n*MAX_V+l] = x2_in[l];
       lat_out_list[n*MAX_V+l] = y2_in[l];
-    }
+    }    
   }
 
 nxgrid = 0;
@@ -745,16 +726,16 @@ nxgrid = 0;
                                               n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
                                               lon_out_max_list,lon_out_avg,area_in,area_out, \
                                               pxgrid_area,pnxgrid,pi_in,pj_in,pi_out,pj_out,pstart,nthreads)
-#endif
+#endif  
   for(m=0; m<nblocks; m++) {
     int i1, j1, ij;
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n0, n1, n2, n3, l,n1_in;
       double lat_in_min,lat_in_max,lon_in_min,lon_in_max,lon_in_avg;
       double x1_in[MV], y1_in[MV], x_out[MV], y_out[MV];
-
+ 
       n0 = j1*nx1p+i1;       n1 = j1*nx1p+i1+1;
-      n2 = (j1+1)*nx1p+i1+1; n3 = (j1+1)*nx1p+i1;
+      n2 = (j1+1)*nx1p+i1+1; n3 = (j1+1)*nx1p+i1;      
       x1_in[0] = lon_in[n0]; y1_in[0] = lat_in[n0];
       x1_in[1] = lon_in[n1]; y1_in[1] = lat_in[n1];
       x1_in[2] = lon_in[n2]; y1_in[2] = lat_in[n2];
@@ -766,13 +747,13 @@ nxgrid = 0;
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
       for(ij=istart2[m]; ij<=iend2[m]; ij++) {
-	int n_in, n_out, i2, j2, n2_in;
+	int n_out, i2, j2, n2_in;
 	double xarea, dx, lon_out_min, lon_out_max;
 	double x2_in[MAX_V], y2_in[MAX_V];
-
+	
 	i2 = ij%nx2;
 	j2 = ij/nx2;
-
+	
 	if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
 	/* adjust x2_in according to lon_in_avg*/
 	n2_in = n2_list[ij];
@@ -781,7 +762,7 @@ nxgrid = 0;
 	  y2_in[l] = lat_out_list[ij*MAX_V+l];
 	}
 	lon_out_min = lon_out_min_list[ij];
-	lon_out_max = lon_out_max_list[ij];
+	lon_out_max = lon_out_max_list[ij];  
         dx = lon_out_avg[ij] - lon_in_avg;
 	if(dx < -M_PI ) {
 	  lon_out_min += TPI;
@@ -801,13 +782,13 @@ nxgrid = 0;
 	if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
           double min_area;
 	  int    nn;
-	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];	
 	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
 	  if( xarea/min_area > AREA_RATIO_THRESH ) {
 	    pnxgrid[m]++;
             if(pnxgrid[m]>= MAXXGRID/nthreads)
 	      error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
-	    nn = pstart[m] + pnxgrid[m]-1;
+	    nn = pstart[m] + pnxgrid[m]-1;	    
 
 	    pxgrid_area[nn] = xarea;
 	    pi_in[nn]       = i1;
@@ -815,9 +796,9 @@ nxgrid = 0;
 	    pi_out[nn]      = i2;
 	    pj_out[nn]      = j2;
 	  }
-
+	  
 	}
-
+	
       }
     }
   }
@@ -851,20 +832,20 @@ nxgrid = 0;
     free(pj_out);
     free(pxgrid_area);
   }
-
+  
   free(area_in);
-  free(area_out);
+  free(area_out);  
   free(lon_out_min_list);
   free(lon_out_max_list);
   free(lat_out_min_list);
   free(lat_out_max_list);
   free(lon_out_avg);
-  free(n2_list);
+  free(n2_list);  
   free(lon_out_list);
   free(lat_out_list);
 
   return nxgrid;
-
+  
 };/* get_xgrid_2Dx2D_order1 */
 
 /********************************************************************************
@@ -872,7 +853,7 @@ nxgrid = 0;
   This routine generate exchange grids between two grids for the second order
   conservative interpolation. nlon_in,nlat_in,nlon_out,nlat_out are the size of the grid cell
   and lon_in,lat_in, lon_out,lat_out are geographic grid location of grid cell bounds.
-  mask is on grid lon_in/lat_in.
+  mask is on grid lon_in/lat_in. 
 ********************************************************************************/
 #ifndef __AIX
 int create_xgrid_2dx2d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
@@ -893,84 +874,27 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
-#define MAX_V 8
+#define MAX_V 8  
   int nx1, nx2, ny1, ny2, nx1p, nx2p, nxgrid;
-  double xctrlon, xctrlat;
   double *area_in, *area_out;
-  int nblocks =1;
-  int *istart2=NULL, *iend2=NULL;
-  int npts_left, nblks_left, pos, m, npts_my, ij;
-  double *lon_out_min_list,*lon_out_max_list,*lon_out_avg,*lat_out_min_list,*lat_out_max_list;
+  int ij, i1, j1;
+  double *lon_out_min_list,*lon_out_max_list,*lon_out_avg,*lat_out_min_list,*lat_out_max_list;  
   double *lon_out_list, *lat_out_list;
-  int *pnxgrid=NULL, *pstart;
-  int *pi_in=NULL, *pj_in=NULL, *pi_out=NULL, *pj_out=NULL;
-  double *pxgrid_area=NULL, *pxgrid_clon=NULL, *pxgrid_clat=NULL;
   int    *n2_list;
-  int nthreads, nxgrid_block_max;
-
+  int mxxgrid;
+  
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
-  ny2 = *nlat_out;
+  ny2 = *nlat_out;  
   nx1p = nx1 + 1;
   nx2p = nx2 + 1;
+  mxxgrid = get_maxxgrid();
 
   area_in  = (double *)malloc(nx1*ny1*sizeof(double));
   area_out = (double *)malloc(nx2*ny2*sizeof(double));
-  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);
+  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);     
   get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);
-
-  nthreads = 1;
-#if defined(_OPENMP)
-#pragma omp parallel
-  nthreads = omp_get_num_threads();
-#endif
-
-  nblocks = nthreads;
-
-  istart2 = (int *)malloc(nblocks*sizeof(int));
-  iend2 = (int *)malloc(nblocks*sizeof(int));
-
-  pstart = (int *)malloc(nblocks*sizeof(int));
-  pnxgrid = (int *)malloc(nblocks*sizeof(int));
-
-  nxgrid_block_max = MAXXGRID/nblocks;
-
-  for(m=0; m<nblocks; m++) {
-    pnxgrid[m] = 0;
-    pstart[m] = m*nxgrid_block_max;
-  }
-
-  if(nblocks == 1) {
-    pi_in = i_in;
-    pj_in = j_in;
-    pi_out = i_out;
-    pj_out = j_out;
-    pxgrid_area = xgrid_area;
-    pxgrid_clon = xgrid_clon;
-    pxgrid_clat = xgrid_clat;
-  }
-  else {
-    pi_in = (int *)malloc(MAXXGRID*sizeof(int));
-    pj_in = (int *)malloc(MAXXGRID*sizeof(int));
-    pi_out = (int *)malloc(MAXXGRID*sizeof(int));
-    pj_out = (int *)malloc(MAXXGRID*sizeof(int));
-    pxgrid_area = (double *)malloc(MAXXGRID*sizeof(double));
-    pxgrid_clon = (double *)malloc(MAXXGRID*sizeof(double));
-    pxgrid_clat = (double *)malloc(MAXXGRID*sizeof(double));
-  }
-
-  npts_left = nx2*ny2;
-  nblks_left = nblocks;
-  pos = 0;
-  for(m=0; m<nblocks; m++) {
-    istart2[m] = pos;
-    npts_my = npts_left/nblks_left;
-    iend2[m] = istart2[m] + npts_my - 1;
-    pos = iend2[m] + 1;
-    npts_left -= npts_my;
-    nblks_left--;
-  }
 
   lon_out_min_list = (double *)malloc(nx2*ny2*sizeof(double));
   lon_out_max_list = (double *)malloc(nx2*ny2*sizeof(double));
@@ -983,8 +907,21 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) shared(nx2,ny2,nx2p,lon_out,lat_out,lat_out_min_list, \
                                               lat_out_max_list,lon_out_min_list,lon_out_max_list, \
-                                              lon_out_avg,n2_list,lon_out_list,lat_out_list)
-#endif
+                                              lon_out_avg,n2_list,lon_out_list,lat_out_list) 
+#endif                        
+nxgrid = 0;
+#pragma acc kernels copyin(lon_out[0:(nx2+1)*(ny2+1)], lat_out[0:(nx2+1)*(ny2+1)], mask_in[0:nx1*ny1], \
+                           xgrid_area[0:mxxgrid], xgrid_clon[0:mxxgrid], xgrid_clat[0:mxxgrid], \
+                           i_in[0:mxxgrid], j_in[0:mxxgrid], i_out[0:mxxgrid],j_out[0:mxxgrid], \
+                           area_in[0:nx1*ny1], area_out[0:nx2*ny2], \
+                           lon_in[0:(nx1+1)*(ny1+1)], lat_in[0:(nx1+1)*(ny1+1)]) \
+                   copyout(lon_out_list[0:MAX_V*nx2*ny2], lat_out_list[0:MAX_V*nx2*ny2], \
+		          lat_out_min_list[0:nx2*ny2], lat_out_max_list[0:nx2*ny2],  \
+		          lon_out_min_list[0:nx2*ny2], lon_out_max_list[0:nx2*ny2],  \
+		          lon_out_avg[0:nx2*ny2], n2_list[0:nx2*ny2]) \
+                   copy (nxgrid)
+{
+#pragma acc loop independent
   for(ij=0; ij<nx2*ny2; ij++){
     int i2, j2, n, n0, n1, n2, n3, n2_in, l;
     double x2_in[MV], y2_in[MV];
@@ -997,22 +934,22 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
     x2_in[1] = lon_out[n1]; y2_in[1] = lat_out[n1];
     x2_in[2] = lon_out[n2]; y2_in[2] = lat_out[n2];
     x2_in[3] = lon_out[n3]; y2_in[3] = lat_out[n3];
-
+    
     lat_out_min_list[n] = minval_double(4, y2_in);
     lat_out_max_list[n] = maxval_double(4, y2_in);
     n2_in = fix_lon(x2_in, y2_in, 4, M_PI);
-    if(n2_in > MAX_V) error_handler("create_xgrid.c: n2_in is greater than MAX_V");
+//    if(n2_in > MAX_V) error_handler("create_xgrid.c: n2_in is greater than MAX_V");
     lon_out_min_list[n] = minval_double(n2_in, x2_in);
     lon_out_max_list[n] = maxval_double(n2_in, x2_in);
     lon_out_avg[n] = avgval_double(n2_in, x2_in);
     n2_list[n] = n2_in;
+#pragma acc loop independent
     for(l=0; l<n2_in; l++) {
       lon_out_list[n*MAX_V+l] = x2_in[l];
       lat_out_list[n*MAX_V+l] = y2_in[l];
-    }
+    }    
   }
 
-nxgrid = 0;
 
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) shared(nblocks,nx1,ny1,nx1p,mask_in,lon_in,lat_in, \
@@ -1021,16 +958,15 @@ nxgrid = 0;
                                               lon_out_max_list,lon_out_avg,area_in,area_out, \
                                               pxgrid_area,pnxgrid,pxgrid_clon,pxgrid_clat,pi_in, \
                                               pj_in,pi_out,pj_out,pstart,nthreads)
-#endif
-  for(m=0; m<nblocks; m++) {
-    int i1, j1, ij;
+#endif  
+#pragma acc loop independent reduction(+:nxgrid) collapse(2)
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n0, n1, n2, n3, l,n1_in;
       double lat_in_min,lat_in_max,lon_in_min,lon_in_max,lon_in_avg;
       double x1_in[MV], y1_in[MV], x_out[MV], y_out[MV];
-
+ 
       n0 = j1*nx1p+i1;       n1 = j1*nx1p+i1+1;
-      n2 = (j1+1)*nx1p+i1+1; n3 = (j1+1)*nx1p+i1;
+      n2 = (j1+1)*nx1p+i1+1; n3 = (j1+1)*nx1p+i1;      
       x1_in[0] = lon_in[n0]; y1_in[0] = lat_in[n0];
       x1_in[1] = lon_in[n1]; y1_in[1] = lat_in[n1];
       x1_in[2] = lon_in[n2]; y1_in[2] = lat_in[n2];
@@ -1041,32 +977,36 @@ nxgrid = 0;
       lon_in_min = minval_double(n1_in, x1_in);
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
-      for(ij=istart2[m]; ij<=iend2[m]; ij++) {
-	int n_in, n_out, i2, j2, n2_in;
+#pragma acc loop independent reduction(+:nxgrid)
+      for(ij=0; ij<=nx2*ny2; ij++) {
+	int n_out, i2, j2, n2_in;
 	double xarea, dx, lon_out_min, lon_out_max;
 	double x2_in[MAX_V], y2_in[MAX_V];
-
+	
 	i2 = ij%nx2;
 	j2 = ij/nx2;
-
+	
 	if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
 	/* adjust x2_in according to lon_in_avg*/
 	n2_in = n2_list[ij];
+#pragma acc loop seq
 	for(l=0; l<n2_in; l++) {
 	  x2_in[l] = lon_out_list[ij*MAX_V+l];
 	  y2_in[l] = lat_out_list[ij*MAX_V+l];
 	}
 	lon_out_min = lon_out_min_list[ij];
-	lon_out_max = lon_out_max_list[ij];
+	lon_out_max = lon_out_max_list[ij];  
         dx = lon_out_avg[ij] - lon_in_avg;
 	if(dx < -M_PI ) {
 	  lon_out_min += TPI;
 	  lon_out_max += TPI;
+#pragma acc loop seq
 	  for (l=0; l<n2_in; l++) x2_in[l] += TPI;
 	}
         else if (dx >  M_PI) {
 	  lon_out_min -= TPI;
 	  lon_out_max -= TPI;
+#pragma acc loop seq
 	  for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
 	}
 
@@ -1074,78 +1014,41 @@ nxgrid = 0;
 	   consider cyclic condition
 	*/
 	if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
+	n_out = 1;
 	if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
           double min_area;
-	  int nn;
-	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];	
 	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
 	  if( xarea/min_area > AREA_RATIO_THRESH ) {
-	    pnxgrid[m]++;
-            if(pnxgrid[m]>= MAXXGRID/nthreads)
-	      error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
-	    nn = pstart[m] + pnxgrid[m]-1;
-	    pxgrid_area[nn] = xarea;
-	    pxgrid_clon[nn] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
-	    pxgrid_clat[nn] = poly_ctrlat (x_out, y_out, n_out );
-	    pi_in[nn]       = i1;
-	    pj_in[nn]       = j1;
-	    pi_out[nn]      = i2;
-	    pj_out[nn]      = j2;
-	  }
+//            if(nxgrid>= MAXXGRID/nthreads)
+//	      error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
+	    xgrid_area[nxgrid] = xarea;
+	    xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
+	    xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
+	    i_in[nxgrid]       = i1;
+	    j_in[nxgrid]       = j1;
+	    i_out[nxgrid]      = i2;
+	    j_out[nxgrid]      = j2;
+	    nxgrid++;
+	  }	  
 	}
       }
     }
-  }
-
-  /*copy data if nblocks > 1 */
-  if(nblocks == 1) {
-    nxgrid = pnxgrid[0];
-    pi_in = NULL;
-    pj_in = NULL;
-    pi_out = NULL;
-    pj_out = NULL;
-    pxgrid_area = NULL;
-    pxgrid_clon = NULL;
-    pxgrid_clat = NULL;
-  }
-  else {
-    int nn, i;
-    nxgrid = 0;
-    for(m=0; m<nblocks; m++) {
-      for(i=0; i<pnxgrid[m]; i++) {
-	nn = pstart[m] + i;
-	i_in[nxgrid] = pi_in[nn];
-	j_in[nxgrid] = pj_in[nn];
-	i_out[nxgrid] = pi_out[nn];
-	j_out[nxgrid] = pj_out[nn];
-	xgrid_area[nxgrid] = pxgrid_area[nn];
-	xgrid_clon[nxgrid] = pxgrid_clon[nn];
-	xgrid_clat[nxgrid] = pxgrid_clat[nn];
-	nxgrid++;
-      }
-    }
-    free(pi_in);
-    free(pj_in);
-    free(pi_out);
-    free(pj_out);
-    free(pxgrid_area);
-    free(pxgrid_clon);
-    free(pxgrid_clat);
-  }
+}
 
   free(area_in);
-  free(area_out);
+  free(area_out);  
   free(lon_out_min_list);
   free(lon_out_max_list);
   free(lat_out_min_list);
   free(lat_out_max_list);
   free(lon_out_avg);
-  free(n2_list);
+  free(n2_list);  
   free(lon_out_list);
   free(lat_out_list);
 
   return nxgrid;
-
+  
 };/* get_xgrid_2Dx2D_order2 */
 
 
@@ -1164,7 +1067,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
   y_last = lat_in[n_in-1];
   inside_last = (x_last >= ll_lon);
   for (i_in=0,i_out=0;i_in<n_in;i_in++) {
-
+ 
     /* if crossing LEFT boundary - output intersection */
     if ((inside=(lon_in[i_in] >= ll_lon))!=inside_last) {
       x_tmp[i_out] = ll_lon;
@@ -1187,7 +1090,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
   y_last = y_tmp[n_out-1];
   inside_last = (x_last <= ur_lon);
   for (i_in=0,i_out=0;i_in<n_out;i_in++) {
-
+ 
     /* if crossing RIGHT boundary - output intersection */
     if ((inside=(x_tmp[i_in] <= ur_lon))!=inside_last) {
       lon_out[i_out]   = ur_lon;
@@ -1200,7 +1103,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
       lon_out[i_out]   = x_tmp[i_in];
       lat_out[i_out++] = y_tmp[i_in];
     }
-
+    
     x_last = x_tmp[i_in];
     y_last = y_tmp[i_in];
     inside_last = inside;
@@ -1212,7 +1115,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
   y_last = lat_out[n_out-1];
   inside_last = (y_last >= ll_lat);
   for (i_in=0,i_out=0;i_in<n_out;i_in++) {
-
+ 
     /* if crossing BOTTOM boundary - output intersection */
     if ((inside=(lat_out[i_in] >= ll_lat))!=inside_last) {
       y_tmp[i_out]   = ll_lat;
@@ -1235,7 +1138,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
   y_last = y_tmp[n_out-1];
   inside_last = (y_last <= ur_lat);
   for (i_in=0,i_out=0;i_in<n_out;i_in++) {
-
+ 
     /* if crossing TOP boundary - output intersection */
     if ((inside=(y_tmp[i_in] <= ur_lat))!=inside_last) {
       lat_out[i_out]   = ur_lat;
@@ -1252,7 +1155,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
     inside_last = inside;
   }
   return(i_out);
-}; /* clip */
+}; /* clip */  
 
 
 /*******************************************************************************
@@ -1260,40 +1163,33 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
    between any two grid boxes. It return the number of vertices for the exchange grid.
 *******************************************************************************/
 
-int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
-	 const double lon2_in[], const double lat2_in[], int n2_in,
+#pragma acc routine seq
+int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in, 
+	 const double lon2_in[], const double lat2_in[], int n2_in, 
 	 double lon_out[], double lat_out[])
 {
   double lon_tmp[MV], lat_tmp[MV];
-  double lon2_tmp[MV], lat2_tmp[MV];
   double x1_0, y1_0, x1_1, y1_1, x2_0, y2_0, x2_1, y2_1;
   double dx1, dy1, dx2, dy2, determ, ds1, ds2;
   int i_out, n_out, inside_last, inside, i1, i2;
-  int gttwopi=0;
+
   /* clip polygon with each boundary of the polygon */
   /* We treat lon1_in/lat1_in as clip polygon and lon2_in/lat2_in as subject polygon */
   n_out = n1_in;
+#pragma acc loop seq
   for(i1=0; i1<n1_in; i1++) {
     lon_tmp[i1] = lon1_in[i1];
     lat_tmp[i1] = lat1_in[i1];
-    if(lon_tmp[i1]>TPI || lon_tmp[i1]<0.0) gttwopi = 1;
   }
+  x2_0 = lon2_in[n2_in-1];
+  y2_0 = lat2_in[n2_in-1];
   for(i2=0; i2<n2_in; i2++) {
-    lon2_tmp[i2] = lon2_in[i2];
-    lat2_tmp[i2] = lat2_in[i2];
-  }
-  //Some grid boxes near North Pole are clipped wrong (issue #42 )
-  //The following heuristic fix seems to work. Why?
-  if(gttwopi){pimod(lon_tmp,n1_in);pimod(lon2_tmp,n2_in);} 
-
-  x2_0 = lon2_tmp[n2_in-1];
-  y2_0 = lat2_tmp[n2_in-1];
-  for(i2=0; i2<n2_in; i2++) {
-    x2_1 = lon2_tmp[i2];
-    y2_1 = lat2_tmp[i2];
+    x2_1 = lon2_in[i2];
+    y2_1 = lat2_in[i2];
     x1_0 = lon_tmp[n_out-1];
     y1_0 = lat_tmp[n_out-1];
     inside_last = inside_edge( x2_0, y2_0, x2_1, y2_1, x1_0, y1_0);
+#pragma acc loop seq
     for(i1=0, i_out=0; i1<n_out; i1++) {
       x1_1 = lon_tmp[i1];
       y1_1 = lat_tmp[i1];
@@ -1308,24 +1204,25 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
 	ds1 = y1_0*x1_1 - y1_1*x1_0;
 	ds2 = y2_0*x2_1 - y2_1*x2_0;
 	determ = dy2*dx1 - dy1*dx2;
-        if(fabs(determ) < EPSLN30) {
-	  error_handler("the line between <x1_0,y1_0> and  <x1_1,y1_1> should not parallel to "
-				     "the line between <x2_0,y2_0> and  <x2_1,y2_1>");
-	}
+//        if(fabs(determ) < EPSLN30) {
+//	  error_handler("the line between <x1_0,y1_0> and  <x1_1,y1_1> should not parallel to "
+//				     "the line between <x2_0,y2_0> and  <x2_1,y2_1>");
+//	}
 	lon_out[i_out]   = (dx2*ds1 - dx1*ds2)/determ;
 	lat_out[i_out++] = (dy2*ds1 - dy1*ds2)/determ;
-
+	
 
       }
       if(inside) {
 	lon_out[i_out]   = x1_1;
-	lat_out[i_out++] = y1_1;
+	lat_out[i_out++] = y1_1;	
       }
       x1_0 = x1_1;
       y1_0 = y1_1;
       inside_last = inside;
     }
     if(!(n_out=i_out)) return 0;
+#pragma acc loop seq
     for(i1=0; i1<n_out; i1++) {
       lon_tmp[i1] = lon_out[i1];
       lat_tmp[i1] = lat_out[i1];
@@ -1336,15 +1233,8 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
   }
   return(n_out);
 }; /* clip */
-
-void pimod(double x[],int nn)
-{
-  for (int i=0;i<nn;i++) {
-    if      (x[i] < -M_PI) x[i] += TPI;
-    else if (x[i] >  M_PI) x[i] -= TPI;
-  }
-}
-/*#define debug_test_create_xgrid*/
+    
+/*#define debug_test_create_xgrid*/  
 
 #ifndef __AIX
 int create_xgrid_great_circle_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
@@ -1359,7 +1249,7 @@ int create_xgrid_great_circle_(const int *nlon_in, const int *nlat_in, const int
   return nxgrid;
 };
 #endif
-
+  
 int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
 			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
@@ -1367,20 +1257,19 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
 {
 
   int nx1, nx2, ny1, ny2, nx1p, nx2p, ny1p, ny2p, nxgrid, n1_in, n2_in;
-  int n0, n1, n2, n3, i1, j1, i2, j2, l, n;
+  int n0, n1, n2, n3, i1, j1, i2, j2;
   double x1_in[MV], y1_in[MV], z1_in[MV];
   double x2_in[MV], y2_in[MV], z2_in[MV];
   double x_out[MV], y_out[MV], z_out[MV];
   double *x1=NULL, *y1=NULL, *z1=NULL;
   double *x2=NULL, *y2=NULL, *z2=NULL;
 
-  double xctrlon, xctrlat;
   double *area1, *area2, min_area;
-
+  
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
-  ny2 = *nlat_out;
+  ny2 = *nlat_out;  
   nxgrid = 0;
   nx1p = nx1 + 1;
   nx2p = nx2 + 1;
@@ -1394,28 +1283,28 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
   x2 = (double *)malloc(nx2p*ny2p*sizeof(double));
   y2 = (double *)malloc(nx2p*ny2p*sizeof(double));
   z2 = (double *)malloc(nx2p*ny2p*sizeof(double));
-
+  
   latlon2xyz(nx1p*ny1p, lon_in, lat_in, x1, y1, z1);
   latlon2xyz(nx2p*ny2p, lon_out, lat_out, x2, y2, z2);
-
+  
   area1  = (double *)malloc(nx1*ny1*sizeof(double));
   area2 = (double *)malloc(nx2*ny2*sizeof(double));
-  get_grid_great_circle_area(nlon_in, nlat_in, lon_in, lat_in, area1);
-  get_grid_great_circle_area(nlon_out, nlat_out, lon_out, lat_out, area2);
+  get_grid_great_circle_area(nlon_in, nlat_in, lon_in, lat_in, area1);     
+  get_grid_great_circle_area(nlon_out, nlat_out, lon_out, lat_out, area2); 
   n1_in = 4;
   n2_in = 4;
-
+  
   for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
     /* clockwise */
     n0 = j1*nx1p+i1;       n1 = (j1+1)*nx1p+i1;
-    n2 = (j1+1)*nx1p+i1+1; n3 = j1*nx1p+i1+1;
+    n2 = (j1+1)*nx1p+i1+1; n3 = j1*nx1p+i1+1;      
     x1_in[0] = x1[n0]; y1_in[0] = y1[n0]; z1_in[0] = z1[n0];
     x1_in[1] = x1[n1]; y1_in[1] = y1[n1]; z1_in[1] = z1[n1];
     x1_in[2] = x1[n2]; y1_in[2] = y1[n2]; z1_in[2] = z1[n2];
     x1_in[3] = x1[n3]; y1_in[3] = y1[n3]; z1_in[3] = z1[n3];
-
+      
     for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
-      int n_in, n_out;
+      int n_out;
       double xarea;
 
       n0 = j2*nx2p+i2;       n1 = (j2+1)*nx2p+i2;
@@ -1430,12 +1319,12 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
 	xarea = great_circle_area ( n_out, x_out, y_out, z_out ) * mask_in[j1*nx1+i1];
 	min_area = min(area1[j1*nx1+i1], area2[j2*nx2+i2]);
 	if( xarea/min_area > AREA_RATIO_THRESH ) {
-#ifdef debug_test_create_xgrid
+#ifdef debug_test_create_xgrid	  
 	  printf("(i2,j2)=(%d,%d), (i1,j1)=(%d,%d), xarea=%g\n", i2, j2, i1, j1, xarea);
 #endif
 	  xgrid_area[nxgrid] = xarea;
 	  xgrid_clon[nxgrid] = 0; /*z1l: will be developed very soon */
-	  xgrid_clat[nxgrid] = 0;
+	  xgrid_clat[nxgrid] = 0; 
 	  i_in[nxgrid]       = i1;
 	  j_in[nxgrid]       = j1;
 	  i_out[nxgrid]      = i2;
@@ -1447,9 +1336,9 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
     }
   }
 
-
+  
   free(area1);
-  free(area2);
+  free(area2);  
 
   free(x1);
   free(y1);
@@ -1457,9 +1346,9 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
   free(x2);
   free(y2);
   free(z2);
-
+  
   return nxgrid;
-
+  
 };/* create_xgrid_great_circle */
 
 /*******************************************************************************
@@ -1470,15 +1359,13 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
    RANGE_CHECK_CRITERIA is used to determine if the two grid boxes are possible to be
    overlap. The size should be between 0 and 0.5. The larger the range_check_criteria,
    the more expensive of the computatioin. When the value is close to 0,
-   some small exchange grid might be lost. Suggest to use value 0.05 for C48.
+   some small exchange grid might be lost. Suggest to use value 0.05 for C48. 
 *******************************************************************************/
 
-int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in,
-			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in,
+int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in, 
+			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in, 
 			    double x_out[], double y_out[], double z_out[])
 {
-  struct Node *subjList=NULL;
-  struct Node *clipList=NULL;
   struct Node *grid1List=NULL;
   struct Node *grid2List=NULL;
   struct Node *intersectList=NULL;
@@ -1486,7 +1373,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   struct Node *curList=NULL;
   struct Node *firstIntersect=NULL, *curIntersect=NULL;
   struct Node *temp1=NULL, *temp2=NULL, *temp=NULL;
-
+  
   int    i1, i2, i1p, i2p, i2p2, npts1, npts2;
   int    nintersect, n_out;
   int    maxiter1, maxiter2, iter1, iter2;
@@ -1499,38 +1386,37 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   double u1, u2;
   double min_x1, max_x1, min_y1, max_y1, min_z1, max_z1;
   double min_x2, max_x2, min_y2, max_y2, min_z2, max_z2;
-  static int first_call=1;
 
-
+  
   /* first check the min and max of (x1_in, y1_in, z1_in) with (x2_in, y2_in, z2_in) */
   min_x1 = minval_double(n1_in, x1_in);
-  max_x2 = maxval_double(n2_in, x2_in);
+  max_x2 = maxval_double(n2_in, x2_in);  
   if(min_x1 >= max_x2+RANGE_CHECK_CRITERIA) return 0;
-  max_x1 = maxval_double(n1_in, x1_in);
+  max_x1 = maxval_double(n1_in, x1_in); 
   min_x2 = minval_double(n2_in, x2_in);
   if(min_x2 >= max_x1+RANGE_CHECK_CRITERIA) return 0;
 
   min_y1 = minval_double(n1_in, y1_in);
-  max_y2 = maxval_double(n2_in, y2_in);
+  max_y2 = maxval_double(n2_in, y2_in);  
   if(min_y1 >= max_y2+RANGE_CHECK_CRITERIA) return 0;
-  max_y1 = maxval_double(n1_in, y1_in);
+  max_y1 = maxval_double(n1_in, y1_in); 
   min_y2 = minval_double(n2_in, y2_in);
-  if(min_y2 >= max_y1+RANGE_CHECK_CRITERIA) return 0;
+  if(min_y2 >= max_y1+RANGE_CHECK_CRITERIA) return 0;  
 
   min_z1 = minval_double(n1_in, z1_in);
-  max_z2 = maxval_double(n2_in, z2_in);
+  max_z2 = maxval_double(n2_in, z2_in);  
   if(min_z1 >= max_z2+RANGE_CHECK_CRITERIA) return 0;
-  max_z1 = maxval_double(n1_in, z1_in);
+  max_z1 = maxval_double(n1_in, z1_in); 
   min_z2 = minval_double(n2_in, z2_in);
-  if(min_z2 >= max_z1+RANGE_CHECK_CRITERIA) return 0;
+  if(min_z2 >= max_z1+RANGE_CHECK_CRITERIA) return 0;    
 
   rewindList();
 
   grid1List = getNext();
-  grid2List = getNext();
+  grid2List = getNext();  
   intersectList = getNext();
   polyList = getNext();
-
+    
   /* insert points into SubjList and ClipList */
   for(i1=0; i1<n1_in; i1++) addEnd(grid1List, x1_in[i1], y1_in[i1], z1_in[i1], 0, 0, 0, -1);
   for(i2=0; i2<n2_in; i2++) addEnd(grid2List, x2_in[i2], y2_in[i2], z2_in[i2], 0, 0, 0, -1);
@@ -1540,12 +1426,12 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   n_out = 0;
   /* set the inside value */
 #ifdef debug_test_create_xgrid
-  printf("\nNOTE from clip_2dx2d_great_circle: begin to set inside value grid1List\n");
-#endif
+  printf("\nNOTE from clip_2dx2d_great_circle: begin to set inside value grid1List\n"); 
+#endif  
   /* first check number of points in grid1 is inside grid2 */
 
   temp = grid1List;
-  while(temp) {
+  while(temp) {    
     if(insidePolygon(temp, grid2List))
       temp->isInside = 1;
     else
@@ -1554,8 +1440,8 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   }
 
 #ifdef debug_test_create_xgrid
-  printf("\nNOTE from clip_2dx2d_great_circle: begin to set inside value of grid2List\n");
-#endif
+  printf("\nNOTE from clip_2dx2d_great_circle: begin to set inside value of grid2List\n"); 
+#endif      
   /* check if grid2List is inside grid1List */
   temp = grid2List;
 
@@ -1566,19 +1452,19 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       temp->isInside = 0;
     temp = getNextNode(temp);
   }
-
+      
   /* make sure the grid box is clockwise */
-
+  
   /*make sure each polygon is convex, which is equivalent that the great_circle_area is positive */
   if( gridArea(grid1List) <= 0 )
     error_handler("create_xgrid.c(clip_2dx2d_great_circle): grid box 1 is not convex");
   if( gridArea(grid2List) <= 0 )
     error_handler("create_xgrid.c(clip_2dx2d_great_circle): grid box 2 is not convex");
-
+  
 #ifdef debug_test_create_xgrid
   printNode(grid1List, "grid1List");
   printNode(grid2List, "grid2List");
-#endif
+#endif  
 
   /* get the coordinates from grid1List and grid2List.
      Please not npts1 might not equal n1_in, npts2 might not equal n2_in because of pole
@@ -1593,12 +1479,12 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   for(i2=0; i2<npts2; i2++) {
     getCoordinates(temp, pt2[i2]);
     temp = temp->Next;
-  }
-
+  }  
+  
   firstIntersect=getNext();
   curIntersect = getNext();
 
-#ifdef debug_test_create_xgrid
+#ifdef debug_test_create_xgrid  
   printf("\n\n************************ Start line_intersect_2D_3D ******************************\n");
 #endif
   /* first find all the intersection points */
@@ -1619,17 +1505,15 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       printf("********************************************************************************\n");
 #endif
       if( line_intersect_2D_3D(p1_0, p1_1, p2_0, p2_1, p2_2, intersect, &u1, &u2, &inbound) ) {
-	int n_prev, n_cur;
-	int is_in_subj, is_in_clip;
 
-	/* from the value of u1, u2 and inbound, we can partially decide if a point is inside or outside of polygon */
-
+	/* from the value of u1, u2 and inbound, we can partially decide if a point is inside or outside of polygon */        
+	
 	/* add the intersection into intersetList, The intersection might already be in
 	   intersectList and will be taken care addIntersect
 	*/
 	if(addIntersect(intersectList, intersect[0], intersect[1], intersect[2], 1, u1, u2, inbound, i1, i1p, i2, i2p)) {
 	  /* add the intersection into the grid1List */
-
+    
 	  if(u1 == 1) {
 	    insertIntersect(grid1List, intersect[0], intersect[1], intersect[2], 0.0, u2, inbound, p1_1[0], p1_1[1], p1_1[2]);
 	  }
@@ -1656,7 +1540,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	    p2_1[0] = intersect[0];
 	    p2_1[1] = intersect[1];
 	    p2_1[2] = intersect[2];
-	  }
+	  } 
 	  else if(u2 == 0) {
 	    p2_0[0] = intersect[0];
 	    p2_0[1] = intersect[1];
@@ -1666,7 +1550,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       }
     }
   }
-
+  
   /* set inbound value for the points in intersectList that has inbound == 0,
      this will also set some inbound value of the points in grid1List
   */
@@ -1692,7 +1576,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 
   /* if has_inbound = 1, find the overlapping */
   n_out = 0;
-
+  
   if(has_inbound) {
     maxiter1 = nintersect;
 #ifdef debug_test_create_xgrid
@@ -1702,7 +1586,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
     printNode(grid2List, "beginning clip list");
     printNode(grid1List, "beginning subj list");
     printf("\n************************ End line_intersect_2D_3D **********************************\n\n");
-#endif
+#endif  
     temp1 = getNode(grid1List, *firstIntersect);
     if( temp1 == NULL) {
       double lon[10], lat[10];
@@ -1712,20 +1596,20 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       printf("\n");
       xyz2latlon(n2_in, x2_in, y2_in, z2_in, lon, lat);
       for(i=0; i< n2_in; i++) printf("lon2 = %g, lat2 = %g\n", lon[i]*R2D, lat[i]*R2D);
-      printf("\n");
-
+      printf("\n");	
+	
       error_handler("firstIntersect is not in the grid1List");
     }
     addNode(polyList, *firstIntersect);
     nintersect--;
-#ifdef debug_test_create_xgrid
+#ifdef debug_test_create_xgrid    
     printNode(polyList, "polyList at stage 1");
-#endif
-
+#endif      
+	
     /* Loop over the grid1List and grid2List to find again the firstIntersect */
     curList = grid1List;
     curListNum = 0;
-
+	
     /* Loop through curList to find the next intersection, the loop will end
        when come back to firstIntersect
     */
@@ -1736,7 +1620,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
     while( iter1 < maxiter1 ) {
 #ifdef debug_test_create_xgrid
       printf("\n----------- At iteration = %d\n\n", iter1+1 );
-      printNode(curIntersect, "curIntersect at the begining of iter1");
+      printNode(curIntersect, "curIntersect at the begining of iter1");      
 #endif
       /* find the curIntersect in curList and get the next intersection points */
       temp1 =  getNode(curList, *curIntersect);
@@ -1753,13 +1637,13 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	temp2IsIntersect = 0;
 	if( isIntersect( *temp2 ) ) { /* copy the point and switch to the grid2List */
 	  struct Node *temp3;
-
+	  
 	  /* first check if temp2 is the firstIntersect */
 	  if( sameNode( *temp2, *firstIntersect) ) {
-	    found1 = 1;
+	    found1 = 1; 
 	    break;
-	  }
-
+	  }	  
+	  
 	  temp3 = temp2->Next;
 	  if( temp3 == NULL) temp3 = curList;
 	  if( temp3 == NULL) error_handler("creat_xgrid.c: temp3 can not be NULL");
@@ -1776,10 +1660,10 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	}
 	else {
 	  addNode(polyList, *temp2);
-#ifdef debug_test_create_xgrid
+#ifdef debug_test_create_xgrid    
 	  printNode(polyList, "polyList at stage 2");
-#endif
-	  if(temp2IsIntersect) {
+#endif      	  
+	  if(temp2IsIntersect) { 
 	    nintersect--;
 	  }
 	}
@@ -1788,23 +1672,23 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	iter2 ++;
       }
       if(found1) break;
-
+    
       if( !found2 ) error_handler(" not found the next intersection ");
 
       /* if find the first intersection, the poly found */
       if( sameNode( *curIntersect, *firstIntersect) ) {
-	found1 = 1;
+	found1 = 1; 
 	break;
       }
 
       /* add curIntersect to polyList and remove it from intersectList and curList */
       addNode(polyList, *curIntersect);
-#ifdef debug_test_create_xgrid
+#ifdef debug_test_create_xgrid    
       printNode(polyList, "polyList at stage 3");
-#endif
+#endif      
       nintersect--;
-
-
+      
+      
       /* switch curList */
       if( curListNum == 0) {
 	curList = grid2List;
@@ -1828,7 +1712,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       temp1 = temp1->Next;
       n_out++;
     }
-
+    
     /* if(n_out < 3) error_handler(" The clipped region has < 3 vertices"); */
     if( n_out < 3) n_out = 0;
 #ifdef debug_test_create_xgrid
@@ -1843,14 +1727,14 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
     /* One possible is that grid1List is inside grid2List */
 #ifdef debug_test_create_xgrid
     printf("\nNOTE from clip_2dx2d_great_circle: check if grid1 is inside grid2\n");
-#endif
+#endif    
     n1in2 = 0;
     temp = grid1List;
     while(temp) {
       if(temp->intersect != 1) {
-#ifdef debug_test_create_xgrid
+#ifdef debug_test_create_xgrid	
 	printf("grid1->isInside = %d\n", temp->isInside);
-#endif
+#endif 
 	if( temp->isInside == 1) n1in2++;
       }
       temp = getNextNode(temp);
@@ -1867,26 +1751,26 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
     }
     if(n_out>0) return n_out;
   }
-
+  
   /* check if grid2List is inside grid1List */
   if(n_out ==0){
     int n, n2in1;
 #ifdef debug_test_create_xgrid
     printf("\nNOTE from clip_2dx2d_great_circle: check if grid2 is inside grid1\n");
-#endif
-
+#endif    
+    
     temp = grid2List;
     n2in1 = 0;
     while(temp) {
       if(temp->intersect != 1) {
-#ifdef debug_test_create_xgrid
+#ifdef debug_test_create_xgrid	
 	printf("grid2->isInside = %d\n", temp->isInside);
 #endif
 	if( temp->isInside == 1) n2in1++;
       }
       temp = getNextNode(temp);
     }
-
+      
     if(npts2==n2in1) { /* grid2 is inside grid1 */
       n_out = npts2;
       n = 0;
@@ -1896,11 +1780,11 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	n++;
 	temp = getNextNode(temp);
       }
-
+      
     }
-  }
+  }  
 
-
+  
   return n_out;
 }
 
@@ -1930,7 +1814,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   int is_inter1, is_inter2;
 
   *inbound = 0;
-
+  
   /* first check if any vertices are the same */
   if(samePoint(a1[0], a1[1], a1[2], q1[0], q1[1], q1[2])) {
     *u_a = 0;
@@ -1939,8 +1823,8 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
     intersect[1] = a1[1];
     intersect[2] = a1[2];
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound);
-#endif
+    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound); 
+#endif      
     return 1;
    }
    else if (samePoint(a1[0], a1[1], a1[2], q2[0], q2[1], q2[2])) {
@@ -1950,14 +1834,14 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
     intersect[1] = a1[1];
     intersect[2] = a1[2];
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound);
-#endif
+    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound); 
+#endif      
     return 1;
   }
    else if(samePoint(a2[0], a2[1], a2[2], q1[0], q1[1], q1[2])) {
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound);
-#endif
+    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound); 
+#endif           
     *u_a = 1;
     *u_q = 0;
     intersect[0] = a2[0];
@@ -1967,8 +1851,8 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
    }
    else if (samePoint(a2[0], a2[1], a2[2], q2[0], q2[1], q2[2])) {
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound);
-#endif
+    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound); 
+#endif           
     *u_a = 1;
     *u_q = 1;
     intersect[0] = a2[0];
@@ -1998,7 +1882,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   if(fabs(*u_a) < EPSLN8) *u_a = 0;
   if(fabs(*u_a-1) < EPSLN8) *u_a = 1;
 
-
+  
 #ifdef debug_test_create_xgrid
     printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f\n", *u_a);
 #endif
@@ -2028,12 +1912,12 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
 #ifdef debug_test_create_xgrid
     printf("\nNOTE from line_intersect_2D_3D: u_q = %19.15f\n", *u_q);
 #endif
-
+  
 
   if( (*u_q < 0) || (*u_q > 1) ) return 0;
-
+  
   u =*u_a;
-
+  
   /* The two planes are coincidental */
   vect_cross(a1, a2, c1);
   vect_cross(q1, q2, c2);
@@ -2041,7 +1925,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   coincident = metric(c3);
 
   if(fabs(coincident) < EPSLN30) return 0;
-
+  
   /* Calculate point of intersection */
   intersect[0]=a1[0] + u*(a2[0]-a1[0]);
   intersect[1]=a1[1] + u*(a2[1]-a1[1]);
@@ -2052,7 +1936,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
 
   /* when u_q =0 or u_q =1, the following could not decide the inbound value */
   if(*u_q != 0 && *u_q != 1){
-
+  
     p1[0] = a2[0]-a1[0];
     p1[1] = a2[1]-a1[1];
     p1[2] = a2[2]-a1[2];
@@ -2071,29 +1955,23 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
     if(sense > 0) *inbound = 2; /* v1 going into v2 in CCW sense */
   }
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: inbound=%d\n", *inbound);
-#endif
-
+    printf("\nNOTE from line_intersect_2D_3D: inbound=%d\n", *inbound); 
+#endif      
+  
   return 1;
 }
 
 
 /*------------------------------------------------------------------------------
   double poly_ctrlat(const double x[], const double y[], int n)
-  This routine is used to calculate the latitude of the centroid
-  Reference: First- and Second-Order Conservative Remapping Schemes for Grids in
-             Spherical Coordinates, P. Jones, Monthly Weather Review, 1998, vol127, p2204
-  The following is an implementation of equation (13) in the above paper:
-     \int lat.dA = \int_c [-cos(lat)-lat sin(lat)] dlon
-  It assumes the sides of the spherical polygons are line segments with tangent
-  (lat2-lat1)/(lon2-lon1) between a pair of vertices in approximating the above
-  line integral along the sides of the polygon  \int_c.
+  This routine is used to calculate the latitude of the centroid 
    ---------------------------------------------------------------------------*/
 
 double poly_ctrlat(const double x[], const double y[], int n)
 {
   double ctrlat = 0.0;
   int    i;
+
   for (i=0;i<n;i++) {
     int ip = (i+1) % n;
     double dx = (x[ip]-x[i]);
@@ -2106,59 +1984,15 @@ double poly_ctrlat(const double x[], const double y[], int n)
     avg_y = (lat1+lat2)*0.5;
     if      (dx==0.0) continue;
     if(dx > M_PI)  dx = dx - 2.0*M_PI;
-    if(dx <= -M_PI) dx = dx + 2.0*M_PI; // flip sign for dx=-pi to fix huge value see comments in function poly_area
+    if(dx < -M_PI) dx = dx + 2.0*M_PI;
 
     if ( fabs(hdy)< SMALL_VALUE ) /* cheap area calculation along latitude */
       ctrlat -= dx*(2*cos(avg_y) + lat2*sin(avg_y) - cos(lat1) );
-    else
+    else 
       ctrlat -= dx*( (sin(hdy)/hdy)*(2*cos(avg_y) + lat2*sin(avg_y)) - cos(lat1) );
   }
-  if(fabs(ctrlat) > HPI) printf("WARNING poly_ctrlat: Large values for ctrlat: %19.15f\n", ctrlat);
   return (ctrlat*RADIUS*RADIUS);
-}; /* poly_ctrlat */
-/*An alternate implementation of poly_ctrlat for future developments. Under construction.*/
-double poly_ctrlat2(const double x[], const double y[], int n)
-{
-  double ctrlat = 0.0;
-  int    i,ip;
-  double dx,dy,avg_y, hdy,lat1,lat2,da,dat,dxs= 0.0;
-  int hasPole=0, hasBadxm=0, hasBadxp=0;
-  for (i=0;i<n;i++) {
-    ip = (i+1) % n;
-    dx = (x[ip]-x[i]);
-    if(fabs(dx+M_PI) < SMALL_VALUE) hasBadxm=1;
-    if(fabs(dx-M_PI) < SMALL_VALUE) hasBadxp=1;
-    if(y[i]==-HPI || y[i]==HPI) hasPole=1;
-  }
-
-  for (i=0;i<n;i++) {
-    ip = (i+1) % n;
-    dx = (x[ip]-x[i]);
-    lat1 = y[ip];
-    lat2 = y[i];
-    dy = lat2 - lat1;
-    hdy = dy*0.5;
-    avg_y = (lat1+lat2)*0.5;
-    if(dx > M_PI)  dx = dx - 2.0*M_PI;
-    if(dx < -M_PI) dx = dx + 2.0*M_PI;
-
-    if ( fabs(hdy)< SMALL_VALUE ) // limit to avoid div by 0
-      dat = 1.0;
-    else
-      dat = sin(hdy)/hdy;
-
-    da = -dx*( dat *(2*cos(avg_y) + lat2*sin(avg_y)) - cos(lat1) );
-    ctrlat += da;
-    dxs += dx;
-    if(hasBadxm || hasBadxp) printf("poly_ctrlat: %19.15f,%19.15f,%19.15f,%19.15f\n", dx,dxs,da,ctrlat);
-  }
-  if(fabs(ctrlat)>M_PI){
-    printf("Error    : Nonzero gridcell dx sum in poly_ctrlat: %19.15f,%19.15f,%19.15f\n",avg_y, dxs,ctrlat);
-    ctrlat = fabs(ctrlat) - M_PI*M_PI;
-    printf("Corrected: Nonzero gridcell dx sum in poly_ctrlat: %19.15f,%19.15f,%19.15f\n",avg_y, dxs,ctrlat);
-  }
-  return (ctrlat*RADIUS*RADIUS);
-}; /* poly_ctrlat */
+}; /* poly_ctrlat */        
 
 /*------------------------------------------------------------------------------
   double poly_ctrlon(const double x[], const double y[], int n, double clon)
@@ -2177,16 +2011,16 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
     phi1   = x[ip];
     phi2   = x[i];
     lat1 = y[ip];
-    lat2 = y[i];
+    lat2 = y[i];    
     dphi   = phi1 - phi2;
-
+    
     if      (dphi==0.0) continue;
 
     f1 = 0.5*(cos(lat1)*sin(lat1)+lat1);
     f2 = 0.5*(cos(lat2)*sin(lat2)+lat2);
 
-     /* this will make sure longitude of centroid is at
-        the same interval as the center of any grid */
+     /* this will make sure longitude of centroid is at 
+        the same interval as the center of any grid */  
     if(dphi > M_PI)  dphi = dphi - 2.0*M_PI;
     if(dphi < -M_PI) dphi = dphi + 2.0*M_PI;
     dphi1 = phi1 - clon;
@@ -2194,9 +2028,9 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
     if( dphi1 <-M_PI) dphi1 += 2.0*M_PI;
     dphi2 = phi2 -clon;
     if( dphi2 > M_PI) dphi2 -= 2.0*M_PI;
-    if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;
+    if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;    
 
-    if(fabs(dphi2 -dphi1) < M_PI) {
+    if(abs(dphi2 -dphi1) < M_PI) {
       ctrlon -= dphi * (dphi1*f1+dphi2*f2)/2.0;
     }
     else {
@@ -2204,11 +2038,11 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
 	fac = M_PI;
       else
 	fac = -M_PI;
-      fint = f1 + (f2-f1)*(fac-dphi1)/fabs(dphi);
+      fint = f1 + (f2-f1)*(fac-dphi1)/abs(dphi);
       ctrlon -= 0.5*dphi1*(dphi1-fac)*f1 - 0.5*dphi2*(dphi2+fac)*f2
 	+ 0.5*fac*(dphi1+dphi2)*fint;
 	}
-
+    
   }
   return (ctrlon*RADIUS*RADIUS);
 };   /* poly_ctrlon */
@@ -2221,24 +2055,24 @@ double box_ctrlat(double ll_lon, double ll_lat, double ur_lon, double ur_lat)
 {
   double dphi = ur_lon-ll_lon;
   double ctrlat;
-
+  
   if(dphi > M_PI)  dphi = dphi - 2.0*M_PI;
   if(dphi < -M_PI) dphi = dphi + 2.0*M_PI;
   ctrlat = dphi*(cos(ur_lat) + ur_lat*sin(ur_lat)-(cos(ll_lat) + ll_lat*sin(ll_lat)));
-  return (ctrlat*RADIUS*RADIUS);
+  return (ctrlat*RADIUS*RADIUS); 
 }; /* box_ctrlat */
 
 /*------------------------------------------------------------------------------
   double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, double clon)
-  This routine is used to calculate the lontitude of the centroid
+  This routine is used to calculate the lontitude of the centroid 
    ----------------------------------------------------------------------------*/
 double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, double clon)
 {
   double phi1, phi2, dphi, lat1, lat2, dphi1, dphi2;
-  double f1, f2, fac, fint;
+  double f1, f2, fac, fint;  
   double ctrlon  = 0.0;
   int i;
-  clon = clon;
+  clon = clon;  
   for( i =0; i<2; i++) {
     if(i == 0) {
       phi1 = ur_lon;
@@ -2262,9 +2096,9 @@ double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, do
     if( dphi1 <-M_PI) dphi1 += 2.0*M_PI;
     dphi2 = phi2 -clon;
     if( dphi2 > M_PI) dphi2 -= 2.0*M_PI;
-    if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;
+    if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;    
 
-    if(fabs(dphi2 -dphi1) < M_PI) {
+    if(abs(dphi2 -dphi1) < M_PI) {
       ctrlon -= dphi * (dphi1*f1+dphi2*f2)/2.0;
     }
     else {
@@ -2272,35 +2106,35 @@ double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, do
 	fac = M_PI;
       else
 	fac = -M_PI;
-      fint = f1 + (f2-f1)*(fac-dphi1)/fabs(dphi);
+      fint = f1 + (f2-f1)*(fac-dphi1)/abs(dphi);
       ctrlon -= 0.5*dphi1*(dphi1-fac)*f1 - 0.5*dphi2*(dphi2+fac)*f2
 	+ 0.5*fac*(dphi1+dphi2)*fint;
     }
   }
-  return (ctrlon*RADIUS*RADIUS);
+  return (ctrlon*RADIUS*RADIUS);    
 } /* box_ctrlon */
 
 /*******************************************************************************
   double grid_box_radius(double *x, double *y, double *z, int n);
   Find the radius of the grid box, the radius is defined the
   maximum distance between any two vertices
-*******************************************************************************/
+*******************************************************************************/ 
 double grid_box_radius(const double *x, const double *y, const double *z, int n)
 {
   double radius;
   int i, j;
-
+  
   radius = 0;
   for(i=0; i<n-1; i++) {
     for(j=i+1; j<n; j++) {
       radius = max(radius, pow(x[i]-x[j],2.)+pow(y[i]-y[j],2.)+pow(z[i]-z[j],2.));
     }
   }
-
+  
   radius = sqrt(radius);
 
   return (radius);
-
+  
 }; /* grid_box_radius */
 
 /*******************************************************************************
@@ -2317,7 +2151,7 @@ double dist_between_boxes(const double *x1, const double *y1, const double *z1, 
 
   dist = 0.0;
   for(i=0; i<n1; i++) {
-    for(j=0; j<n2; j++) {
+    for(j=0; j<n2; j++) {   
       dist = max(dist, pow(x1[i]-x2[j],2.)+pow(y1[i]-y2[j],2.)+pow(z1[i]-z2[j],2.));
     }
   }
@@ -2332,7 +2166,7 @@ double dist_between_boxes(const double *x1, const double *y1, const double *z1, 
  determine a point(x,y) is inside or outside a given edge with vertex,
  (x0,y0) and (x1,y1). return 1 if inside and 0 if outside. <y1-y0, -(x1-x0)> is
  the outward edge normal from vertex <x0,y0> to <x1,y1>. <x-x0,y-y0> is the vector
- from <x0,y0> to <x,y>.
+ from <x0,y0> to <x,y>. 
  if Inner produce <x-x0,y-y0>*<y1-y0, -(x1-x0)> > 0, outside, otherwise inside.
  inner product value = 0 also treate as inside.
 *******************************************************************************/
@@ -2340,20 +2174,19 @@ int inside_edge(double x0, double y0, double x1, double y1, double x, double y)
 {
    const double SMALL = 1.e-12;
    double product;
-
+   
    product = ( x-x0 )*(y1-y0) + (x0-x1)*(y-y0);
    return (product<=SMALL) ? 1:0;
-
+   
  }; /* inside_edge */
 
 
 /* The following is a test program to test subroutines in create_xgrid.c */
-/* To compile: icc -Dtest_create_xgrid -Ddebug_test_create_xgrid -g -O0 ./create_xgrid.c -o test_create_xgrid -L. -lfrencutils */
+
 #ifdef test_create_xgrid
 
 #include "create_xgrid.h"
 #include <math.h>
-#include <string.h>
 
 #define D2R (M_PI/180)
 #define R2D (180/M_PI)
@@ -2371,11 +2204,11 @@ int main(int argc, char* argv[])
   int    n1_in, n2_in, n_out, i, j;
   int    nlon1=0, nlat1=0, nlon2=0, nlat2=0;
   int    n;
-  int    ntest = 26;
-
+  int    ntest = 11;
+  
 
   for(n=11; n<=ntest; n++) {
-
+    
     switch (n) {
     case 1:
       /****************************************************************
@@ -2383,10 +2216,10 @@ int main(int argc, char* argv[])
        test clip_2dx2d_great_cirle case 1:
        box 1: (20,10), (20,12), (22,12), (22,10)
        box 2: (21,11), (21,14), (24,14), (24,11)
-       out  : (21, 12.0018), (22, 12), (22, 11.0033), (21, 11)
+       out  : (21, 12.0018), (22, 12), (22, 11.0033), (21, 11) 
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;
+      n1_in = 4; n2_in = 4;  
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
       lon1_in[0] = 20; lat1_in[0] = 10;
       lon1_in[1] = 20; lat1_in[1] = 12;
@@ -2397,7 +2230,7 @@ int main(int argc, char* argv[])
       lon2_in[2] = 24; lat2_in[2] = 14;
       lon2_in[3] = 24; lat2_in[3] = 11;
       break;
-
+      
     case 2:
       /****************************************************************
 
@@ -2406,12 +2239,11 @@ int main(int argc, char* argv[])
         box 2: (20,10), (20,12), (22,12), (22,10)
         out  : (20,10), (20,12), (22,12), (22,10)
 
-      ****************************************************************/
-      n1_in = 4; n2_in = 4;
-      lon1_in[0] = 20; lat1_in[0] =-90;
-      lon1_in[1] = 20; lat1_in[1] =-89;
-      lon1_in[2] = 22; lat1_in[2] =-88;
-      lon1_in[3] = 24; lat1_in[3] =-89;
+      ****************************************************************/      
+      lon1_in[0] = 20; lat1_in[0] = 10;
+      lon1_in[1] = 20; lat1_in[1] = 12;
+      lon1_in[2] = 22; lat1_in[2] = 12;
+      lon1_in[3] = 22; lat1_in[3] = 10;  
 
       for(i=0; i<n2_in; i++) {
 	lon2_in[i] = lon1_in[i];
@@ -2423,12 +2255,12 @@ int main(int argc, char* argv[])
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 3: one cubic sphere grid close to the pole with lat-lon grid.
-       box 1: (251.7, 88.98), (148.3, 88.98), (57.81, 88.72), (342.2, 88.72)
+       box 1: (251.7, 88.98), (148.3, 88.98), (57.81, 88.72), (342.2, 88.72) 
        box 2: (150, 88), (150, 90), (152.5, 90), (152.5, 88)
-       out  : (152.5, 89.0642), (150, 89.0165), (0, 90)
+       out  : (152.5, 89.0642), (150, 89.0165), (0, 90) 
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;
+      n1_in = 4; n2_in = 4;  
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
       lon1_in[0] = 251.7; lat1_in[0] = 88.98;
       lon1_in[1] = 148.3; lat1_in[1] = 88.98;
@@ -2451,18 +2283,18 @@ int main(int argc, char* argv[])
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 4: One box contains the pole
-       box 1: (-160, 88.5354), (152.011, 87.8123) , (102.985, 88.4008), (20, 89.8047)
+       box 1: (-160, 88.5354), (152.011, 87.8123) , (102.985, 88.4008), (20, 89.8047) 
        box 2: (145,88), (145,90), (150,90), (150,88)
-       out  : (145.916, 88.0011), (145, 88.0249), (0, 90), (150, 88)
+       out  : (145.916, 88.0011), (145, 88.0249), (0, 90), (150, 88) 
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;
+      n1_in = 4; n2_in = 4;  
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
 
       lon1_in[0] = -160;  lat1_in[0] = 88.5354;
       lon1_in[1] = 152.011; lat1_in[1] = 87.8123;
       lon1_in[2] = 102.985; lat1_in[2] = 88.4008;
-      lon1_in[3] = 20; lat1_in[3] = 89.8047;
+      lon1_in[3] = 20; lat1_in[3] = 89.8047;  
 
       lon2_in[0] = 145; lat2_in[0] = 88;
       lon2_in[1] = 145; lat2_in[1] = 90;
@@ -2476,41 +2308,41 @@ int main(int argc, char* argv[])
        test clip_2dx2d_great_cirle case 5: One tripolar grid around the pole with lat-lon grid.
        box 1: (-202.6, 87.95), (-280, 89.56), (-100, 90), (-190, 88)
        box 2: (21,11), (21,14), (24,14), (24,11)
-       out  : (150, 88.7006), (145,  88.9507), (0, 90)
+       out  : (150, 88.7006), (145,  88.9507), (0, 90) 
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;
+      n1_in = 4; n2_in = 4;  
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
 
       lon1_in[0] = -202.6;  lat1_in[0] = 87.95;
       lon1_in[1] = -280.;   lat1_in[1] = 89.56;
       lon1_in[2] = -100.0; lat1_in[2] = 90;
-      lon1_in[3] = -190.; lat1_in[3] = 88;
+      lon1_in[3] = -190.; lat1_in[3] = 88;  
 
       lon2_in[0] = 145; lat2_in[0] = 88;
       lon2_in[1] = 145; lat2_in[1] = 90;
       lon2_in[2] = 150; lat2_in[2] = 90;
       lon2_in[3] = 150; lat2_in[3] = 88;
-      break;
+      break; 
 
     case 6:
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 6: One cubic sphere grid arounc the pole with one tripolar grid box
                                        around the pole.
-       box 1: (-160, 88.5354), (152.011, 87.8123) , (102.985, 88.4008), (20, 89.8047)
+       box 1: (-160, 88.5354), (152.011, 87.8123) , (102.985, 88.4008), (20, 89.8047) 
        box 2: (-202.6, 87.95), (-280, 89.56), (-100, 90), (-190, 88)
-       out  : (170, 88.309), (157.082, 88.0005), (83.714, 89.559), (80, 89.6094), (0, 90), (200, 88.5354)
+       out  : (170, 88.309), (157.082, 88.0005), (83.714, 89.559), (80, 89.6094), (0, 90), (200, 88.5354) 
 
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;
+      n1_in = 4; n2_in = 4;  
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
 
       lon1_in[0] = -160;  lat1_in[0] = 88.5354;
       lon1_in[1] = 152.011; lat1_in[1] = 87.8123;
       lon1_in[2] = 102.985; lat1_in[2] = 88.4008;
-      lon1_in[3] = 20; lat1_in[3] = 89.8047;
+      lon1_in[3] = 20; lat1_in[3] = 89.8047;  
 
       lon2_in[0] = -202.6;  lat2_in[0] = 87.95;
       lon2_in[1] = -280.;   lat2_in[1] = 89.56;
@@ -2527,7 +2359,7 @@ int main(int argc, char* argv[])
        out  : (20,10), (20,12), (22,12), (22,10)
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;
+      n1_in = 4; n2_in = 4;  
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
       lon1_in[0] = 20; lat1_in[0] = 10;
       lon1_in[1] = 20; lat1_in[1] = 12;
@@ -2544,12 +2376,12 @@ int main(int argc, char* argv[])
 
        test clip_2dx2d_great_cirle case 8: Cubic sphere grid at tile = 1, point (i=25,j=1)
           with N45 at (i=141,j=23)
-       box 1:
-       box 2:
+       box 1: 
+       box 2: 
        out  : None
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;
+      n1_in = 4; n2_in = 4;  
       /* first a simple lat-lo
 	 n grid box to clip another lat-lon grid box */
       lon1_in[0] = 350.0; lat1_in[0] = -45;
@@ -2560,19 +2392,19 @@ int main(int argc, char* argv[])
       lon2_in[1] = 350.0;   lat2_in[1] = -44;
       lon2_in[2] = 352.5; lat2_in[2] = -44;
       lon2_in[3] = 352.5; lat2_in[3] = -46;
-      break;
+      break;      
 
-    case 9:
+    case 9:      
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 9: Cubic sphere grid at tile = 1, point (i=1,j=1)
           with N45 at (i=51,j=61)
-       box 1:
-       box 2:
+       box 1: 
+       box 2: 
        out  : None
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;
+      n1_in = 4; n2_in = 4;  
 
       lon1_in[0] = 305.0; lat1_in[0] = -35.26;
       lon1_in[1] = 305.0; lat1_in[1] = -33.80;
@@ -2582,19 +2414,19 @@ int main(int argc, char* argv[])
       lon2_in[1] = 125;   lat2_in[1] = 34;
       lon2_in[2] = 127.5; lat2_in[2] = 34;
       lon2_in[3] = 127.5; lat2_in[3] = 32;
-      break;
+      break;      
 
-    case 10:
+    case 10:      
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 10: Cubic sphere grid at tile = 3, point (i=24,j=1)
           with N45 at (i=51,j=46)
-       box 1:
-       box 2:
+       box 1: 
+       box 2: 
        out  : None
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;
+      n1_in = 4; n2_in = 4;  
 
       lon1_in[0] = 125.0; lat1_in[0] = 1.46935;
       lon1_in[1] = 126.573; lat1_in[1] = 1.5091;
@@ -2604,16 +2436,16 @@ int main(int argc, char* argv[])
       lon2_in[1] = 125;   lat2_in[1] = 2;
       lon2_in[2] = 127.5; lat2_in[2] = 2;
       lon2_in[3] = 127.5; lat2_in[3] = 0;
-      break;
+      break;      
 
-    case 11:
+    case 11:      
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 10: Cubic sphere grid at tile = 3, point (i=24,j=1)
           with N45 at (i=51,j=46)
-       box 1:
-       box 2:
-       out  :
+       box 1: 
+       box 2: 
+       out  : 
 
       ****************************************************************/
       nlon1 = 1;
@@ -2627,7 +2459,7 @@ int main(int argc, char* argv[])
       lon1_in[1] = 170.0; lat1_in[1] = 87.92;
       lon1_in[2] = 260.0; lat1_in[2] = 87.92;
       lon1_in[3] = 215.0;  lat1_in[3] = 87.06;
-
+      
 /*       lon1_in[0] = 35.0; lat1_in[0] = 87.06; */
 /*       lon1_in[1] = 80.0; lat1_in[1] = 87.92; */
 /*       lon1_in[2] = 125.0; lat1_in[2] = 87.06; */
@@ -2642,7 +2474,7 @@ int main(int argc, char* argv[])
       lon2_in[1] = 170;   lat2_in[1] = 88;
       lon2_in[2] = 167.5; lat2_in[2] = 90;
       lon2_in[3] = 170;   lat2_in[3] = 90;
-
+      
 /*       nlon1 = 3; */
 /*       nlat1 = 2; */
 /*       nlon2 = 1; */
@@ -2683,13 +2515,13 @@ int main(int argc, char* argv[])
 /*       lon2_in[2] = 305;   lat2_in[2] = -32; */
 /*       lon2_in[3] = 307.5; lat2_in[3] = -32; */
 
-       nlon1 = 2;
-       nlat1 = 2;
-       nlon2 = 1;
+       nlon1 = 2; 
+       nlat1 = 2; 
+       nlon2 = 1; 
        nlat2 = 1;
       n1_in = (nlon1+1)*(nlat1+1);
       n2_in = (nlon2+1)*(nlat2+1);
-
+       
       lon1_in[0] = 111.3; lat1_in[0] = 1.591;
       lon1_in[1] = 109.7; lat1_in[1] = 2.926;
       lon1_in[2] = 108.2; lat1_in[2] = 4.256;
@@ -2704,16 +2536,16 @@ int main(int argc, char* argv[])
       lon2_in[1] = 110;   lat2_in[1] = 0;
       lon2_in[2] = 107.5; lat2_in[2] = 2;
       lon2_in[3] = 110;   lat2_in[3] = 2;
-
-      break;
-
+      
+      break;      
+      
     case 12:
       /****************************************************************
 
        test : create_xgrid_great_circle
        box 1: (20,10), (20,12), (22,12), (22,10)
        box 2: (21,11), (21,14), (24,14), (24,11)
-       out  : (21, 12.0018), (22, 12), (22, 11.0033), (21, 11)
+       out  : (21, 12.0018), (22, 12), (22, 11.0033), (21, 11) 
 
       ****************************************************************/
       nlon1 = 2;
@@ -2722,7 +2554,7 @@ int main(int argc, char* argv[])
       nlat2 = 3;
       n1_in = (nlon1+1)*(nlat1+1);
       n2_in = (nlon2+1)*(nlat2+1);
-
+      
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
       for(j=0; j<=nlat1; j++) for(i=0; i<=nlon1; i++){
 	lon1_in[j*(nlon1+1)+i] = 20.0 + (i-1)*2.0;
@@ -2732,7 +2564,7 @@ int main(int argc, char* argv[])
 	lon2_in[j*(nlon2+1)+i] = 19.0 + (i-1)*2.0;
 	lat2_in[j*(nlon2+1)+i] = 9.0 + (j-1)*2.0;
       }
-
+	
       break;
 
     case 13:
@@ -2752,7 +2584,7 @@ int main(int argc, char* argv[])
 /*       lon2_in[1] = ; lat2_in[1] = ; */
 /*       lon2_in[2] = ; lat2_in[2] = ; */
 /*       lon2_in[3] = ; lat2_in[3] = ;     */
-
+      
 /*       lon1_in[0] = 1.35536; lat1_in[0] = 1.16251; */
 /*       lon1_in[1] = 1.36805; lat1_in[1] = 1.15369; */
 /*       lon1_in[2] = 1.37843; lat1_in[2] = 1.16729; */
@@ -2778,237 +2610,11 @@ int main(int argc, char* argv[])
       lon2_in[0] = 120.369415056522087; lat2_in[0] = 16.752176828509153;
       lon2_in[1] = 119.999999999999986; lat2_in[1] = 16.752505523196167;
       lon2_in[2] = 120.369415056522087; lat2_in[2] = 16.397797949548146;
-      lon2_in[3] = 119.999999999999986; lat2_in[3] = 16.398120477217255;
-
-      break;
-
-    case 14:
-      /****************************************************************
-       test clip_2dx2d_great_cirle case 14: Cubic sphere grid at tile = 3, point (i=24,j=1)
-         identical grid boxes 
-      ****************************************************************/
-      /*
-      nlon1 = 1;
-      nlat1 = 1;
-      nlon2 = 1;
-      nlat2 = 1;
-      n1_in = (nlon1+1)*(nlat1+1);
-      n2_in = (nlon2+1)*(nlat2+1);
-
-      lon1_in[0] = 350.0; lat1_in[0] = 90.00;
-      lon1_in[1] = 170.0; lat1_in[1] = 87.92;
-      lon1_in[2] = 260.0; lat1_in[2] = 87.92;
-      lon1_in[3] = 215.0; lat1_in[3] = 87.06;
-
-      lon2_in[0] = 350.0; lat2_in[0] = 90.00;
-      lon2_in[1] = 170.0; lat2_in[1] = 87.92;
-      lon2_in[2] = 260.0; lat2_in[2] = 87.92;
-      lon2_in[3] = 215.0; lat2_in[3] = 87.06;
-      */
-      n1_in = 4; n2_in = 4;
-
-      //double lon1_14[] = {82.400,82.400,262.400,262.400,326.498,379.641};
-      //double lat1_14[] = {89.835,90.000, 90.000, 89.847, 89.648, 89.642};
-      double lon1_14[] = {350.,170.,260.,215.};
-      double lat1_14[] = {90.,87.92,87.92,87.06};
-      //double lon1_14[] = {82.400,262.400,326.498};
-      //double lat1_14[] = {89.835, 90.000, 89.648};
-      memcpy(lon1_in,lon1_14,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_14,sizeof(lat1_in));
-      memcpy(lon2_in,lon1_14,sizeof(lon2_in));
-      memcpy(lat2_in,lat1_14,sizeof(lat2_in));
-      break;
-
-    case 15:
-      n1_in = 6; n2_in = 5;
-      double lon1_15[] = {145.159, 198.302, 262.400, 262.400,  82.400,  82.400};
-      double lat1_15[] = { 89.642,  89.648,  89.847,  90.000,  90.000,  89.835};
-
-      double lon2_15[] = {150.000, 177.824, 240.000, 240.000, 150.000};
-      double lat2_15[] = { 89.789,  89.761,  89.889,  90.000,  90.000};
-      memcpy(lon1_in,lon1_15,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_15,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_15,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_15,sizeof(lat2_in));
-      //Must give the second box
-      break;
-
-    case 16:
-      /*Must give [[-57.748, -30, -30, -97.6, -97.6],
-                   [89.876, 89.891, 90, 90, 89.9183]]*/ 
-      n1_in = 6; n2_in = 5;
-      double lon1_16[] = {82.400,  82.400, 262.400, 262.400, 326.498, 379.641};
-      double lat1_16[] = {89.835,  90.000,  90.000,  89.847,  89.648,  89.642};
-      double lon2_16[] = {302.252, 330.000, 330.000, 240.000, 240.000};
-      double lat2_16[] = {89.876,  89.891,  90.000,  90.000,  89.942};
-      memcpy(lon1_in,lon1_16,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_16,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_16,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_16,sizeof(lat2_in));
-      break;
-
-    case 17:
-      /*Must give the second square
-	 -30, -2.252, 60, 60, -30,
-	 89.891, 89.876, 89.942, 90, 90,
-      */
-      n1_in = 6; n2_in = 5;
-      lon1_in[0]=82.400;  lon1_in[1]=82.400; lon1_in[2]=262.400; lon1_in[3]=262.400; lon1_in[4]=326.498; lon1_in[5]=379.641;
-      lat1_in[0]=89.835;  lat1_in[1]=90.000; lat1_in[2]=90.000;  lat1_in[3]=89.847;  lat1_in[4]=89.648;  lat1_in[5]=89.642;
-
-      double lon2_17[] = {-30.000,  -2.252,  60.000,  60.000, -30.000};
-      double lat2_17[] = { 89.891,  89.876,  89.942,  90.000,  90.000};
-      memcpy(lon2_in,lon2_17,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_17,sizeof(lat2_in));
-      break;
-
-    case 18:
-      n1_in = 6; n2_in = 5;
-      double lon1_18[] = {82.400,  82.400, 262.400, 262.400, 326.498, 379.641};
-      double lat1_18[] = {89.835,  90.000,  90.000,  89.847,  89.648,  89.642};
-
-      double lon2_18[] = {150.000, 177.824, 240.000, 240.000, 150.000};
-      double lat2_18[] = {89.789,  89.761,  89.889,  90.000,  90.000};
-      memcpy(lon1_in,lon1_18,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_18,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_18,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_18,sizeof(lat2_in));
-      break;
-      /*Must give nothing*/
-    case 19:
-      /****************************************************************
-        test clip_2dx2d 2: two boxes that include the North Pole 
-                           one has vertices on the tripolar fold
-                           the other is totally outside the first
-                           This actually happens for some stretched grid
-                           configurations  mosaic_c256r25tlat32.0_om4p25 
-        The test gives wrong answers!
-      ****************************************************************/
-      n1_in = 6; n2_in = 5;
-      double lon1_19[] = {145.159, 198.302, 262.400, 262.400,  82.400,  82.400};
-      double lat1_19[] = {89.642,  89.648,  89.847,  90.000,  90.000,  89.835};
-
-      double lon2_19[] = {-30.000,  -2.176,  60.000,  60.000, -30.000};
-      double lat2_19[] = {89.789,  89.761,  89.889,  90.000,  90.000};
-      memcpy(lon1_in,lon1_19,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_19,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_19,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_19,sizeof(lat2_in));
-      break;
-
-    case 20:
-      /*Must give
- n_out= 5 
- 122.176, 150, 150, 82.4, 82.4,
- 89.761, 89.789, 90, 90, 89.8429,
-       */      n1_in = 6; n2_in = 5;
-      double lon1_20[] = {145.159, 198.302, 262.400, 262.400,  82.400,  82.400};
-      double lat1_20[] = {89.642,  89.648,  89.847,  90.000,  90.000,  89.835};
-
-      double lon2_20[] = {122.176, 150.000, 150.000,  60.000,  60.000};
-      double lat2_20[] = { 89.761,  89.789,  90.000,  90.000,  89.889};
-      memcpy(lon1_in,lon1_20,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_20,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_20,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_20,sizeof(lat2_in));
-      break;
-
-    case 21:
-      /*Must give
- n_out= 5 
- 60.000,  82.400,  82.400,  60.000],
- 89.889,  89.843,  90.000,  90.000]
-       */      
-      n1_in = 6; n2_in = 5;
-      double lon1_21[] = {82.400,  82.400, 262.400, 262.400, 326.498, 379.641};
-      double lat1_21[] = {89.835,  90.000,  90.000,  89.847,  89.648,  89.642};
-
-      double lon2_21[] = {122.176, 150.000, 150.000,  60.000,  60.000};
-      double lat2_21[] = { 89.761,  89.789,  90.000,  90.000,  89.889};
-      memcpy(lon1_in,lon1_21,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_21,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_21,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_21,sizeof(lat2_in));
-      break;
-
-    case 26:
-      /*Side crosses SP (Right cell).
-	Must give same box
-      */      
-      n1_in = 4; n2_in = 4;
-      double lon1_22[] = {209.68793552504,158.60256162113,82.40000000000,262.40000000000};
-      double lat1_22[] = {-89.11514201451,-89.26896927380,-89.82370183256, -89.46584623220};
-
-      double lon2_22[] = {209.68793552504,158.60256162113,82.40000000000,262.40000000000};
-      double lat2_22[] = {-89.11514201451,-89.26896927380,-89.82370183256, -89.46584623220};
-      memcpy(lon1_in,lon1_22,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_22,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_22,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_22,sizeof(lat2_in));
-      break;
-
-    case 23:
-      /*Side does not cross SP (Right cell).
-	Must give same box
-      */      
+      lon2_in[3] = 119.999999999999986; lat2_in[3] = 16.398120477217255;      
       
-      n1_in = 4; n2_in = 4;
-      double lon1_23[] = {158.60256162113,121.19651597620,82.40000000000,82.40000000000};
-      double lat1_23[] = {-89.26896927380,-88.85737639760,-89.10746816044,-89.82370183256};
-
-      double lon2_23[] = {158.60256162113,121.19651597620,82.40000000000,82.40000000000};
-      double lat2_23[] = {-89.26896927380,-88.85737639760,-89.10746816044,-89.82370183256};
-      memcpy(lon1_in,lon1_23,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_23,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_23,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_23,sizeof(lat2_in));
       break;
 
-    case 24:
-      /*Side crosses SP (Left cell). Added twin poles.
-	Must give the same box
-      */      
-      n1_in = 6; n2_in = 6;
-      double lon1_24[] = {262.40000000000,262.40000000000,82.4,82.4,6.19743837887,-44.88793552504};
-      double lat1_24[] = {-89.46584623220,-90.0,         -90.0,-89.82370183256, -89.26896927380, -89.11514201451};
-
-      double lon2_24[] = {262.40000000000,262.40000000000,82.4,82.4,6.19743837887,-44.88793552504};
-      double lat2_24[] = {-89.46584623220,-90.0,         -90.0,-89.82370183256, -89.26896927380, -89.11514201451};
-      memcpy(lon1_in,lon1_24,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_24,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_24,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_24,sizeof(lat2_in));
-      break;
-    case 25:
-      /*Side crosses SP (Left cell). 
-	Must givethe same box
-      */      
-      n1_in = 4; n2_in = 4;
-      double lon1_25[] = {262.40000000000,82.4,6.19743837887,-44.88793552504};
-      double lat1_25[] = {-89.46584623220, -89.82370183256, -89.26896927380, -89.11514201451};
-
-      double lon2_25[] = {262.40000000000,82.4,6.19743837887,-44.88793552504};
-      double lat2_25[] = {-89.46584623220, -89.82370183256, -89.26896927380, -89.11514201451};
-      memcpy(lon1_in,lon1_25,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_25,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_25,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_25,sizeof(lat2_in));
-      break;
-    case 22:
-      /*Side does not cross SP (Left cell).
-	Must give same box
-      */       
-      n1_in = 4; n2_in = 4;
-      double lon1_26[] = {82.4,82.4,43.60348402380,6.19743837887};
-      double lat1_26[] = {-89.82370183256, -89.10746816044, -88.85737639760, -89.26896927380};
-
-      double lon2_26[] = {82.4,82.4,43.60348402380,6.19743837887};
-      double lat2_26[] = {-89.82370183256, -89.10746816044, -88.85737639760, -89.26896927380};
-      memcpy(lon1_in,lon1_26,sizeof(lon1_in));
-      memcpy(lat1_in,lat1_26,sizeof(lat1_in));
-      memcpy(lon2_in,lon2_26,sizeof(lon2_in));
-      memcpy(lat2_in,lat2_26,sizeof(lat2_in));
-      break;
+      
     default:
       error_handler("test_create_xgrid: incorrect case number");
     }
@@ -3021,13 +2627,14 @@ int main(int argc, char* argv[])
     for(i=0; i<n2_in; i++) {
       lon2_in[i] *= D2R; lat2_in[i] *=D2R;
     }
-
-
+    
+  
     printf("\n*********************************************************\n");
-    printf("               Case %d                                    \n", n);
+    printf("\n               Case %d                                    \n", n);
+    printf("\n*********************************************************\n");
 
 
-    if( n > 10 && n <= 14) {
+    if( n > 10 ) {
       int nxgrid;
       int *i1, *j1, *i2, *j2;
       double *xarea, *xclon, *xclat, *mask1;
@@ -3042,17 +2649,18 @@ int main(int argc, char* argv[])
       xclat = (double *)malloc(MAXXGRID*sizeof(double));
 
       for(i=0; i<nlon1*nlat1; i++) mask1[i] = 1.0;
-
+      
       nxgrid = create_xgrid_great_circle(&nlon1, &nlat1, &nlon2, &nlat2, lon1_in, lat1_in,
 					 lon2_in, lat2_in, mask1, i1, j1, i2, j2,
 					 xarea, xclon, xclat);
-      printf("     First input grid box longitude, latitude   \n");
+      printf("\n*********************************************************\n");
+      printf("\n     First input grid box longitude, latitude   \n \n");
       for(i=0; i<n1_in; i++) printf(" %g,  %g \n", lon1_in[i]*R2D, lat1_in[i]*R2D);
-
-      printf("     Second input grid box longitude, latitude \n");
+  
+      printf("\n     Second input grid box longitude, latitude \n \n");
       for(i=0; i<n2_in; i++) printf(" %g,  %g \n", lon2_in[i]*R2D, lat2_in[i]*R2D);
 
-      printf("  Number of exchange grid is %d\n", nxgrid);
+      printf("\n  Number of exchange grid is %d\n", nxgrid);
       for(i=0; i<nxgrid; i++) {
 	printf("(i1,j1)=(%d,%d), (i2,j2)=(%d, %d), xgrid_area=%g, xgrid_clon=%g, xgrid_clat=%g\n",
 	       i1[i], j1[i], i2[i], j2[i], xarea[i], xclon[i], xclat[i]);
@@ -3064,17 +2672,17 @@ int main(int argc, char* argv[])
 	double area_sum;
 	int    i;
 	area_sum = 0.0;
-
+	
 	for(i=0; i<nxgrid; i++) {
 	  area_sum+= xarea[i];
 	}
 
 	area1 = (double *)malloc((nlon1)*(nlat1)*sizeof(double));
-	get_grid_great_circle_area_(&nlon1, &nlat1, lon1_in, lat1_in, area1);
+	get_grid_great_circle_area_(&nlon1, &nlat1, lon1_in, lat1_in, area1);      
 
 	printf("xgrid area sum is %g, grid 1 area is %g\n", area_sum, area1[0]);
       }
-
+	
       printf("\n");
       free(i1);
       free(i2);
@@ -3083,75 +2691,25 @@ int main(int argc, char* argv[])
       free(xarea);
       free(xclon);
       free(xclat);
-      free(mask1);
-    }
-    else if(n>14) {
-     // latlon2xyz(n1_in, lon1_in, lat1_in, x1_in, y1_in, z1_in);
-     // latlon2xyz(n2_in, lon2_in, lat2_in, x2_in, y2_in, z2_in);
-
-      n_out = clip_2dx2d(lon1_in, lat1_in, n1_in, lon2_in, lat2_in, n2_in, lon_out, lat_out);
-
-      n1_in = fix_lon(lon1_in, lat1_in, n1_in, M_PI);
-      n2_in = fix_lon(lon2_in, lat2_in, n2_in, M_PI);
-      n_out = fix_lon(lon_out, lat_out, n_out, M_PI);
-
-      double area1 = poly_area (lon1_in, lat1_in, n1_in );
-      double area2 = poly_area (lon2_in, lat2_in, n2_in );
-      double area_out = poly_area (lon_out, lat_out, n_out );
-
-      printf("     First input grid box longitude, latitude, area= %g \n",area1);
-      for(i=0; i<n1_in; i++) printf(" %g,", lon1_in[i]*R2D);
-      printf("\n");
-      for(i=0; i<n1_in; i++) printf(" %g,", lat1_in[i]*R2D);
-      printf("\n");
-
-      printf("     Second input grid box longitude, latitude,area= %g \n",area2);
-      for(i=0; i<n2_in; i++) printf(" %g,", lon2_in[i]*R2D);
-      printf("\n");
-      for(i=0; i<n2_in; i++) printf(" %g,", lat2_in[i]*R2D);
-      printf("\n");
-      
-
-      printf("     output clip grid box longitude, latitude, area= %g \n ",area_out);
-      printf("n_out= %d \n",n_out);
-      for(i=0; i<n_out; i++) printf(" %g,", lon_out[i]*R2D);
-      printf("\n");
-      for(i=0; i<n_out; i++) printf(" %g,", lat_out[i]*R2D);
-      printf("\n");
-      if(area1>1.0e14 || area2>1.0e14 || area_out>1.0e14) printf("Error in calculating area !\n");  
-      if(n==16 || n==20) printf("Must result n_out=5!\n");
-      if(n==21) printf("Must result n_out=4!\n");
-      if(n==15 || n==17) printf("Must result the second box!\n");
-      if(n==18 || n==19) printf("Must result n_out=0!\n");
-      if(n==22 || n==23) printf("Same box! area22=area23\n");
-      if(n==24 || n==25 || n==26) printf("Same box! area24=area25=area26\n");
+      free(mask1);      
     }
     else {
       latlon2xyz(n1_in, lon1_in, lat1_in, x1_in, y1_in, z1_in);
       latlon2xyz(n2_in, lon2_in, lat2_in, x2_in, y2_in, z2_in);
-
+    
       n_out = clip_2dx2d_great_circle(x1_in, y1_in, z1_in, 4, x2_in, y2_in, z2_in, n2_in,
 				      x_out, y_out,  z_out);
       xyz2latlon(n_out, x_out, y_out, z_out, lon_out, lat_out);
 
       printf("\n*********************************************************\n");
       printf("\n     First input grid box longitude, latitude   \n \n");
-      for(i=0; i<n1_in; i++) printf(" %g,", lon1_in[i]*R2D);
-      printf("\n");
-      for(i=0; i<n1_in; i++) printf(" %g,", lat1_in[i]*R2D);
-      printf("\n");
-
+      for(i=0; i<n1_in; i++) printf(" %g,  %g \n", lon1_in[i]*R2D, lat1_in[i]*R2D);
+  
       printf("\n     Second input grid box longitude, latitude \n \n");
-      for(i=0; i<n2_in; i++) printf(" %g,", lon2_in[i]*R2D);
-      printf("\n");
-      for(i=0; i<n2_in; i++) printf(" %g,", lat2_in[i]*R2D);
-      printf("\n");
-
-      printf("\n     output clip grid box longitude, latitude for case %d \n \n",n);
-      printf("n_out= %d \n",n_out);
-      for(i=0; i<n_out; i++) printf(" %g,", lon_out[i]*R2D);
-      printf("\n");
-      for(i=0; i<n_out; i++) printf(" %g,", lat_out[i]*R2D);
+      for(i=0; i<n2_in; i++) printf(" %g,  %g \n", lon2_in[i]*R2D, lat2_in[i]*R2D);
+  
+      printf("\n     output clip grid box longitude, latitude for case 1 \n \n");
+      for(i=0; i<n_out; i++) printf(" %g,  %g \n", lon_out[i]*R2D, lat_out[i]*R2D);
       printf("\n");
     }
   }

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -1,3 +1,22 @@
+/***********************************************************************
+ *                   GNU Lesser General Public License
+ *
+ * This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+ *
+ * FRE-NCtools is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * FRE-NCtools is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FRE-NCTools.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ **********************************************************************/
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
@@ -5,7 +24,7 @@
 #include "create_xgrid.h"
 #include "constant.h"
 
-#define AREA_RATIO_THRESH (1.e-6)  
+#define AREA_RATIO_THRESH (1.e-6)
 #define MASK_THRESH       (0.5)
 #define EPSLN8            (1.e-8)
 #define EPSLN30           (1.0e-30)
@@ -24,7 +43,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   int get_maxxgrid
   return constants MAXXGRID.
 *******************************************************************************/
-int get_maxxgrid(void)  
+int get_maxxgrid(void)
 {
   return MAXXGRID;
 }
@@ -49,7 +68,7 @@ void get_grid_area(const int *nlon, const int *nlat, const double *lon, const do
 {
   int nx, ny, nxp, i, j, n_in;
   double x_in[20], y_in[20];
-  
+
   nx = *nlon;
   ny = *nlat;
   nxp = nx + 1;
@@ -63,7 +82,7 @@ void get_grid_area(const int *nlon, const int *nlat, const double *lon, const do
     y_in[1] = lat[j*nxp+i+1];
     y_in[2] = lat[(j+1)*nxp+i+1];
     y_in[3] = lat[(j+1)*nxp+i];
-    n_in = fix_lon(x_in, y_in, 4, M_PI);    
+    n_in = fix_lon(x_in, y_in, 4, M_PI);
     area[j*nx+i] = poly_area(x_in, y_in, n_in);
   }
 
@@ -95,7 +114,7 @@ void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *
   z = (double *)malloc(nxp*nyp*sizeof(double));
 
   latlon2xyz(nxp*nyp, lon, lat, x, y, z);
-  
+
   for(j=0; j<ny; j++) for(i=0; i < nx; i++) {
     /* clockwise */
     n0 = j*nxp+i;
@@ -114,7 +133,7 @@ void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *
   free(x);
   free(y);
   free(z);
-  
+
 };  /* get_grid_great_circle_area */
 
 
@@ -122,7 +141,7 @@ void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double 
 {
   int nx, ny, nxp, i, j, n_in;
   double x_in[20], y_in[20];
-  
+
   nx = *nlon;
   ny = *nlat;
   nxp = nx + 1;
@@ -136,7 +155,7 @@ void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double 
     y_in[1] = lat[j*nxp+i+1];
     y_in[2] = lat[(j+1)*nxp+i+1];
     y_in[3] = lat[(j+1)*nxp+i];
-    n_in = fix_lon(x_in, y_in, 4, M_PI);    
+    n_in = fix_lon(x_in, y_in, 4, M_PI);
     area[j*nx+i] = poly_area_dimensionless(x_in, y_in, n_in);
   }
 
@@ -148,7 +167,7 @@ void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon
 {
   int nx, ny, nxp, i, j, n_in;
   double x_in[20], y_in[20];
-  
+
   nx = *nlon;
   ny = *nlat;
   nxp = nx + 1;
@@ -172,19 +191,19 @@ void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon
   void create_xgrid_1dx2d_order1
   This routine generate exchange grids between two grids for the first order
   conservative interpolation. nlon_in,nlat_in,nlon_out,nlat_out are the size of the grid cell
-  and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds. 
+  and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds.
 *******************************************************************************/
 int create_xgrid_1dx2d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
 			       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out, double *xgrid_area)
 {
   int nxgrid;
-  
+
   nxgrid = create_xgrid_1dx2d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
 			       i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
-    
-};  
+
+};
 
 int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
 			      const double *lat_in, const double *lon_out, const double *lat_out,
@@ -197,7 +216,7 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
   double ll_lon, ll_lat, ur_lon, ur_lat, x_in[MV], y_in[MV], x_out[MV], y_out[MV];
   double *area_in, *area_out, min_area;
   double *tmpx, *tmpy;
-  
+
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
@@ -220,10 +239,10 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
      get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);
   else
     get_grid_area_no_adjust(nlon_in, nlat_in, tmpx, tmpy, area_in);
-  
-  get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);  
+
+  get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);
   free(tmpx);
-  free(tmpy);  
+  free(tmpy);
 
   for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
 
@@ -232,7 +251,7 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
       int n_in, n_out;
       double Xarea;
-      
+
       y_in[0] = lat_out[j2*nx2p+i2];
       y_in[1] = lat_out[j2*nx2p+i2+1];
       y_in[2] = lat_out[(j2+1)*nx2p+i2+1];
@@ -247,7 +266,7 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
       x_in[2] = lon_out[(j2+1)*nx2p+i2+1];
       x_in[3] = lon_out[(j2+1)*nx2p+i2];
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
-      
+
       if ( (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
 	Xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
 	min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
@@ -266,9 +285,9 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
 
   free(area_in);
   free(area_out);
-  
+
   return nxgrid;
-  
+
 }; /* create_xgrid_1dx2d_order1 */
 
 
@@ -300,7 +319,7 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   double ll_lon, ll_lat, ur_lon, ur_lat, x_in[MV], y_in[MV], x_out[MV], y_out[MV];
   double *area_in, *area_out, min_area;
   double *tmpx, *tmpy;
-  
+
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
@@ -318,11 +337,11 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
     tmpx[j1*nx1p+i1] = lon_in[i1];
     tmpy[j1*nx1p+i1] = lat_in[j1];
   }
-  get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);     
-  get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);  
+  get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);
+  get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);
   free(tmpx);
-  free(tmpy);    
-  
+  free(tmpy);
+
   for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
 
     ll_lon = lon_in[i1];   ll_lat = lat_in[j1];
@@ -330,7 +349,7 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
     for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
       int n_in, n_out;
       double xarea, lon_in_avg;
-      
+
       y_in[0] = lat_out[j2*nx2p+i2];
       y_in[1] = lat_out[j2*nx2p+i2+1];
       y_in[2] = lat_out[(j2+1)*nx2p+i2+1];
@@ -346,11 +365,11 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
       x_in[3] = lon_out[(j2+1)*nx2p+i2];
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
       lon_in_avg = avgval_double(n_in, x_in);
-      
+
       if (  (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];	
+	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
         min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	if(xarea/min_area > AREA_RATIO_THRESH ) {	  
+	if(xarea/min_area > AREA_RATIO_THRESH ) {
 	  xgrid_area[nxgrid] = xarea;
 	  xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
 	  xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
@@ -366,9 +385,9 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   }
   free(area_in);
   free(area_out);
-  
+
   return nxgrid;
-  
+
 }; /* create_xgrid_1dx2d_order2 */
 
 /*******************************************************************************
@@ -376,7 +395,7 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   This routine generate exchange grids between two grids for the first order
   conservative interpolation. nlon_in,nlat_in,nlon_out,nlat_out are the size of the grid cell
   and lon_out,lat_out are 1-D grid bounds, lon_in,lat_in are geographic grid location of grid cell bounds.
-  mask is on grid lon_in/lat_in. 
+  mask is on grid lon_in/lat_in.
 *******************************************************************************/
 int create_xgrid_2dx1d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
@@ -384,12 +403,12 @@ int create_xgrid_2dx1d_order1_(const int *nlon_in, const int *nlat_in, const int
 			       int *j_out, double *xgrid_area)
 {
   int nxgrid;
-  
+
   nxgrid = create_xgrid_2dx1d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
 			       i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
-    
-};  
+
+};
 int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
 			      const double *lat_in, const double *lon_out, const double *lat_out,
 			      const double *mask_in, int *i_in, int *j_in, int *i_out,
@@ -401,7 +420,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
   double ll_lon, ll_lat, ur_lon, ur_lat, x_in[MV], y_in[MV], x_out[MV], y_out[MV];
   double *area_in, *area_out, min_area;
   double *tmpx, *tmpy;
-  
+
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
@@ -418,12 +437,12 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
     tmpx[j2*nx2p+i2] = lon_out[i2];
     tmpy[j2*nx2p+i2] = lat_out[j2];
   }
-  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);     
-  get_grid_area(nlon_out, nlat_out, tmpx, tmpy, area_out);  
+  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);
+  get_grid_area(nlon_out, nlat_out, tmpx, tmpy, area_out);
 
   free(tmpx);
   free(tmpy);
-  
+
   for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
 
     ll_lon = lon_out[i2];   ll_lat = lat_out[j2];
@@ -431,7 +450,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n_in, n_out;
       double Xarea;
-      
+
       y_in[0] = lat_in[j1*nx1p+i1];
       y_in[1] = lat_in[j1*nx1p+i1+1];
       y_in[2] = lat_in[(j1+1)*nx1p+i1+1];
@@ -447,7 +466,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
       x_in[3] = lon_in[(j1+1)*nx1p+i1];
 
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
-      
+
       if ( (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
 	Xarea = poly_area ( x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
 	min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
@@ -466,9 +485,9 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
 
   free(area_in);
   free(area_out);
-  
+
   return nxgrid;
-  
+
 }; /* create_xgrid_2dx1d_order1 */
 
 
@@ -477,7 +496,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
   This routine generate exchange grids between two grids for the second order
   conservative interpolation. nlon_in,nlat_in,nlon_out,nlat_out are the size of the grid cell
   and lon_out,lat_out are 1-D grid bounds, lon_in,lat_in are geographic grid location of grid cell bounds.
-  mask is on grid lon_in/lat_in. 
+  mask is on grid lon_in/lat_in.
 ********************************************************************************/
 int create_xgrid_2dx1d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
@@ -503,7 +522,7 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
   double *tmpx, *tmpy;
   double *area_in, *area_out, min_area;
   double  lon_in_avg;
-  
+
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
@@ -521,12 +540,12 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
     tmpx[j2*nx2p+i2] = lon_out[i2];
     tmpy[j2*nx2p+i2] = lat_out[j2];
   }
-  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);     
-  get_grid_area(nlon_out, nlat_out, tmpx, tmpy, area_out);  
+  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);
+  get_grid_area(nlon_out, nlat_out, tmpx, tmpy, area_out);
 
   free(tmpx);
-  free(tmpy);  
-  
+  free(tmpy);
+
   for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
 
     ll_lon = lon_out[i2];   ll_lat = lat_out[j2];
@@ -534,7 +553,7 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n_in, n_out;
       double xarea;
-      
+
       y_in[0] = lat_in[j1*nx1p+i1];
       y_in[1] = lat_in[j1*nx1p+i1+1];
       y_in[2] = lat_in[(j1+1)*nx1p+i1+1];
@@ -551,11 +570,11 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
 
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
       lon_in_avg = avgval_double(n_in, x_in);
-      
+
       if (  (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];	
+	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
 	min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	if(xarea/min_area > AREA_RATIO_THRESH ) {	  
+	if(xarea/min_area > AREA_RATIO_THRESH ) {
 	  xgrid_area[nxgrid] = xarea;
 	  xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
 	  xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
@@ -571,10 +590,10 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
   }
 
   free(area_in);
-  free(area_out);  
-  
+  free(area_out);
+
   return nxgrid;
-  
+
 }; /* create_xgrid_2dx1d_order2 */
 
 /*******************************************************************************
@@ -591,12 +610,12 @@ int create_xgrid_2dx2d_order1_(const int *nlon_in, const int *nlat_in, const int
 			       int *j_out, double *xgrid_area)
 {
   int nxgrid;
-  
+
   nxgrid = create_xgrid_2dx2d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
 			       i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
-    
-};  
+
+};
 #endif
 int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
@@ -604,37 +623,37 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
 			      int *j_out, double *xgrid_area)
 {
 
-#define MAX_V 8  
+#define MAX_V 8
   int nx1, nx2, ny1, ny2, nx1p, nx2p, nxgrid;
   double *area_in, *area_out;
   int nblocks =1;
   int *istart2=NULL, *iend2=NULL;
   int npts_left, nblks_left, pos, m, npts_my, ij;
-  double *lon_out_min_list,*lon_out_max_list,*lon_out_avg,*lat_out_min_list,*lat_out_max_list;  
+  double *lon_out_min_list,*lon_out_max_list,*lon_out_avg,*lat_out_min_list,*lat_out_max_list;
   double *lon_out_list, *lat_out_list;
   int *pnxgrid=NULL, *pstart;
   int *pi_in=NULL, *pj_in=NULL, *pi_out=NULL, *pj_out=NULL;
   double *pxgrid_area=NULL;
   int    *n2_list;
   int nthreads, nxgrid_block_max;
-  
+
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
-  ny2 = *nlat_out;  
+  ny2 = *nlat_out;
   nx1p = nx1 + 1;
   nx2p = nx2 + 1;
 
   area_in  = (double *)malloc(nx1*ny1*sizeof(double));
   area_out = (double *)malloc(nx2*ny2*sizeof(double));
-  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);     
+  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);
   get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);
 
   nthreads = 1;
 #if defined(_OPENMP)
 #pragma omp parallel
   nthreads = omp_get_num_threads();
-#endif  
+#endif
 
   nblocks = nthreads;
 
@@ -645,7 +664,7 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
   pnxgrid = (int *)malloc(nblocks*sizeof(int));
 
   nxgrid_block_max = MAXXGRID/nblocks;
-  
+
   for(m=0; m<nblocks; m++) {
     pnxgrid[m] = 0;
     pstart[m] = m*nxgrid_block_max;
@@ -665,7 +684,7 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     pj_out = (int *)malloc(MAXXGRID*sizeof(int));
     pxgrid_area = (double *)malloc(MAXXGRID*sizeof(double));
   }
-  
+
   npts_left = nx2*ny2;
   nblks_left = nblocks;
   pos = 0;
@@ -689,8 +708,8 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) shared(nx2,ny2,nx2p,lon_out,lat_out,lat_out_min_list, \
                                               lat_out_max_list,lon_out_min_list,lon_out_max_list, \
-                                              lon_out_avg,n2_list,lon_out_list,lat_out_list) 
-#endif                        
+                                              lon_out_avg,n2_list,lon_out_list,lat_out_list)
+#endif
   for(ij=0; ij<nx2*ny2; ij++){
     int i2, j2, n, n0, n1, n2, n3, n2_in, l;
     double x2_in[MV], y2_in[MV];
@@ -703,7 +722,7 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     x2_in[1] = lon_out[n1]; y2_in[1] = lat_out[n1];
     x2_in[2] = lon_out[n2]; y2_in[2] = lat_out[n2];
     x2_in[3] = lon_out[n3]; y2_in[3] = lat_out[n3];
-    
+
     lat_out_min_list[n] = minval_double(4, y2_in);
     lat_out_max_list[n] = maxval_double(4, y2_in);
     n2_in = fix_lon(x2_in, y2_in, 4, M_PI);
@@ -715,7 +734,7 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     for(l=0; l<n2_in; l++) {
       lon_out_list[n*MAX_V+l] = x2_in[l];
       lat_out_list[n*MAX_V+l] = y2_in[l];
-    }    
+    }
   }
 
 nxgrid = 0;
@@ -726,16 +745,16 @@ nxgrid = 0;
                                               n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
                                               lon_out_max_list,lon_out_avg,area_in,area_out, \
                                               pxgrid_area,pnxgrid,pi_in,pj_in,pi_out,pj_out,pstart,nthreads)
-#endif  
+#endif
   for(m=0; m<nblocks; m++) {
     int i1, j1, ij;
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n0, n1, n2, n3, l,n1_in;
       double lat_in_min,lat_in_max,lon_in_min,lon_in_max,lon_in_avg;
       double x1_in[MV], y1_in[MV], x_out[MV], y_out[MV];
- 
+
       n0 = j1*nx1p+i1;       n1 = j1*nx1p+i1+1;
-      n2 = (j1+1)*nx1p+i1+1; n3 = (j1+1)*nx1p+i1;      
+      n2 = (j1+1)*nx1p+i1+1; n3 = (j1+1)*nx1p+i1;
       x1_in[0] = lon_in[n0]; y1_in[0] = lat_in[n0];
       x1_in[1] = lon_in[n1]; y1_in[1] = lat_in[n1];
       x1_in[2] = lon_in[n2]; y1_in[2] = lat_in[n2];
@@ -750,10 +769,10 @@ nxgrid = 0;
 	int n_out, i2, j2, n2_in;
 	double xarea, dx, lon_out_min, lon_out_max;
 	double x2_in[MAX_V], y2_in[MAX_V];
-	
+
 	i2 = ij%nx2;
 	j2 = ij/nx2;
-	
+
 	if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
 	/* adjust x2_in according to lon_in_avg*/
 	n2_in = n2_list[ij];
@@ -762,7 +781,7 @@ nxgrid = 0;
 	  y2_in[l] = lat_out_list[ij*MAX_V+l];
 	}
 	lon_out_min = lon_out_min_list[ij];
-	lon_out_max = lon_out_max_list[ij];  
+	lon_out_max = lon_out_max_list[ij];
         dx = lon_out_avg[ij] - lon_in_avg;
 	if(dx < -M_PI ) {
 	  lon_out_min += TPI;
@@ -782,13 +801,13 @@ nxgrid = 0;
 	if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
           double min_area;
 	  int    nn;
-	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];	
+	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
 	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
 	  if( xarea/min_area > AREA_RATIO_THRESH ) {
 	    pnxgrid[m]++;
             if(pnxgrid[m]>= MAXXGRID/nthreads)
 	      error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
-	    nn = pstart[m] + pnxgrid[m]-1;	    
+	    nn = pstart[m] + pnxgrid[m]-1;
 
 	    pxgrid_area[nn] = xarea;
 	    pi_in[nn]       = i1;
@@ -796,9 +815,9 @@ nxgrid = 0;
 	    pi_out[nn]      = i2;
 	    pj_out[nn]      = j2;
 	  }
-	  
+
 	}
-	
+
       }
     }
   }
@@ -832,20 +851,20 @@ nxgrid = 0;
     free(pj_out);
     free(pxgrid_area);
   }
-  
+
   free(area_in);
-  free(area_out);  
+  free(area_out);
   free(lon_out_min_list);
   free(lon_out_max_list);
   free(lat_out_min_list);
   free(lat_out_max_list);
   free(lon_out_avg);
-  free(n2_list);  
+  free(n2_list);
   free(lon_out_list);
   free(lat_out_list);
 
   return nxgrid;
-  
+
 };/* get_xgrid_2Dx2D_order1 */
 
 /********************************************************************************
@@ -853,7 +872,7 @@ nxgrid = 0;
   This routine generate exchange grids between two grids for the second order
   conservative interpolation. nlon_in,nlat_in,nlon_out,nlat_out are the size of the grid cell
   and lon_in,lat_in, lon_out,lat_out are geographic grid location of grid cell bounds.
-  mask is on grid lon_in/lat_in. 
+  mask is on grid lon_in/lat_in.
 ********************************************************************************/
 #ifndef __AIX
 int create_xgrid_2dx2d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
@@ -874,26 +893,26 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
-#define MAX_V 8  
+#define MAX_V 8
   int nx1, nx2, ny1, ny2, nx1p, nx2p, nxgrid;
   double *area_in, *area_out;
   int ij, i1, j1;
-  double *lon_out_min_list,*lon_out_max_list,*lon_out_avg,*lat_out_min_list,*lat_out_max_list;  
+  double *lon_out_min_list,*lon_out_max_list,*lon_out_avg,*lat_out_min_list,*lat_out_max_list;
   double *lon_out_list, *lat_out_list;
   int    *n2_list;
   int mxxgrid;
-  
+
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
-  ny2 = *nlat_out;  
+  ny2 = *nlat_out;
   nx1p = nx1 + 1;
   nx2p = nx2 + 1;
   mxxgrid = get_maxxgrid();
 
   area_in  = (double *)malloc(nx1*ny1*sizeof(double));
   area_out = (double *)malloc(nx2*ny2*sizeof(double));
-  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);     
+  get_grid_area(nlon_in, nlat_in, lon_in, lat_in, area_in);
   get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);
 
   lon_out_min_list = (double *)malloc(nx2*ny2*sizeof(double));
@@ -907,8 +926,8 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) shared(nx2,ny2,nx2p,lon_out,lat_out,lat_out_min_list, \
                                               lat_out_max_list,lon_out_min_list,lon_out_max_list, \
-                                              lon_out_avg,n2_list,lon_out_list,lat_out_list) 
-#endif                        
+                                              lon_out_avg,n2_list,lon_out_list,lat_out_list)
+#endif
 nxgrid = 0;
 #pragma acc kernels copyin(lon_out[0:(nx2+1)*(ny2+1)], lat_out[0:(nx2+1)*(ny2+1)], mask_in[0:nx1*ny1], \
                            xgrid_area[0:mxxgrid], xgrid_clon[0:mxxgrid], xgrid_clat[0:mxxgrid], \
@@ -934,7 +953,7 @@ nxgrid = 0;
     x2_in[1] = lon_out[n1]; y2_in[1] = lat_out[n1];
     x2_in[2] = lon_out[n2]; y2_in[2] = lat_out[n2];
     x2_in[3] = lon_out[n3]; y2_in[3] = lat_out[n3];
-    
+
     lat_out_min_list[n] = minval_double(4, y2_in);
     lat_out_max_list[n] = maxval_double(4, y2_in);
     n2_in = fix_lon(x2_in, y2_in, 4, M_PI);
@@ -947,7 +966,7 @@ nxgrid = 0;
     for(l=0; l<n2_in; l++) {
       lon_out_list[n*MAX_V+l] = x2_in[l];
       lat_out_list[n*MAX_V+l] = y2_in[l];
-    }    
+    }
   }
 
 
@@ -958,15 +977,15 @@ nxgrid = 0;
                                               lon_out_max_list,lon_out_avg,area_in,area_out, \
                                               pxgrid_area,pnxgrid,pxgrid_clon,pxgrid_clat,pi_in, \
                                               pj_in,pi_out,pj_out,pstart,nthreads)
-#endif  
+#endif
 #pragma acc loop independent reduction(+:nxgrid) collapse(2)
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n0, n1, n2, n3, l,n1_in;
       double lat_in_min,lat_in_max,lon_in_min,lon_in_max,lon_in_avg;
       double x1_in[MV], y1_in[MV], x_out[MV], y_out[MV];
- 
+
       n0 = j1*nx1p+i1;       n1 = j1*nx1p+i1+1;
-      n2 = (j1+1)*nx1p+i1+1; n3 = (j1+1)*nx1p+i1;      
+      n2 = (j1+1)*nx1p+i1+1; n3 = (j1+1)*nx1p+i1;
       x1_in[0] = lon_in[n0]; y1_in[0] = lat_in[n0];
       x1_in[1] = lon_in[n1]; y1_in[1] = lat_in[n1];
       x1_in[2] = lon_in[n2]; y1_in[2] = lat_in[n2];
@@ -982,10 +1001,10 @@ nxgrid = 0;
 	int n_out, i2, j2, n2_in;
 	double xarea, dx, lon_out_min, lon_out_max;
 	double x2_in[MAX_V], y2_in[MAX_V];
-	
+
 	i2 = ij%nx2;
 	j2 = ij/nx2;
-	
+
 	if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
 	/* adjust x2_in according to lon_in_avg*/
 	n2_in = n2_list[ij];
@@ -995,7 +1014,7 @@ nxgrid = 0;
 	  y2_in[l] = lat_out_list[ij*MAX_V+l];
 	}
 	lon_out_min = lon_out_min_list[ij];
-	lon_out_max = lon_out_max_list[ij];  
+	lon_out_max = lon_out_max_list[ij];
         dx = lon_out_avg[ij] - lon_in_avg;
 	if(dx < -M_PI ) {
 	  lon_out_min += TPI;
@@ -1017,7 +1036,7 @@ nxgrid = 0;
 	n_out = 1;
 	if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
           double min_area;
-	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];	
+	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
 	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
 	  if( xarea/min_area > AREA_RATIO_THRESH ) {
 //            if(nxgrid>= MAXXGRID/nthreads)
@@ -1030,25 +1049,25 @@ nxgrid = 0;
 	    i_out[nxgrid]      = i2;
 	    j_out[nxgrid]      = j2;
 	    nxgrid++;
-	  }	  
+	  }
 	}
       }
     }
 }
 
   free(area_in);
-  free(area_out);  
+  free(area_out);
   free(lon_out_min_list);
   free(lon_out_max_list);
   free(lat_out_min_list);
   free(lat_out_max_list);
   free(lon_out_avg);
-  free(n2_list);  
+  free(n2_list);
   free(lon_out_list);
   free(lat_out_list);
 
   return nxgrid;
-  
+
 };/* get_xgrid_2Dx2D_order2 */
 
 
@@ -1067,7 +1086,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
   y_last = lat_in[n_in-1];
   inside_last = (x_last >= ll_lon);
   for (i_in=0,i_out=0;i_in<n_in;i_in++) {
- 
+
     /* if crossing LEFT boundary - output intersection */
     if ((inside=(lon_in[i_in] >= ll_lon))!=inside_last) {
       x_tmp[i_out] = ll_lon;
@@ -1090,7 +1109,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
   y_last = y_tmp[n_out-1];
   inside_last = (x_last <= ur_lon);
   for (i_in=0,i_out=0;i_in<n_out;i_in++) {
- 
+
     /* if crossing RIGHT boundary - output intersection */
     if ((inside=(x_tmp[i_in] <= ur_lon))!=inside_last) {
       lon_out[i_out]   = ur_lon;
@@ -1103,7 +1122,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
       lon_out[i_out]   = x_tmp[i_in];
       lat_out[i_out++] = y_tmp[i_in];
     }
-    
+
     x_last = x_tmp[i_in];
     y_last = y_tmp[i_in];
     inside_last = inside;
@@ -1115,7 +1134,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
   y_last = lat_out[n_out-1];
   inside_last = (y_last >= ll_lat);
   for (i_in=0,i_out=0;i_in<n_out;i_in++) {
- 
+
     /* if crossing BOTTOM boundary - output intersection */
     if ((inside=(lat_out[i_in] >= ll_lat))!=inside_last) {
       y_tmp[i_out]   = ll_lat;
@@ -1138,7 +1157,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
   y_last = y_tmp[n_out-1];
   inside_last = (y_last <= ur_lat);
   for (i_in=0,i_out=0;i_in<n_out;i_in++) {
- 
+
     /* if crossing TOP boundary - output intersection */
     if ((inside=(y_tmp[i_in] <= ur_lat))!=inside_last) {
       lat_out[i_out]   = ur_lat;
@@ -1155,7 +1174,7 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
     inside_last = inside;
   }
   return(i_out);
-}; /* clip */  
+}; /* clip */
 
 
 /*******************************************************************************
@@ -1164,8 +1183,8 @@ int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, 
 *******************************************************************************/
 
 #pragma acc routine seq
-int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in, 
-	 const double lon2_in[], const double lat2_in[], int n2_in, 
+int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
+	 const double lon2_in[], const double lat2_in[], int n2_in,
 	 double lon_out[], double lat_out[])
 {
   double lon_tmp[MV], lat_tmp[MV];
@@ -1210,12 +1229,12 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
 //	}
 	lon_out[i_out]   = (dx2*ds1 - dx1*ds2)/determ;
 	lat_out[i_out++] = (dy2*ds1 - dy1*ds2)/determ;
-	
+
 
       }
       if(inside) {
 	lon_out[i_out]   = x1_1;
-	lat_out[i_out++] = y1_1;	
+	lat_out[i_out++] = y1_1;
       }
       x1_0 = x1_1;
       y1_0 = y1_1;
@@ -1233,8 +1252,8 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
   }
   return(n_out);
 }; /* clip */
-    
-/*#define debug_test_create_xgrid*/  
+
+/*#define debug_test_create_xgrid*/
 
 #ifndef __AIX
 int create_xgrid_great_circle_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
@@ -1249,7 +1268,7 @@ int create_xgrid_great_circle_(const int *nlon_in, const int *nlat_in, const int
   return nxgrid;
 };
 #endif
-  
+
 int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
 			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
@@ -1265,11 +1284,11 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
   double *x2=NULL, *y2=NULL, *z2=NULL;
 
   double *area1, *area2, min_area;
-  
+
   nx1 = *nlon_in;
   ny1 = *nlat_in;
   nx2 = *nlon_out;
-  ny2 = *nlat_out;  
+  ny2 = *nlat_out;
   nxgrid = 0;
   nx1p = nx1 + 1;
   nx2p = nx2 + 1;
@@ -1283,26 +1302,26 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
   x2 = (double *)malloc(nx2p*ny2p*sizeof(double));
   y2 = (double *)malloc(nx2p*ny2p*sizeof(double));
   z2 = (double *)malloc(nx2p*ny2p*sizeof(double));
-  
+
   latlon2xyz(nx1p*ny1p, lon_in, lat_in, x1, y1, z1);
   latlon2xyz(nx2p*ny2p, lon_out, lat_out, x2, y2, z2);
-  
+
   area1  = (double *)malloc(nx1*ny1*sizeof(double));
   area2 = (double *)malloc(nx2*ny2*sizeof(double));
-  get_grid_great_circle_area(nlon_in, nlat_in, lon_in, lat_in, area1);     
-  get_grid_great_circle_area(nlon_out, nlat_out, lon_out, lat_out, area2); 
+  get_grid_great_circle_area(nlon_in, nlat_in, lon_in, lat_in, area1);
+  get_grid_great_circle_area(nlon_out, nlat_out, lon_out, lat_out, area2);
   n1_in = 4;
   n2_in = 4;
-  
+
   for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
     /* clockwise */
     n0 = j1*nx1p+i1;       n1 = (j1+1)*nx1p+i1;
-    n2 = (j1+1)*nx1p+i1+1; n3 = j1*nx1p+i1+1;      
+    n2 = (j1+1)*nx1p+i1+1; n3 = j1*nx1p+i1+1;
     x1_in[0] = x1[n0]; y1_in[0] = y1[n0]; z1_in[0] = z1[n0];
     x1_in[1] = x1[n1]; y1_in[1] = y1[n1]; z1_in[1] = z1[n1];
     x1_in[2] = x1[n2]; y1_in[2] = y1[n2]; z1_in[2] = z1[n2];
     x1_in[3] = x1[n3]; y1_in[3] = y1[n3]; z1_in[3] = z1[n3];
-      
+
     for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
       int n_out;
       double xarea;
@@ -1319,12 +1338,12 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
 	xarea = great_circle_area ( n_out, x_out, y_out, z_out ) * mask_in[j1*nx1+i1];
 	min_area = min(area1[j1*nx1+i1], area2[j2*nx2+i2]);
 	if( xarea/min_area > AREA_RATIO_THRESH ) {
-#ifdef debug_test_create_xgrid	  
+#ifdef debug_test_create_xgrid
 	  printf("(i2,j2)=(%d,%d), (i1,j1)=(%d,%d), xarea=%g\n", i2, j2, i1, j1, xarea);
 #endif
 	  xgrid_area[nxgrid] = xarea;
 	  xgrid_clon[nxgrid] = 0; /*z1l: will be developed very soon */
-	  xgrid_clat[nxgrid] = 0; 
+	  xgrid_clat[nxgrid] = 0;
 	  i_in[nxgrid]       = i1;
 	  j_in[nxgrid]       = j1;
 	  i_out[nxgrid]      = i2;
@@ -1336,9 +1355,9 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
     }
   }
 
-  
+
   free(area1);
-  free(area2);  
+  free(area2);
 
   free(x1);
   free(y1);
@@ -1346,9 +1365,9 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
   free(x2);
   free(y2);
   free(z2);
-  
+
   return nxgrid;
-  
+
 };/* create_xgrid_great_circle */
 
 /*******************************************************************************
@@ -1359,11 +1378,11 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
    RANGE_CHECK_CRITERIA is used to determine if the two grid boxes are possible to be
    overlap. The size should be between 0 and 0.5. The larger the range_check_criteria,
    the more expensive of the computatioin. When the value is close to 0,
-   some small exchange grid might be lost. Suggest to use value 0.05 for C48. 
+   some small exchange grid might be lost. Suggest to use value 0.05 for C48.
 *******************************************************************************/
 
-int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in, 
-			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in, 
+int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in,
+			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in,
 			    double x_out[], double y_out[], double z_out[])
 {
   struct Node *grid1List=NULL;
@@ -1373,7 +1392,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   struct Node *curList=NULL;
   struct Node *firstIntersect=NULL, *curIntersect=NULL;
   struct Node *temp1=NULL, *temp2=NULL, *temp=NULL;
-  
+
   int    i1, i2, i1p, i2p, i2p2, npts1, npts2;
   int    nintersect, n_out;
   int    maxiter1, maxiter2, iter1, iter2;
@@ -1387,36 +1406,36 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   double min_x1, max_x1, min_y1, max_y1, min_z1, max_z1;
   double min_x2, max_x2, min_y2, max_y2, min_z2, max_z2;
 
-  
+
   /* first check the min and max of (x1_in, y1_in, z1_in) with (x2_in, y2_in, z2_in) */
   min_x1 = minval_double(n1_in, x1_in);
-  max_x2 = maxval_double(n2_in, x2_in);  
+  max_x2 = maxval_double(n2_in, x2_in);
   if(min_x1 >= max_x2+RANGE_CHECK_CRITERIA) return 0;
-  max_x1 = maxval_double(n1_in, x1_in); 
+  max_x1 = maxval_double(n1_in, x1_in);
   min_x2 = minval_double(n2_in, x2_in);
   if(min_x2 >= max_x1+RANGE_CHECK_CRITERIA) return 0;
 
   min_y1 = minval_double(n1_in, y1_in);
-  max_y2 = maxval_double(n2_in, y2_in);  
+  max_y2 = maxval_double(n2_in, y2_in);
   if(min_y1 >= max_y2+RANGE_CHECK_CRITERIA) return 0;
-  max_y1 = maxval_double(n1_in, y1_in); 
+  max_y1 = maxval_double(n1_in, y1_in);
   min_y2 = minval_double(n2_in, y2_in);
-  if(min_y2 >= max_y1+RANGE_CHECK_CRITERIA) return 0;  
+  if(min_y2 >= max_y1+RANGE_CHECK_CRITERIA) return 0;
 
   min_z1 = minval_double(n1_in, z1_in);
-  max_z2 = maxval_double(n2_in, z2_in);  
+  max_z2 = maxval_double(n2_in, z2_in);
   if(min_z1 >= max_z2+RANGE_CHECK_CRITERIA) return 0;
-  max_z1 = maxval_double(n1_in, z1_in); 
+  max_z1 = maxval_double(n1_in, z1_in);
   min_z2 = minval_double(n2_in, z2_in);
-  if(min_z2 >= max_z1+RANGE_CHECK_CRITERIA) return 0;    
+  if(min_z2 >= max_z1+RANGE_CHECK_CRITERIA) return 0;
 
   rewindList();
 
   grid1List = getNext();
-  grid2List = getNext();  
+  grid2List = getNext();
   intersectList = getNext();
   polyList = getNext();
-    
+
   /* insert points into SubjList and ClipList */
   for(i1=0; i1<n1_in; i1++) addEnd(grid1List, x1_in[i1], y1_in[i1], z1_in[i1], 0, 0, 0, -1);
   for(i2=0; i2<n2_in; i2++) addEnd(grid2List, x2_in[i2], y2_in[i2], z2_in[i2], 0, 0, 0, -1);
@@ -1426,12 +1445,12 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   n_out = 0;
   /* set the inside value */
 #ifdef debug_test_create_xgrid
-  printf("\nNOTE from clip_2dx2d_great_circle: begin to set inside value grid1List\n"); 
-#endif  
+  printf("\nNOTE from clip_2dx2d_great_circle: begin to set inside value grid1List\n");
+#endif
   /* first check number of points in grid1 is inside grid2 */
 
   temp = grid1List;
-  while(temp) {    
+  while(temp) {
     if(insidePolygon(temp, grid2List))
       temp->isInside = 1;
     else
@@ -1440,8 +1459,8 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   }
 
 #ifdef debug_test_create_xgrid
-  printf("\nNOTE from clip_2dx2d_great_circle: begin to set inside value of grid2List\n"); 
-#endif      
+  printf("\nNOTE from clip_2dx2d_great_circle: begin to set inside value of grid2List\n");
+#endif
   /* check if grid2List is inside grid1List */
   temp = grid2List;
 
@@ -1452,19 +1471,19 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       temp->isInside = 0;
     temp = getNextNode(temp);
   }
-      
+
   /* make sure the grid box is clockwise */
-  
+
   /*make sure each polygon is convex, which is equivalent that the great_circle_area is positive */
   if( gridArea(grid1List) <= 0 )
     error_handler("create_xgrid.c(clip_2dx2d_great_circle): grid box 1 is not convex");
   if( gridArea(grid2List) <= 0 )
     error_handler("create_xgrid.c(clip_2dx2d_great_circle): grid box 2 is not convex");
-  
+
 #ifdef debug_test_create_xgrid
   printNode(grid1List, "grid1List");
   printNode(grid2List, "grid2List");
-#endif  
+#endif
 
   /* get the coordinates from grid1List and grid2List.
      Please not npts1 might not equal n1_in, npts2 might not equal n2_in because of pole
@@ -1479,12 +1498,12 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
   for(i2=0; i2<npts2; i2++) {
     getCoordinates(temp, pt2[i2]);
     temp = temp->Next;
-  }  
-  
+  }
+
   firstIntersect=getNext();
   curIntersect = getNext();
 
-#ifdef debug_test_create_xgrid  
+#ifdef debug_test_create_xgrid
   printf("\n\n************************ Start line_intersect_2D_3D ******************************\n");
 #endif
   /* first find all the intersection points */
@@ -1506,14 +1525,14 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 #endif
       if( line_intersect_2D_3D(p1_0, p1_1, p2_0, p2_1, p2_2, intersect, &u1, &u2, &inbound) ) {
 
-	/* from the value of u1, u2 and inbound, we can partially decide if a point is inside or outside of polygon */        
-	
+	/* from the value of u1, u2 and inbound, we can partially decide if a point is inside or outside of polygon */
+
 	/* add the intersection into intersetList, The intersection might already be in
 	   intersectList and will be taken care addIntersect
 	*/
 	if(addIntersect(intersectList, intersect[0], intersect[1], intersect[2], 1, u1, u2, inbound, i1, i1p, i2, i2p)) {
 	  /* add the intersection into the grid1List */
-    
+
 	  if(u1 == 1) {
 	    insertIntersect(grid1List, intersect[0], intersect[1], intersect[2], 0.0, u2, inbound, p1_1[0], p1_1[1], p1_1[2]);
 	  }
@@ -1540,7 +1559,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	    p2_1[0] = intersect[0];
 	    p2_1[1] = intersect[1];
 	    p2_1[2] = intersect[2];
-	  } 
+	  }
 	  else if(u2 == 0) {
 	    p2_0[0] = intersect[0];
 	    p2_0[1] = intersect[1];
@@ -1550,7 +1569,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       }
     }
   }
-  
+
   /* set inbound value for the points in intersectList that has inbound == 0,
      this will also set some inbound value of the points in grid1List
   */
@@ -1576,7 +1595,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 
   /* if has_inbound = 1, find the overlapping */
   n_out = 0;
-  
+
   if(has_inbound) {
     maxiter1 = nintersect;
 #ifdef debug_test_create_xgrid
@@ -1586,7 +1605,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
     printNode(grid2List, "beginning clip list");
     printNode(grid1List, "beginning subj list");
     printf("\n************************ End line_intersect_2D_3D **********************************\n\n");
-#endif  
+#endif
     temp1 = getNode(grid1List, *firstIntersect);
     if( temp1 == NULL) {
       double lon[10], lat[10];
@@ -1596,20 +1615,20 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       printf("\n");
       xyz2latlon(n2_in, x2_in, y2_in, z2_in, lon, lat);
       for(i=0; i< n2_in; i++) printf("lon2 = %g, lat2 = %g\n", lon[i]*R2D, lat[i]*R2D);
-      printf("\n");	
-	
+      printf("\n");
+
       error_handler("firstIntersect is not in the grid1List");
     }
     addNode(polyList, *firstIntersect);
     nintersect--;
-#ifdef debug_test_create_xgrid    
+#ifdef debug_test_create_xgrid
     printNode(polyList, "polyList at stage 1");
-#endif      
-	
+#endif
+
     /* Loop over the grid1List and grid2List to find again the firstIntersect */
     curList = grid1List;
     curListNum = 0;
-	
+
     /* Loop through curList to find the next intersection, the loop will end
        when come back to firstIntersect
     */
@@ -1620,7 +1639,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
     while( iter1 < maxiter1 ) {
 #ifdef debug_test_create_xgrid
       printf("\n----------- At iteration = %d\n\n", iter1+1 );
-      printNode(curIntersect, "curIntersect at the begining of iter1");      
+      printNode(curIntersect, "curIntersect at the begining of iter1");
 #endif
       /* find the curIntersect in curList and get the next intersection points */
       temp1 =  getNode(curList, *curIntersect);
@@ -1637,13 +1656,13 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	temp2IsIntersect = 0;
 	if( isIntersect( *temp2 ) ) { /* copy the point and switch to the grid2List */
 	  struct Node *temp3;
-	  
+
 	  /* first check if temp2 is the firstIntersect */
 	  if( sameNode( *temp2, *firstIntersect) ) {
-	    found1 = 1; 
+	    found1 = 1;
 	    break;
-	  }	  
-	  
+	  }
+
 	  temp3 = temp2->Next;
 	  if( temp3 == NULL) temp3 = curList;
 	  if( temp3 == NULL) error_handler("creat_xgrid.c: temp3 can not be NULL");
@@ -1660,10 +1679,10 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	}
 	else {
 	  addNode(polyList, *temp2);
-#ifdef debug_test_create_xgrid    
+#ifdef debug_test_create_xgrid
 	  printNode(polyList, "polyList at stage 2");
-#endif      	  
-	  if(temp2IsIntersect) { 
+#endif
+	  if(temp2IsIntersect) {
 	    nintersect--;
 	  }
 	}
@@ -1672,23 +1691,23 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	iter2 ++;
       }
       if(found1) break;
-    
+
       if( !found2 ) error_handler(" not found the next intersection ");
 
       /* if find the first intersection, the poly found */
       if( sameNode( *curIntersect, *firstIntersect) ) {
-	found1 = 1; 
+	found1 = 1;
 	break;
       }
 
       /* add curIntersect to polyList and remove it from intersectList and curList */
       addNode(polyList, *curIntersect);
-#ifdef debug_test_create_xgrid    
+#ifdef debug_test_create_xgrid
       printNode(polyList, "polyList at stage 3");
-#endif      
+#endif
       nintersect--;
-      
-      
+
+
       /* switch curList */
       if( curListNum == 0) {
 	curList = grid2List;
@@ -1712,7 +1731,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       temp1 = temp1->Next;
       n_out++;
     }
-    
+
     /* if(n_out < 3) error_handler(" The clipped region has < 3 vertices"); */
     if( n_out < 3) n_out = 0;
 #ifdef debug_test_create_xgrid
@@ -1727,14 +1746,14 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
     /* One possible is that grid1List is inside grid2List */
 #ifdef debug_test_create_xgrid
     printf("\nNOTE from clip_2dx2d_great_circle: check if grid1 is inside grid2\n");
-#endif    
+#endif
     n1in2 = 0;
     temp = grid1List;
     while(temp) {
       if(temp->intersect != 1) {
-#ifdef debug_test_create_xgrid	
+#ifdef debug_test_create_xgrid
 	printf("grid1->isInside = %d\n", temp->isInside);
-#endif 
+#endif
 	if( temp->isInside == 1) n1in2++;
       }
       temp = getNextNode(temp);
@@ -1751,26 +1770,26 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
     }
     if(n_out>0) return n_out;
   }
-  
+
   /* check if grid2List is inside grid1List */
   if(n_out ==0){
     int n, n2in1;
 #ifdef debug_test_create_xgrid
     printf("\nNOTE from clip_2dx2d_great_circle: check if grid2 is inside grid1\n");
-#endif    
-    
+#endif
+
     temp = grid2List;
     n2in1 = 0;
     while(temp) {
       if(temp->intersect != 1) {
-#ifdef debug_test_create_xgrid	
+#ifdef debug_test_create_xgrid
 	printf("grid2->isInside = %d\n", temp->isInside);
 #endif
 	if( temp->isInside == 1) n2in1++;
       }
       temp = getNextNode(temp);
     }
-      
+
     if(npts2==n2in1) { /* grid2 is inside grid1 */
       n_out = npts2;
       n = 0;
@@ -1780,11 +1799,11 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	n++;
 	temp = getNextNode(temp);
       }
-      
-    }
-  }  
 
-  
+    }
+  }
+
+
   return n_out;
 }
 
@@ -1814,7 +1833,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   int is_inter1, is_inter2;
 
   *inbound = 0;
-  
+
   /* first check if any vertices are the same */
   if(samePoint(a1[0], a1[1], a1[2], q1[0], q1[1], q1[2])) {
     *u_a = 0;
@@ -1823,8 +1842,8 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
     intersect[1] = a1[1];
     intersect[2] = a1[2];
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound); 
-#endif      
+    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound);
+#endif
     return 1;
    }
    else if (samePoint(a1[0], a1[1], a1[2], q2[0], q2[1], q2[2])) {
@@ -1834,14 +1853,14 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
     intersect[1] = a1[1];
     intersect[2] = a1[2];
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound); 
-#endif      
+    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound);
+#endif
     return 1;
   }
    else if(samePoint(a2[0], a2[1], a2[2], q1[0], q1[1], q1[2])) {
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound); 
-#endif           
+    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound);
+#endif
     *u_a = 1;
     *u_q = 0;
     intersect[0] = a2[0];
@@ -1851,8 +1870,8 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
    }
    else if (samePoint(a2[0], a2[1], a2[2], q2[0], q2[1], q2[2])) {
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound); 
-#endif           
+    printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f, u_q=%19.15f, inbound=%d\n", *u_a, *u_q, *inbound);
+#endif
     *u_a = 1;
     *u_q = 1;
     intersect[0] = a2[0];
@@ -1882,7 +1901,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   if(fabs(*u_a) < EPSLN8) *u_a = 0;
   if(fabs(*u_a-1) < EPSLN8) *u_a = 1;
 
-  
+
 #ifdef debug_test_create_xgrid
     printf("\nNOTE from line_intersect_2D_3D: u_a = %19.15f\n", *u_a);
 #endif
@@ -1912,12 +1931,12 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
 #ifdef debug_test_create_xgrid
     printf("\nNOTE from line_intersect_2D_3D: u_q = %19.15f\n", *u_q);
 #endif
-  
+
 
   if( (*u_q < 0) || (*u_q > 1) ) return 0;
-  
+
   u =*u_a;
-  
+
   /* The two planes are coincidental */
   vect_cross(a1, a2, c1);
   vect_cross(q1, q2, c2);
@@ -1925,7 +1944,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   coincident = metric(c3);
 
   if(fabs(coincident) < EPSLN30) return 0;
-  
+
   /* Calculate point of intersection */
   intersect[0]=a1[0] + u*(a2[0]-a1[0]);
   intersect[1]=a1[1] + u*(a2[1]-a1[1]);
@@ -1936,7 +1955,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
 
   /* when u_q =0 or u_q =1, the following could not decide the inbound value */
   if(*u_q != 0 && *u_q != 1){
-  
+
     p1[0] = a2[0]-a1[0];
     p1[1] = a2[1]-a1[1];
     p1[2] = a2[2]-a1[2];
@@ -1955,16 +1974,16 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
     if(sense > 0) *inbound = 2; /* v1 going into v2 in CCW sense */
   }
 #ifdef debug_test_create_xgrid
-    printf("\nNOTE from line_intersect_2D_3D: inbound=%d\n", *inbound); 
-#endif      
-  
+    printf("\nNOTE from line_intersect_2D_3D: inbound=%d\n", *inbound);
+#endif
+
   return 1;
 }
 
 
 /*------------------------------------------------------------------------------
   double poly_ctrlat(const double x[], const double y[], int n)
-  This routine is used to calculate the latitude of the centroid 
+  This routine is used to calculate the latitude of the centroid
    ---------------------------------------------------------------------------*/
 
 double poly_ctrlat(const double x[], const double y[], int n)
@@ -1988,11 +2007,11 @@ double poly_ctrlat(const double x[], const double y[], int n)
 
     if ( fabs(hdy)< SMALL_VALUE ) /* cheap area calculation along latitude */
       ctrlat -= dx*(2*cos(avg_y) + lat2*sin(avg_y) - cos(lat1) );
-    else 
+    else
       ctrlat -= dx*( (sin(hdy)/hdy)*(2*cos(avg_y) + lat2*sin(avg_y)) - cos(lat1) );
   }
   return (ctrlat*RADIUS*RADIUS);
-}; /* poly_ctrlat */        
+}; /* poly_ctrlat */
 
 /*------------------------------------------------------------------------------
   double poly_ctrlon(const double x[], const double y[], int n, double clon)
@@ -2011,16 +2030,16 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
     phi1   = x[ip];
     phi2   = x[i];
     lat1 = y[ip];
-    lat2 = y[i];    
+    lat2 = y[i];
     dphi   = phi1 - phi2;
-    
+
     if      (dphi==0.0) continue;
 
     f1 = 0.5*(cos(lat1)*sin(lat1)+lat1);
     f2 = 0.5*(cos(lat2)*sin(lat2)+lat2);
 
-     /* this will make sure longitude of centroid is at 
-        the same interval as the center of any grid */  
+     /* this will make sure longitude of centroid is at
+        the same interval as the center of any grid */
     if(dphi > M_PI)  dphi = dphi - 2.0*M_PI;
     if(dphi < -M_PI) dphi = dphi + 2.0*M_PI;
     dphi1 = phi1 - clon;
@@ -2028,7 +2047,7 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
     if( dphi1 <-M_PI) dphi1 += 2.0*M_PI;
     dphi2 = phi2 -clon;
     if( dphi2 > M_PI) dphi2 -= 2.0*M_PI;
-    if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;    
+    if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;
 
     if(abs(dphi2 -dphi1) < M_PI) {
       ctrlon -= dphi * (dphi1*f1+dphi2*f2)/2.0;
@@ -2042,7 +2061,7 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
       ctrlon -= 0.5*dphi1*(dphi1-fac)*f1 - 0.5*dphi2*(dphi2+fac)*f2
 	+ 0.5*fac*(dphi1+dphi2)*fint;
 	}
-    
+
   }
   return (ctrlon*RADIUS*RADIUS);
 };   /* poly_ctrlon */
@@ -2055,24 +2074,24 @@ double box_ctrlat(double ll_lon, double ll_lat, double ur_lon, double ur_lat)
 {
   double dphi = ur_lon-ll_lon;
   double ctrlat;
-  
+
   if(dphi > M_PI)  dphi = dphi - 2.0*M_PI;
   if(dphi < -M_PI) dphi = dphi + 2.0*M_PI;
   ctrlat = dphi*(cos(ur_lat) + ur_lat*sin(ur_lat)-(cos(ll_lat) + ll_lat*sin(ll_lat)));
-  return (ctrlat*RADIUS*RADIUS); 
+  return (ctrlat*RADIUS*RADIUS);
 }; /* box_ctrlat */
 
 /*------------------------------------------------------------------------------
   double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, double clon)
-  This routine is used to calculate the lontitude of the centroid 
+  This routine is used to calculate the lontitude of the centroid
    ----------------------------------------------------------------------------*/
 double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, double clon)
 {
   double phi1, phi2, dphi, lat1, lat2, dphi1, dphi2;
-  double f1, f2, fac, fint;  
+  double f1, f2, fac, fint;
   double ctrlon  = 0.0;
   int i;
-  clon = clon;  
+  clon = clon;
   for( i =0; i<2; i++) {
     if(i == 0) {
       phi1 = ur_lon;
@@ -2096,7 +2115,7 @@ double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, do
     if( dphi1 <-M_PI) dphi1 += 2.0*M_PI;
     dphi2 = phi2 -clon;
     if( dphi2 > M_PI) dphi2 -= 2.0*M_PI;
-    if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;    
+    if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;
 
     if(abs(dphi2 -dphi1) < M_PI) {
       ctrlon -= dphi * (dphi1*f1+dphi2*f2)/2.0;
@@ -2111,30 +2130,30 @@ double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, do
 	+ 0.5*fac*(dphi1+dphi2)*fint;
     }
   }
-  return (ctrlon*RADIUS*RADIUS);    
+  return (ctrlon*RADIUS*RADIUS);
 } /* box_ctrlon */
 
 /*******************************************************************************
   double grid_box_radius(double *x, double *y, double *z, int n);
   Find the radius of the grid box, the radius is defined the
   maximum distance between any two vertices
-*******************************************************************************/ 
+*******************************************************************************/
 double grid_box_radius(const double *x, const double *y, const double *z, int n)
 {
   double radius;
   int i, j;
-  
+
   radius = 0;
   for(i=0; i<n-1; i++) {
     for(j=i+1; j<n; j++) {
       radius = max(radius, pow(x[i]-x[j],2.)+pow(y[i]-y[j],2.)+pow(z[i]-z[j],2.));
     }
   }
-  
+
   radius = sqrt(radius);
 
   return (radius);
-  
+
 }; /* grid_box_radius */
 
 /*******************************************************************************
@@ -2151,7 +2170,7 @@ double dist_between_boxes(const double *x1, const double *y1, const double *z1, 
 
   dist = 0.0;
   for(i=0; i<n1; i++) {
-    for(j=0; j<n2; j++) {   
+    for(j=0; j<n2; j++) {
       dist = max(dist, pow(x1[i]-x2[j],2.)+pow(y1[i]-y2[j],2.)+pow(z1[i]-z2[j],2.));
     }
   }
@@ -2166,7 +2185,7 @@ double dist_between_boxes(const double *x1, const double *y1, const double *z1, 
  determine a point(x,y) is inside or outside a given edge with vertex,
  (x0,y0) and (x1,y1). return 1 if inside and 0 if outside. <y1-y0, -(x1-x0)> is
  the outward edge normal from vertex <x0,y0> to <x1,y1>. <x-x0,y-y0> is the vector
- from <x0,y0> to <x,y>. 
+ from <x0,y0> to <x,y>.
  if Inner produce <x-x0,y-y0>*<y1-y0, -(x1-x0)> > 0, outside, otherwise inside.
  inner product value = 0 also treate as inside.
 *******************************************************************************/
@@ -2174,10 +2193,10 @@ int inside_edge(double x0, double y0, double x1, double y1, double x, double y)
 {
    const double SMALL = 1.e-12;
    double product;
-   
+
    product = ( x-x0 )*(y1-y0) + (x0-x1)*(y-y0);
    return (product<=SMALL) ? 1:0;
-   
+
  }; /* inside_edge */
 
 
@@ -2205,10 +2224,10 @@ int main(int argc, char* argv[])
   int    nlon1=0, nlat1=0, nlon2=0, nlat2=0;
   int    n;
   int    ntest = 11;
-  
+
 
   for(n=11; n<=ntest; n++) {
-    
+
     switch (n) {
     case 1:
       /****************************************************************
@@ -2216,10 +2235,10 @@ int main(int argc, char* argv[])
        test clip_2dx2d_great_cirle case 1:
        box 1: (20,10), (20,12), (22,12), (22,10)
        box 2: (21,11), (21,14), (24,14), (24,11)
-       out  : (21, 12.0018), (22, 12), (22, 11.0033), (21, 11) 
+       out  : (21, 12.0018), (22, 12), (22, 11.0033), (21, 11)
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;  
+      n1_in = 4; n2_in = 4;
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
       lon1_in[0] = 20; lat1_in[0] = 10;
       lon1_in[1] = 20; lat1_in[1] = 12;
@@ -2230,7 +2249,7 @@ int main(int argc, char* argv[])
       lon2_in[2] = 24; lat2_in[2] = 14;
       lon2_in[3] = 24; lat2_in[3] = 11;
       break;
-      
+
     case 2:
       /****************************************************************
 
@@ -2239,11 +2258,11 @@ int main(int argc, char* argv[])
         box 2: (20,10), (20,12), (22,12), (22,10)
         out  : (20,10), (20,12), (22,12), (22,10)
 
-      ****************************************************************/      
+      ****************************************************************/
       lon1_in[0] = 20; lat1_in[0] = 10;
       lon1_in[1] = 20; lat1_in[1] = 12;
       lon1_in[2] = 22; lat1_in[2] = 12;
-      lon1_in[3] = 22; lat1_in[3] = 10;  
+      lon1_in[3] = 22; lat1_in[3] = 10;
 
       for(i=0; i<n2_in; i++) {
 	lon2_in[i] = lon1_in[i];
@@ -2255,12 +2274,12 @@ int main(int argc, char* argv[])
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 3: one cubic sphere grid close to the pole with lat-lon grid.
-       box 1: (251.7, 88.98), (148.3, 88.98), (57.81, 88.72), (342.2, 88.72) 
+       box 1: (251.7, 88.98), (148.3, 88.98), (57.81, 88.72), (342.2, 88.72)
        box 2: (150, 88), (150, 90), (152.5, 90), (152.5, 88)
-       out  : (152.5, 89.0642), (150, 89.0165), (0, 90) 
+       out  : (152.5, 89.0642), (150, 89.0165), (0, 90)
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;  
+      n1_in = 4; n2_in = 4;
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
       lon1_in[0] = 251.7; lat1_in[0] = 88.98;
       lon1_in[1] = 148.3; lat1_in[1] = 88.98;
@@ -2283,18 +2302,18 @@ int main(int argc, char* argv[])
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 4: One box contains the pole
-       box 1: (-160, 88.5354), (152.011, 87.8123) , (102.985, 88.4008), (20, 89.8047) 
+       box 1: (-160, 88.5354), (152.011, 87.8123) , (102.985, 88.4008), (20, 89.8047)
        box 2: (145,88), (145,90), (150,90), (150,88)
-       out  : (145.916, 88.0011), (145, 88.0249), (0, 90), (150, 88) 
+       out  : (145.916, 88.0011), (145, 88.0249), (0, 90), (150, 88)
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;  
+      n1_in = 4; n2_in = 4;
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
 
       lon1_in[0] = -160;  lat1_in[0] = 88.5354;
       lon1_in[1] = 152.011; lat1_in[1] = 87.8123;
       lon1_in[2] = 102.985; lat1_in[2] = 88.4008;
-      lon1_in[3] = 20; lat1_in[3] = 89.8047;  
+      lon1_in[3] = 20; lat1_in[3] = 89.8047;
 
       lon2_in[0] = 145; lat2_in[0] = 88;
       lon2_in[1] = 145; lat2_in[1] = 90;
@@ -2308,41 +2327,41 @@ int main(int argc, char* argv[])
        test clip_2dx2d_great_cirle case 5: One tripolar grid around the pole with lat-lon grid.
        box 1: (-202.6, 87.95), (-280, 89.56), (-100, 90), (-190, 88)
        box 2: (21,11), (21,14), (24,14), (24,11)
-       out  : (150, 88.7006), (145,  88.9507), (0, 90) 
+       out  : (150, 88.7006), (145,  88.9507), (0, 90)
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;  
+      n1_in = 4; n2_in = 4;
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
 
       lon1_in[0] = -202.6;  lat1_in[0] = 87.95;
       lon1_in[1] = -280.;   lat1_in[1] = 89.56;
       lon1_in[2] = -100.0; lat1_in[2] = 90;
-      lon1_in[3] = -190.; lat1_in[3] = 88;  
+      lon1_in[3] = -190.; lat1_in[3] = 88;
 
       lon2_in[0] = 145; lat2_in[0] = 88;
       lon2_in[1] = 145; lat2_in[1] = 90;
       lon2_in[2] = 150; lat2_in[2] = 90;
       lon2_in[3] = 150; lat2_in[3] = 88;
-      break; 
+      break;
 
     case 6:
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 6: One cubic sphere grid arounc the pole with one tripolar grid box
                                        around the pole.
-       box 1: (-160, 88.5354), (152.011, 87.8123) , (102.985, 88.4008), (20, 89.8047) 
+       box 1: (-160, 88.5354), (152.011, 87.8123) , (102.985, 88.4008), (20, 89.8047)
        box 2: (-202.6, 87.95), (-280, 89.56), (-100, 90), (-190, 88)
-       out  : (170, 88.309), (157.082, 88.0005), (83.714, 89.559), (80, 89.6094), (0, 90), (200, 88.5354) 
+       out  : (170, 88.309), (157.082, 88.0005), (83.714, 89.559), (80, 89.6094), (0, 90), (200, 88.5354)
 
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;  
+      n1_in = 4; n2_in = 4;
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
 
       lon1_in[0] = -160;  lat1_in[0] = 88.5354;
       lon1_in[1] = 152.011; lat1_in[1] = 87.8123;
       lon1_in[2] = 102.985; lat1_in[2] = 88.4008;
-      lon1_in[3] = 20; lat1_in[3] = 89.8047;  
+      lon1_in[3] = 20; lat1_in[3] = 89.8047;
 
       lon2_in[0] = -202.6;  lat2_in[0] = 87.95;
       lon2_in[1] = -280.;   lat2_in[1] = 89.56;
@@ -2359,7 +2378,7 @@ int main(int argc, char* argv[])
        out  : (20,10), (20,12), (22,12), (22,10)
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;  
+      n1_in = 4; n2_in = 4;
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
       lon1_in[0] = 20; lat1_in[0] = 10;
       lon1_in[1] = 20; lat1_in[1] = 12;
@@ -2376,12 +2395,12 @@ int main(int argc, char* argv[])
 
        test clip_2dx2d_great_cirle case 8: Cubic sphere grid at tile = 1, point (i=25,j=1)
           with N45 at (i=141,j=23)
-       box 1: 
-       box 2: 
+       box 1:
+       box 2:
        out  : None
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;  
+      n1_in = 4; n2_in = 4;
       /* first a simple lat-lo
 	 n grid box to clip another lat-lon grid box */
       lon1_in[0] = 350.0; lat1_in[0] = -45;
@@ -2392,19 +2411,19 @@ int main(int argc, char* argv[])
       lon2_in[1] = 350.0;   lat2_in[1] = -44;
       lon2_in[2] = 352.5; lat2_in[2] = -44;
       lon2_in[3] = 352.5; lat2_in[3] = -46;
-      break;      
+      break;
 
-    case 9:      
+    case 9:
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 9: Cubic sphere grid at tile = 1, point (i=1,j=1)
           with N45 at (i=51,j=61)
-       box 1: 
-       box 2: 
+       box 1:
+       box 2:
        out  : None
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;  
+      n1_in = 4; n2_in = 4;
 
       lon1_in[0] = 305.0; lat1_in[0] = -35.26;
       lon1_in[1] = 305.0; lat1_in[1] = -33.80;
@@ -2414,19 +2433,19 @@ int main(int argc, char* argv[])
       lon2_in[1] = 125;   lat2_in[1] = 34;
       lon2_in[2] = 127.5; lat2_in[2] = 34;
       lon2_in[3] = 127.5; lat2_in[3] = 32;
-      break;      
+      break;
 
-    case 10:      
+    case 10:
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 10: Cubic sphere grid at tile = 3, point (i=24,j=1)
           with N45 at (i=51,j=46)
-       box 1: 
-       box 2: 
+       box 1:
+       box 2:
        out  : None
 
       ****************************************************************/
-      n1_in = 4; n2_in = 4;  
+      n1_in = 4; n2_in = 4;
 
       lon1_in[0] = 125.0; lat1_in[0] = 1.46935;
       lon1_in[1] = 126.573; lat1_in[1] = 1.5091;
@@ -2436,16 +2455,16 @@ int main(int argc, char* argv[])
       lon2_in[1] = 125;   lat2_in[1] = 2;
       lon2_in[2] = 127.5; lat2_in[2] = 2;
       lon2_in[3] = 127.5; lat2_in[3] = 0;
-      break;      
+      break;
 
-    case 11:      
+    case 11:
       /****************************************************************
 
        test clip_2dx2d_great_cirle case 10: Cubic sphere grid at tile = 3, point (i=24,j=1)
           with N45 at (i=51,j=46)
-       box 1: 
-       box 2: 
-       out  : 
+       box 1:
+       box 2:
+       out  :
 
       ****************************************************************/
       nlon1 = 1;
@@ -2459,7 +2478,7 @@ int main(int argc, char* argv[])
       lon1_in[1] = 170.0; lat1_in[1] = 87.92;
       lon1_in[2] = 260.0; lat1_in[2] = 87.92;
       lon1_in[3] = 215.0;  lat1_in[3] = 87.06;
-      
+
 /*       lon1_in[0] = 35.0; lat1_in[0] = 87.06; */
 /*       lon1_in[1] = 80.0; lat1_in[1] = 87.92; */
 /*       lon1_in[2] = 125.0; lat1_in[2] = 87.06; */
@@ -2474,7 +2493,7 @@ int main(int argc, char* argv[])
       lon2_in[1] = 170;   lat2_in[1] = 88;
       lon2_in[2] = 167.5; lat2_in[2] = 90;
       lon2_in[3] = 170;   lat2_in[3] = 90;
-      
+
 /*       nlon1 = 3; */
 /*       nlat1 = 2; */
 /*       nlon2 = 1; */
@@ -2515,13 +2534,13 @@ int main(int argc, char* argv[])
 /*       lon2_in[2] = 305;   lat2_in[2] = -32; */
 /*       lon2_in[3] = 307.5; lat2_in[3] = -32; */
 
-       nlon1 = 2; 
-       nlat1 = 2; 
-       nlon2 = 1; 
+       nlon1 = 2;
+       nlat1 = 2;
+       nlon2 = 1;
        nlat2 = 1;
       n1_in = (nlon1+1)*(nlat1+1);
       n2_in = (nlon2+1)*(nlat2+1);
-       
+
       lon1_in[0] = 111.3; lat1_in[0] = 1.591;
       lon1_in[1] = 109.7; lat1_in[1] = 2.926;
       lon1_in[2] = 108.2; lat1_in[2] = 4.256;
@@ -2536,16 +2555,16 @@ int main(int argc, char* argv[])
       lon2_in[1] = 110;   lat2_in[1] = 0;
       lon2_in[2] = 107.5; lat2_in[2] = 2;
       lon2_in[3] = 110;   lat2_in[3] = 2;
-      
-      break;      
-      
+
+      break;
+
     case 12:
       /****************************************************************
 
        test : create_xgrid_great_circle
        box 1: (20,10), (20,12), (22,12), (22,10)
        box 2: (21,11), (21,14), (24,14), (24,11)
-       out  : (21, 12.0018), (22, 12), (22, 11.0033), (21, 11) 
+       out  : (21, 12.0018), (22, 12), (22, 11.0033), (21, 11)
 
       ****************************************************************/
       nlon1 = 2;
@@ -2554,7 +2573,7 @@ int main(int argc, char* argv[])
       nlat2 = 3;
       n1_in = (nlon1+1)*(nlat1+1);
       n2_in = (nlon2+1)*(nlat2+1);
-      
+
       /* first a simple lat-lon grid box to clip another lat-lon grid box */
       for(j=0; j<=nlat1; j++) for(i=0; i<=nlon1; i++){
 	lon1_in[j*(nlon1+1)+i] = 20.0 + (i-1)*2.0;
@@ -2564,7 +2583,7 @@ int main(int argc, char* argv[])
 	lon2_in[j*(nlon2+1)+i] = 19.0 + (i-1)*2.0;
 	lat2_in[j*(nlon2+1)+i] = 9.0 + (j-1)*2.0;
       }
-	
+
       break;
 
     case 13:
@@ -2584,7 +2603,7 @@ int main(int argc, char* argv[])
 /*       lon2_in[1] = ; lat2_in[1] = ; */
 /*       lon2_in[2] = ; lat2_in[2] = ; */
 /*       lon2_in[3] = ; lat2_in[3] = ;     */
-      
+
 /*       lon1_in[0] = 1.35536; lat1_in[0] = 1.16251; */
 /*       lon1_in[1] = 1.36805; lat1_in[1] = 1.15369; */
 /*       lon1_in[2] = 1.37843; lat1_in[2] = 1.16729; */
@@ -2610,11 +2629,11 @@ int main(int argc, char* argv[])
       lon2_in[0] = 120.369415056522087; lat2_in[0] = 16.752176828509153;
       lon2_in[1] = 119.999999999999986; lat2_in[1] = 16.752505523196167;
       lon2_in[2] = 120.369415056522087; lat2_in[2] = 16.397797949548146;
-      lon2_in[3] = 119.999999999999986; lat2_in[3] = 16.398120477217255;      
-      
+      lon2_in[3] = 119.999999999999986; lat2_in[3] = 16.398120477217255;
+
       break;
 
-      
+
     default:
       error_handler("test_create_xgrid: incorrect case number");
     }
@@ -2627,8 +2646,8 @@ int main(int argc, char* argv[])
     for(i=0; i<n2_in; i++) {
       lon2_in[i] *= D2R; lat2_in[i] *=D2R;
     }
-    
-  
+
+
     printf("\n*********************************************************\n");
     printf("\n               Case %d                                    \n", n);
     printf("\n*********************************************************\n");
@@ -2649,14 +2668,14 @@ int main(int argc, char* argv[])
       xclat = (double *)malloc(MAXXGRID*sizeof(double));
 
       for(i=0; i<nlon1*nlat1; i++) mask1[i] = 1.0;
-      
+
       nxgrid = create_xgrid_great_circle(&nlon1, &nlat1, &nlon2, &nlat2, lon1_in, lat1_in,
 					 lon2_in, lat2_in, mask1, i1, j1, i2, j2,
 					 xarea, xclon, xclat);
       printf("\n*********************************************************\n");
       printf("\n     First input grid box longitude, latitude   \n \n");
       for(i=0; i<n1_in; i++) printf(" %g,  %g \n", lon1_in[i]*R2D, lat1_in[i]*R2D);
-  
+
       printf("\n     Second input grid box longitude, latitude \n \n");
       for(i=0; i<n2_in; i++) printf(" %g,  %g \n", lon2_in[i]*R2D, lat2_in[i]*R2D);
 
@@ -2672,17 +2691,17 @@ int main(int argc, char* argv[])
 	double area_sum;
 	int    i;
 	area_sum = 0.0;
-	
+
 	for(i=0; i<nxgrid; i++) {
 	  area_sum+= xarea[i];
 	}
 
 	area1 = (double *)malloc((nlon1)*(nlat1)*sizeof(double));
-	get_grid_great_circle_area_(&nlon1, &nlat1, lon1_in, lat1_in, area1);      
+	get_grid_great_circle_area_(&nlon1, &nlat1, lon1_in, lat1_in, area1);
 
 	printf("xgrid area sum is %g, grid 1 area is %g\n", area_sum, area1[0]);
       }
-	
+
       printf("\n");
       free(i1);
       free(i2);
@@ -2691,12 +2710,12 @@ int main(int argc, char* argv[])
       free(xarea);
       free(xclon);
       free(xclat);
-      free(mask1);      
+      free(mask1);
     }
     else {
       latlon2xyz(n1_in, lon1_in, lat1_in, x1_in, y1_in, z1_in);
       latlon2xyz(n2_in, lon2_in, lat2_in, x2_in, y2_in, z2_in);
-    
+
       n_out = clip_2dx2d_great_circle(x1_in, y1_in, z1_in, 4, x2_in, y2_in, z2_in, n2_in,
 				      x_out, y_out,  z_out);
       xyz2latlon(n_out, x_out, y_out, z_out, lon_out, lat_out);
@@ -2704,10 +2723,10 @@ int main(int argc, char* argv[])
       printf("\n*********************************************************\n");
       printf("\n     First input grid box longitude, latitude   \n \n");
       for(i=0; i<n1_in; i++) printf(" %g,  %g \n", lon1_in[i]*R2D, lat1_in[i]*R2D);
-  
+
       printf("\n     Second input grid box longitude, latitude \n \n");
       for(i=0; i<n2_in; i++) printf(" %g,  %g \n", lon2_in[i]*R2D, lat2_in[i]*R2D);
-  
+
       printf("\n     output clip grid box longitude, latitude for case 1 \n \n");
       for(i=0; i<n_out; i++) printf(" %g,  %g \n", lon_out[i]*R2D, lat_out[i]*R2D);
       printf("\n");

--- a/tools/libfrencutils/create_xgrid.h
+++ b/tools/libfrencutils/create_xgrid.h
@@ -1,22 +1,3 @@
-/***********************************************************************
- *                   GNU Lesser General Public License
- *
- * This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
- *
- * FRE-NCtools is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at
- * your option) any later version.
- *
- * FRE-NCtools is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with FRE-NCTools.  If not, see
- * <http://www.gnu.org/licenses/>.
- **********************************************************************/
 #ifndef CREATE_XGRID_H_
 #define CREATE_XGRID_H_
 #ifndef MAXXGRID
@@ -26,7 +7,9 @@
 #define MV 50
 /* this value is small compare to earth area */
 
+#pragma acc routine seq
 double poly_ctrlon(const double lon[], const double lat[], int n, double clon);
+#pragma acc routine seq
 double poly_ctrlat(const double lon[], const double lat[], int n);
 double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, double clon);
 double box_ctrlat(double ll_lon, double ll_lat, double ur_lon, double ur_lat);
@@ -37,7 +20,6 @@ void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double 
 void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, double ll_lat,
 	 double ur_lon, double ur_lat, double lon_out[], double lat_out[]);
-void pimod(double x[],int nn);
 int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in, 
 	       const double lon2_in[], const double lat2_in[], int n2_in, 
 	       double lon_out[], double lat_out[]);

--- a/tools/libfrencutils/create_xgrid.h
+++ b/tools/libfrencutils/create_xgrid.h
@@ -1,3 +1,22 @@
+/***********************************************************************
+ *                   GNU Lesser General Public License
+ *
+ * This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+ *
+ * FRE-NCtools is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * FRE-NCtools is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FRE-NCTools.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ **********************************************************************/
 #ifndef CREATE_XGRID_H_
 #define CREATE_XGRID_H_
 #ifndef MAXXGRID
@@ -20,8 +39,8 @@ void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double 
 void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, double ll_lat,
 	 double ur_lon, double ur_lat, double lon_out[], double lat_out[]);
-int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in, 
-	       const double lon2_in[], const double lat2_in[], int n2_in, 
+int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
+	       const double lon2_in[], const double lat2_in[], int n2_in,
 	       double lon_out[], double lat_out[]);
 int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
 			      const double *lat_in, const double *lon_out, const double *lat_out,
@@ -47,8 +66,8 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
 			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
 			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat);
-int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in, 
-			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in, 
+int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in,
+			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in,
 			    double x_out[], double y_out[], double z_out[]);
 int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,

--- a/tools/libfrencutils/mosaic_util.h
+++ b/tools/libfrencutils/mosaic_util.h
@@ -1,45 +1,23 @@
 /***********************************************************************
- *                   GNU Lesser General Public License
- *
- * This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
- *
- * FRE-NCtools is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at
- * your option) any later version.
- *
- * FRE-NCtools is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with FRE-NCTools.  If not, see
- * <http://www.gnu.org/licenses/>.
- **********************************************************************/
-
-#ifndef _MOSAIC_UTIL_H
-#define _MOSAIC_UTIL_H 1
+                      mosaic_util.h
+    This header file provide some utilities routine that will be used in many tools.
+    
+    contact: Zhi.Liang@noaa.gov
+***********************************************************************/
+#ifndef MOSAIC_UTIL_H_
+#define MOSAIC_UTIL_H_
 
 #ifndef RANGE_CHECK_CRITERIA
 #define RANGE_CHECK_CRITERIA 0.05
 #endif
 
-#ifndef _MATH_H
-#include <math.h>
-#endif
-
-/* override the `fabs` function based on the type */
-#define fabs(X) _Generic((X), \
-     long double: fabsl, \
-          double: fabs)(X)
-
 #define min(a,b) (a<b ? a:b)
 #define max(a,b) (a>b ? a:b)
 #define SMALL_VALUE ( 1.e-10 )
+
 struct Node{
   double x, y, z, u, u_clip;
-  int intersect; /* indicate if this point is an intersection, 0 = no, 1= yes, 2=both intersect and vertices */
+  int intersect; /* indicate if this point is an intersection, 0 = no, 1= yes, 2=both intersect and vertices */ 
   int inbound;      /* -1 uninitialized, 0 coincident, 1 outbound, 2 inbound */
   int initialized; /* = 0 means empty list */
   int isInside;   /* = 1 means one point is inside the other polygon, 0 is not, -1 undecided. */
@@ -52,21 +30,26 @@ struct Node{
 void error_handler(const char *msg);
 int nearest_index(double value, const double *array, int ia);
 int lon_fix(double *x, double *y, int n_in, double tlon);
+#pragma acc routine seq
 double minval_double(int size, const double *data);
+#pragma acc routine seq
 double maxval_double(int size, const double *data);
+#pragma acc routine seq
 double avgval_double(int size, const double *data);
-void latlon2xyz(int size, const double *lon, const double *lat, double *x, double *y, double *z);
+void latlon2xyz(int size, const double *lon, const double *lat, double *x, double *y, double *z); 
 void xyz2latlon(int size, const double *x, const double *y, const double *z, double *lon, double *lat);
 double box_area(double ll_lon, double ll_lat, double ur_lon, double ur_lat);
+#pragma acc routine seq
 double poly_area(const double lon[], const double lat[], int n);
 double poly_area_dimensionless(const double lon[], const double lat[], int n);
 double poly_area_no_adjust(const double x[], const double y[], int n);
+#pragma acc routine seq
 int fix_lon(double lon[], double lat[], int n, double tlon);
 void tokenize(const char * const string, const char *tokens, unsigned int varlen,
-         unsigned int maxvar, char * pstring, unsigned int * const nstr);
+	      unsigned int maxvar, char * pstring, unsigned int * const nstr);
 double great_circle_distance(double *p1, double *p2);
 double spherical_excess_area(const double* p_ll, const double* p_ul,
-              const double* p_lr, const double* p_ur, double radius);
+			     const double* p_lr, const double* p_ur, double radius);
 void vect_cross(const double *p1, const double *p2, double *e );
 double spherical_angle(const double *v1, const double *v2, const double *v3);
 void normalize_vect(double *e);
@@ -75,7 +58,7 @@ double great_circle_area(int n, const double *x, const double *y, const double *
 double * cross(const double *p1, const double *p2);
 double dot(const double *p1, const double *p2);
 int intersect_tri_with_line(const double *plane, const double *l1, const double *l2, double *p,
-              double *t);
+			     double *t);
 int invert_matrix_3x3(long double m[], long double m_inv[]);
 void mult(long double m[], long double v[], long double out_v[]);
 double metric(const double *p);
@@ -86,10 +69,8 @@ void rewindList(void);
 struct Node *getNext();
 void initNode(struct Node *node);
 void addEnd(struct Node *list, double x, double y, double z, int intersect, double u, int inbound, int inside);
-int addIntersect(struct Node *list, double x, double y, double z, int intersect, double u1, double u2,
+int addIntersect(struct Node *list, double x, double y, double z, int intersect, double u1, double u2, 
                 int inbound, int is1, int ie1, int is2, int ie2);
-void insertIntersect(struct Node *list, double x, double y, double z, double u1, double u2, int inbound,
-                     double x2, double y2, double z2);
 int length(struct Node *list);
 int samePoint(double x1, double y1, double z1, double x2, double y2, double z2);
 int sameNode(struct Node node1, struct Node node2);
@@ -99,8 +80,10 @@ struct Node *getNextNode(struct Node *list);
 void copyNode(struct Node *node_out, struct Node node_in);
 void printNode(struct Node *list, char *str);
 int intersectInList(struct Node *list, double x, double y, double z);
+void insertIntersect(struct Node *list, double x, double y, double z, double u1, double u2, int inbound,
+                 double x2, double y2, double z2);
 void insertAfter(struct Node *list, double x, double y, double z, int intersect, double u, int inbound,
-       double x2, double y2, double z2);
+		 double x2, double y2, double z2);
 double gridArea(struct Node *grid);
 int isIntersect(struct Node node);
 int getInbound( struct Node node );

--- a/tools/libfrencutils/mosaic_util.h
+++ b/tools/libfrencutils/mosaic_util.h
@@ -1,7 +1,26 @@
 /***********************************************************************
+ *                   GNU Lesser General Public License
+ *
+ * This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+ *
+ * FRE-NCtools is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * FRE-NCtools is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FRE-NCTools.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ **********************************************************************/
+/***********************************************************************
                       mosaic_util.h
     This header file provide some utilities routine that will be used in many tools.
-    
+
     contact: Zhi.Liang@noaa.gov
 ***********************************************************************/
 #ifndef MOSAIC_UTIL_H_
@@ -17,7 +36,7 @@
 
 struct Node{
   double x, y, z, u, u_clip;
-  int intersect; /* indicate if this point is an intersection, 0 = no, 1= yes, 2=both intersect and vertices */ 
+  int intersect; /* indicate if this point is an intersection, 0 = no, 1= yes, 2=both intersect and vertices */
   int inbound;      /* -1 uninitialized, 0 coincident, 1 outbound, 2 inbound */
   int initialized; /* = 0 means empty list */
   int isInside;   /* = 1 means one point is inside the other polygon, 0 is not, -1 undecided. */
@@ -36,7 +55,7 @@ double minval_double(int size, const double *data);
 double maxval_double(int size, const double *data);
 #pragma acc routine seq
 double avgval_double(int size, const double *data);
-void latlon2xyz(int size, const double *lon, const double *lat, double *x, double *y, double *z); 
+void latlon2xyz(int size, const double *lon, const double *lat, double *x, double *y, double *z);
 void xyz2latlon(int size, const double *x, const double *y, const double *z, double *lon, double *lat);
 double box_area(double ll_lon, double ll_lat, double ur_lon, double ur_lat);
 #pragma acc routine seq
@@ -69,7 +88,7 @@ void rewindList(void);
 struct Node *getNext();
 void initNode(struct Node *node);
 void addEnd(struct Node *list, double x, double y, double z, int intersect, double u, int inbound, int inside);
-int addIntersect(struct Node *list, double x, double y, double z, int intersect, double u1, double u2, 
+int addIntersect(struct Node *list, double x, double y, double z, int intersect, double u1, double u2,
                 int inbound, int is1, int ie1, int is2, int ie2);
 int length(struct Node *list);
 int samePoint(double x1, double y1, double z1, double x2, double y2, double z2);

--- a/tools/make_coupler_mosaic/make_coupler_mosaic.c
+++ b/tools/make_coupler_mosaic/make_coupler_mosaic.c
@@ -491,6 +491,9 @@ int main (int argc, char *argv[])
 
   /*if lmosaic is not specifiied, assign amosaic value to it */
   if(!lmosaic) lmosaic = amosaic;
+  
+  // TODO disabled for gpu work
+  //if(reproduce_siena) set_reproduce_siena_true();
 
   /*mosaic_file can not have the same name as amosaic, lmosaic or omosaic, also the file name of
     amosaic, lmosaic, omosaic can not be "mosaic.nc"

--- a/tools/make_coupler_mosaic/make_coupler_mosaic.c
+++ b/tools/make_coupler_mosaic/make_coupler_mosaic.c
@@ -492,8 +492,6 @@ int main (int argc, char *argv[])
   /*if lmosaic is not specifiied, assign amosaic value to it */
   if(!lmosaic) lmosaic = amosaic;
 
-  if(reproduce_siena) set_reproduce_siena_true();
-
   /*mosaic_file can not have the same name as amosaic, lmosaic or omosaic, also the file name of
     amosaic, lmosaic, omosaic can not be "mosaic.nc"
   */

--- a/tools/make_quick_mosaic/make_quick_mosaic.c
+++ b/tools/make_quick_mosaic/make_quick_mosaic.c
@@ -206,6 +206,9 @@ int main (int argc, char *argv[])
     }
   }
 
+  // TODO disabled for gpu work
+  //if(reproduce_siena) set_reproduce_siena_true();
+
   /* First get land grid information */
 
   mpp_init(&argc, &argv);

--- a/tools/make_quick_mosaic/make_quick_mosaic.c
+++ b/tools/make_quick_mosaic/make_quick_mosaic.c
@@ -206,8 +206,6 @@ int main (int argc, char *argv[])
     }
   }
 
-  if(reproduce_siena) set_reproduce_siena_true();
-
   /* First get land grid information */
 
   mpp_init(&argc, &argv);


### PR DESCRIPTION
Adds the code changes from the gpu hackathon. includes some configure.ac changes to add the openacc flags for nvc after a simple check of the `-acc` flag (unless disabled via `--with-openacc=no`).

I tried to keep any changes that happened in between the hackathon and now in the code, but wasn't sure for certain things (mainly if the reproduce_siena flag and routines should be kept) so let me know if any removals look unrelated.

Flags were set up for the gpu box in the original code, I kept them the same except for `-ta=tesla`. Couldn't find any info on it in the nvidia docs so I changed it to `-gpu=cc70` which sets the 'compute capability' target to what the tesla gpu uses.