### PR TITLE
Add in initial openacc code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
         MPI: ${{ matrix.with_mpi }}
         QUAD_P: ${{ matrix.enable_quad_precision }}
     steps:
+    - name: install autoconf dependency
+      run: apt update && apt install autoconf-archive
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/README.md
+++ b/README.md
@@ -188,9 +188,14 @@ make
 make install
 ```
 
-### Parallel NCTools applications
+### NCTools applications
 The option  `--with-mpi` to the `configure` command will configure for building
 parallel running versions of certain FRE-NCtools applications.
+
+### OpenACC NCTools applications
+The option `--with-openacc` to `configure` command will configure for building
+the GPU accelerated version of fregrid. This will result in a separate executable,
+`fregrid_gpu`.
 
 
 ## Building on a GFDL-managed system

--- a/configure.ac
+++ b/configure.ac
@@ -74,13 +74,13 @@ AS_IF([test $gx_cv_c__Generic = no],
 # TODO this should really be added as an m4 macro, surprised there wasn't a existing one in the archives
 AC_ARG_WITH([openacc],
   [AS_HELP_STRING([--with-openacc],
-    [Builds with openacc flags if available (default no)])])
+    [Builds with openacc flags for nvidias nvc compiler if available. This will result in a second executable for fregrid, fregrid_gpu. Flags added: -acc -O2 -g -tp native -gpu=ccnative -Minfo=accel -Mnoinline (default no)])])
 AS_IF([test ${with_openacc:-no} = yes],
   [with_openacc=yes],
   [with_openacc=no])
 AS_IF([test ${with_openacc} = yes],
   [AX_CHECK_COMPILE_FLAG( [-acc],
-       [ AC_SUBST(OPENACC_CFLAGS, "-acc -O2 -g -tp haswell -gpu=cc70 -Minfo=accel -Mnoinline")],
+       [ AC_SUBST(OPENACC_CFLAGS, "-acc -O2 -g -tp native -gpu=ccnative -Minfo=accel -Mnoinline")],
         AC_MSG_ERROR([OpenACC option specified but -acc flag not accepted by compiler]) )])
 AM_CONDITIONAL([WITH_OPENACC], [test "$with_openacc" = "yes"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,17 @@ GX_C__GENERIC
 AS_IF([test $gx_cv_c__Generic = no],
   AC_MSG_ERROR([The C compiler does not support the generic selection C-11 standard.  Please use a C-11 compliant compiler.])
 )
+# openacc support, simple check for working (nvc)openacc flag and allows for disabling if desired
+# TODO this should really be added as an m4 macro, surprised there wasn't a existing one in the archives
+AC_ARG_WITH([openacc],
+  [AS_HELP_STRING([--with-openacc],
+    [Builds with openacc flags if available (default yes)])])
+AS_IF([test ${with_openacc:-yes} = yes],
+  [with_openacc=yes],
+  [with_openacc=no])
+AS_IF([test ${with_openacc} = yes],
+  [AX_CHECK_COMPILE_FLAG( [-acc], [CFLAGS="-acc -tp haswell -gpu=cc70 -Minfo -Mbounds -Mnoinline"])])
+
 
 AC_PROG_FC([ifort gfortran])
 AC_PROG_FC_C_O

--- a/configure.ac
+++ b/configure.ac
@@ -74,12 +74,14 @@ AS_IF([test $gx_cv_c__Generic = no],
 # TODO this should really be added as an m4 macro, surprised there wasn't a existing one in the archives
 AC_ARG_WITH([openacc],
   [AS_HELP_STRING([--with-openacc],
-    [Builds with openacc flags if available (default yes)])])
-AS_IF([test ${with_openacc:-yes} = yes],
+    [Builds with openacc flags if available (default no)])])
+AS_IF([test ${with_openacc:-no} = yes],
   [with_openacc=yes],
   [with_openacc=no])
 AS_IF([test ${with_openacc} = yes],
-  [AX_CHECK_COMPILE_FLAG( [-acc], [CFLAGS="-acc -tp haswell -gpu=cc70 -Minfo -Mbounds -Mnoinline"])])
+  [AX_CHECK_COMPILE_FLAG( [-acc],
+       [CFLAGS="-acc -tp haswell -gpu=cc70 -Minfo -Mnoinline"],
+        AC_MSG_ERROR([OpenACC option specified but -acc flag not accepted by compiler]) )])
 
 
 AC_PROG_FC([ifort gfortran])

--- a/configure.ac
+++ b/configure.ac
@@ -80,8 +80,9 @@ AS_IF([test ${with_openacc:-no} = yes],
   [with_openacc=no])
 AS_IF([test ${with_openacc} = yes],
   [AX_CHECK_COMPILE_FLAG( [-acc],
-       [CFLAGS="-acc -tp haswell -gpu=cc70 -Minfo -Mnoinline"],
+       [ AC_SUBST(OPENACC_CFLAGS, "-acc -O2 -g -tp haswell -gpu=cc70 -Minfo=accel -Mnoinline")],
         AC_MSG_ERROR([OpenACC option specified but -acc flag not accepted by compiler]) )])
+AM_CONDITIONAL([WITH_OPENACC], [test "$with_openacc" = "yes"])
 
 
 AC_PROG_FC([ifort gfortran])

--- a/tools/fregrid/Makefile.am
+++ b/tools/fregrid/Makefile.am
@@ -22,6 +22,10 @@ if WITH_MPI
   bin_PROGRAMS += fregrid_parallel
 endif
 
+if WITH_OPENACC
+  bin_PROGRAMS += fregrid_gpu
+endif
+
 AM_CFLAGS = -I$(top_srcdir)/tools/libfrencutils \
             $(NETCDF_CFLAGS)
 LDADD = $(NETCDF_LDFLAGS) $(NETCDF_LIBS) $(RPATH_FLAGS)
@@ -39,3 +43,7 @@ fregrid_LDADD = $(top_builddir)/tools/libfrencutils/libfrencutils.a $(LDADD)
 fregrid_parallel_SOURCES = $(fregrid_SOURCES)
 fregrid_parallel_CFLAGS = -Duse_libMPI $(MPI_CFLAGS) $(AM_CFLAGS)
 fregrid_parallel_LDADD = $(top_builddir)/tools/libfrencutils/libfrencutils_mpi.a $(LDADD) $(MPI_CLDFLAGS)
+
+fregrid_gpu_SOURCES = $(fregrid_SOURCES)
+fregrid_gpu_CFLAGS = $(OPENACC_CFLAGS) $(AM_CFLAGS)
+fregrid_gpu_LDADD = $(top_builddir)/tools/libfrencutils/libfrencutils_gpu.a $(LDADD)

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <netcdf.h>
 #include <math.h>
+#include <time.h>
 #include "constant.h"
 #include "globals.h"
 #include "create_xgrid.h"
@@ -31,6 +32,8 @@
 #include "mpp.h"
 #include "mpp_io.h"
 #include "read_mosaic.h"
+
+#define DEBUG 0
 
 #define  AREA_RATIO (1.e-3)
 #define  MAXVAL (1.e20)
@@ -56,6 +59,9 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
     double *clat;
   } CellStruct;
   CellStruct *cell_in;
+
+  double time_nxgrid=0;
+  clock_t time_start, time_end;
 
   garea = 4*M_PI*RADIUS*RADIUS;
 
@@ -194,9 +200,14 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 	    int    *g_i_in, *g_j_in;
 	    double *g_area, *g_clon, *g_clat;
 
+   time_start = clock();
 	    nxgrid = create_xgrid_2dx2d_order2(&nx_in, &ny_now, &nx_out, &ny_out, grid_in[m].lonc+jstart*(nx_in+1),
 					       grid_in[m].latc+jstart*(nx_in+1),  grid_out[n].lonc,  grid_out[n].latc,
 					       mask, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+   if(DEBUG) printf("nxgrid, m, & n is: %d %d %d\n",nxgrid, m, n);
+   time_end = clock();
+   time_nxgrid += 1.0 * (time_end - time_start)/CLOCKS_PER_SEC;
+
 	    for(i=0; i<nxgrid; i++) j_in[i] += jstart;
 
 	    /* For the purpose of bitiwise reproducing, the following operation is needed. */
@@ -316,6 +327,8 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 	}  /* if(nxgrid>0) */
       }
     }
+    if(DEBUG) print_time("time_nxgrid", time_nxgrid);
+
     if(opcode & CONSERVE_ORDER2) {
       /* subtrack the grid_in clon and clat to get the distance between xgrid and grid_in */
       for(n=0; n<ntiles_in; n++) {

--- a/tools/libfrencutils/Makefile.am
+++ b/tools/libfrencutils/Makefile.am
@@ -21,6 +21,9 @@ noinst_LIBRARIES = libfrencutils.a
 if WITH_MPI
   noinst_LIBRARIES += libfrencutils_mpi.a
 endif
+if WITH_OPENACC
+  noinst_LIBRARIES += libfrencutils_gpu.a
+endif
 
 AM_CFLAGS = $(NETCDF_CFLAGS)
 
@@ -47,3 +50,6 @@ libfrencutils_a_SOURCES = affinity.c \
 
 libfrencutils_mpi_a_SOURCES = $(libfrencutils_a_SOURCES)
 libfrencutils_mpi_a_CFLAGS = -Duse_libMPI $(MPI_CFLAGS) $(AM_CFLAGS)
+
+libfrencutils_gpu_a_SOURCES = $(libfrencutils_a_SOURCES)
+libfrencutils_gpu_a_CFLAGS = $(OPENACC_CFLAGS) $(AM_CFLAGS)

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -1039,8 +1039,9 @@ nxgrid = 0;
 	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
 	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
 	  if( xarea/min_area > AREA_RATIO_THRESH ) {
-//            if(nxgrid>= MAXXGRID/nthreads)
-//	      error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
+            // commented out for gpu work
+            if(nxgrid>= MAXXGRID/nthreads)
+	      error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
 	    xgrid_area[nxgrid] = xarea;
 	    xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
 	    xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
@@ -1223,10 +1224,11 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
 	ds1 = y1_0*x1_1 - y1_1*x1_0;
 	ds2 = y2_0*x2_1 - y2_1*x2_0;
 	determ = dy2*dx1 - dy1*dx2;
-//        if(fabs(determ) < EPSLN30) {
-//	  error_handler("the line between <x1_0,y1_0> and  <x1_1,y1_1> should not parallel to "
-//				     "the line between <x2_0,y2_0> and  <x2_1,y2_1>");
-//	}
+        // commented out for gpu work
+        if(fabs(determ) < EPSLN30) {
+          error_handler("the line between <x1_0,y1_0> and  <x1_1,y1_1> should not parallel to "
+                        "the line between <x2_0,y2_0> and  <x2_1,y2_1>");
+	}
 	lon_out[i_out]   = (dx2*ds1 - dx1*ds2)/determ;
 	lat_out[i_out++] = (dy2*ds1 - dy1*ds2)/determ;
 
@@ -2100,7 +2102,7 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
     if( dphi2 > M_PI) dphi2 -= 2.0*M_PI;
     if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;
 
-    if(abs(dphi2 -dphi1) < M_PI) {
+    if(fabs(dphi2 -dphi1) < M_PI) {
       ctrlon -= dphi * (dphi1*f1+dphi2*f2)/2.0;
     }
     else {
@@ -2108,7 +2110,7 @@ double poly_ctrlon(const double x[], const double y[], int n, double clon)
 	fac = M_PI;
       else
 	fac = -M_PI;
-      fint = f1 + (f2-f1)*(fac-dphi1)/abs(dphi);
+      fint = f1 + (f2-f1)*(fac-dphi1)/fabs(dphi);
       ctrlon -= 0.5*dphi1*(dphi1-fac)*f1 - 0.5*dphi2*(dphi2+fac)*f2
 	+ 0.5*fac*(dphi1+dphi2)*fint;
 	}
@@ -2168,7 +2170,7 @@ double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, do
     if( dphi2 > M_PI) dphi2 -= 2.0*M_PI;
     if( dphi2 <-M_PI) dphi2 += 2.0*M_PI;
 
-    if(abs(dphi2 -dphi1) < M_PI) {
+    if(fabs(dphi2 -dphi1) < M_PI) {
       ctrlon -= dphi * (dphi1*f1+dphi2*f2)/2.0;
     }
     else {
@@ -2176,7 +2178,7 @@ double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, do
 	fac = M_PI;
       else
 	fac = -M_PI;
-      fint = f1 + (f2-f1)*(fac-dphi1)/abs(dphi);
+      fint = f1 + (f2-f1)*(fac-dphi1)/fabs(dphi);
       ctrlon -= 0.5*dphi1*(dphi1-fac)*f1 - 0.5*dphi2*(dphi2+fac)*f2
 	+ 0.5*fac*(dphi1+dphi2)*fint;
     }
@@ -2689,8 +2691,8 @@ int main(int argc, char* argv[])
     case 14:
       /****************************************************************
        test clip_2dx2d_great_cirle case 14: Cubic sphere grid at tile = 3, point (i=24,j=1)
-       identical grid boxes 
-       ****************************************************************/
+         identical grid boxes
+      ****************************************************************/
       /*
       nlon1 = 1;
       nlat1 = 1;
@@ -2698,10 +2700,12 @@ int main(int argc, char* argv[])
       nlat2 = 1;
       n1_in = (nlon1+1)*(nlat1+1);
       n2_in = (nlon2+1)*(nlat2+1);
+
       lon1_in[0] = 350.0; lat1_in[0] = 90.00;
       lon1_in[1] = 170.0; lat1_in[1] = 87.92;
       lon1_in[2] = 260.0; lat1_in[2] = 87.92;
       lon1_in[3] = 215.0; lat1_in[3] = 87.06;
+
       lon2_in[0] = 350.0; lat2_in[0] = 90.00;
       lon2_in[1] = 170.0; lat2_in[1] = 87.92;
       lon2_in[2] = 260.0; lat2_in[2] = 87.92;
@@ -2734,9 +2738,10 @@ int main(int argc, char* argv[])
       memcpy(lat2_in,lat2_15,sizeof(lat2_in));
       //Must give the second box
       break;
+
     case 16:
       /*Must give [[-57.748, -30, -30, -97.6, -97.6],
-                   [89.876, 89.891, 90, 90, 89.9183]]*/ 
+                   [89.876, 89.891, 90, 90, 89.9183]]*/
       n1_in = 6; n2_in = 5;
       double lon1_16[] = {82.400,  82.400, 262.400, 262.400, 326.498, 379.641};
       double lat1_16[] = {89.835,  90.000,  90.000,  89.847,  89.648,  89.642};
@@ -2778,11 +2783,11 @@ int main(int argc, char* argv[])
       /*Must give nothing*/
     case 19:
       /****************************************************************
-        test clip_2dx2d 2: two boxes that include the North Pole 
+        test clip_2dx2d 2: two boxes that include the North Pole
                            one has vertices on the tripolar fold
                            the other is totally outside the first
                            This actually happens for some stretched grid
-                           configurations  mosaic_c256r25tlat32.0_om4p25 
+                           configurations  mosaic_c256r25tlat32.0_om4p25
         The test gives wrong answers!
       ****************************************************************/
       n1_in = 6; n2_in = 5;
@@ -2799,7 +2804,7 @@ int main(int argc, char* argv[])
 
     case 20:
       /*Must give
- n_out= 5 
+ n_out= 5
  122.176, 150, 150, 82.4, 82.4,
  89.761, 89.789, 90, 90, 89.8429,
        */      n1_in = 6; n2_in = 5;
@@ -2816,10 +2821,10 @@ int main(int argc, char* argv[])
 
     case 21:
       /*Must give
- n_out= 5 
+ n_out= 5
  60.000,  82.400,  82.400,  60.000],
  89.889,  89.843,  90.000,  90.000]
-       */      
+       */
       n1_in = 6; n2_in = 5;
       double lon1_21[] = {82.400,  82.400, 262.400, 262.400, 326.498, 379.641};
       double lat1_21[] = {89.835,  90.000,  90.000,  89.847,  89.648,  89.642};
@@ -2835,7 +2840,7 @@ int main(int argc, char* argv[])
     case 26:
       /*Side crosses SP (Right cell).
 	Must give same box
-      */      
+      */
       n1_in = 4; n2_in = 4;
       double lon1_22[] = {209.68793552504,158.60256162113,82.40000000000,262.40000000000};
       double lat1_22[] = {-89.11514201451,-89.26896927380,-89.82370183256, -89.46584623220};
@@ -2851,7 +2856,7 @@ int main(int argc, char* argv[])
     case 23:
       /*Side does not cross SP (Right cell).
 	Must give same box
-      */      
+      */
 
       n1_in = 4; n2_in = 4;
       double lon1_23[] = {158.60256162113,121.19651597620,82.40000000000,82.40000000000};
@@ -2868,7 +2873,7 @@ int main(int argc, char* argv[])
     case 24:
       /*Side crosses SP (Left cell). Added twin poles.
 	Must give the same box
-      */      
+      */
       n1_in = 6; n2_in = 6;
       double lon1_24[] = {262.40000000000,262.40000000000,82.4,82.4,6.19743837887,-44.88793552504};
       double lat1_24[] = {-89.46584623220,-90.0,         -90.0,-89.82370183256, -89.26896927380, -89.11514201451};
@@ -2881,9 +2886,9 @@ int main(int argc, char* argv[])
       memcpy(lat2_in,lat2_24,sizeof(lat2_in));
       break;
     case 25:
-      /*Side crosses SP (Left cell). 
+      /*Side crosses SP (Left cell).
 	Must givethe same box
-      */      
+      */
       n1_in = 4; n2_in = 4;
       double lon1_25[] = {262.40000000000,82.4,6.19743837887,-44.88793552504};
       double lat1_25[] = {-89.46584623220, -89.82370183256, -89.26896927380, -89.11514201451};
@@ -2898,7 +2903,7 @@ int main(int argc, char* argv[])
     case 22:
       /*Side does not cross SP (Left cell).
 	Must give same box
-      */       
+      */
       n1_in = 4; n2_in = 4;
       double lon1_26[] = {82.4,82.4,43.60348402380,6.19743837887};
       double lat1_26[] = {-89.82370183256, -89.10746816044, -88.85737639760, -89.26896927380};
@@ -3019,7 +3024,7 @@ int main(int argc, char* argv[])
       printf("\n");
       for(i=0; i<n_out; i++) printf(" %g,", lat_out[i]*R2D);
       printf("\n");
-      if(area1>1.0e14 || area2>1.0e14 || area_out>1.0e14) printf("Error in calculating area !\n");  
+      if(area1>1.0e14 || area2>1.0e14 || area_out>1.0e14) printf("Error in calculating area !\n");
       if(n==16 || n==20) printf("Must result n_out=5!\n");
       if(n==21) printf("Must result n_out=4!\n");
       if(n==15 || n==17) printf("Must result the second box!\n");

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -1432,6 +1432,9 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
   double x1_0, y1_0, x1_1, y1_1, x2_0, y2_0, x2_1, y2_1;
   double dx1, dy1, dx2, dy2, determ, ds1, ds2;
   int i_out, n_out, inside_last, inside, i1, i2;
+  // TODO used by pimod update
+  // double lon_tmp[MV], lat2_tmp[MV];
+  // int gtwopi=0 
 
   /* clip polygon with each boundary of the polygon */
   /* We treat lon1_in/lat1_in as clip polygon and lon2_in/lat2_in as subject polygon */
@@ -1444,6 +1447,20 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
   x2_0 = lon2_in[n2_in-1];
   y2_0 = lat2_in[n2_in-1];
   for(i2=0; i2<n2_in; i2++) {
+/* TODO updates diverge (pimod added)
+ *    lon2_tmp[i2] = lon2_in[i2];
+ *    lat2_tmp[i2] = lat2_in[i2];
+ * }
+ * //Some grid boxes near North Pole are clipped wrong (issue #42 )
+ * //The following heuristic fix seems to work. Why?
+ * if(gttwopi){pimod(lon_tmp,n1_in);pimod(lon2_tmp,n2_in);} 
+ *
+ * x2_0 = lon2_tmp[n2_in-1];
+ * y2_0 = lat2_tmp[n2_in-1];
+ * for(i2=0; i2<n2_in; i2++) {
+ * x2_1 = lon2_tmp[i2];
+ * y2_1 = lat2_tmp[i2];
+ */
     x2_1 = lon2_in[i2];
     y2_1 = lat2_in[i2];
     x1_0 = lon_tmp[n_out-1];
@@ -1495,6 +1512,13 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
   return(n_out);
 }; /* clip */
 
+void pimod(double x[],int nn)
+{
+  for (int i=0;i<nn;i++) {
+    if      (x[i] < -M_PI) x[i] += TPI;
+    else if (x[i] >  M_PI) x[i] -= TPI;
+  }
+}
 /*#define debug_test_create_xgrid*/
 
 #ifndef __AIX

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -1087,8 +1087,10 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   get_grid_area(nlon_out, nlat_out, lon_out, lat_out, area_out);
 
   nthreads = 1;
+#if defined(_OPENMP)
 #pragma omp parallel
   nthreads = omp_get_num_threads();
+#endif
 
   nblocks = nthreads;
 

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -1445,13 +1445,13 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
   }
 #pragma acc loop seq
   for(i2=0; i2<n2_in; i2++) {
-     lon2_tmp[i2] = lon2_in[i2];
-     lat2_tmp[i2] = lat2_in[i2];
+    lon2_tmp[i2] = lon2_in[i2];
+    lat2_tmp[i2] = lat2_in[i2];
   }
   //Some grid boxes near North Pole are clipped wrong (issue #42 )
   //The following heuristic fix seems to work. Why?
   if(gttwopi){pimod(lon_tmp,n1_in);pimod(lon2_tmp,n2_in);} 
- 
+
   x2_0 = lon2_tmp[n2_in-1];
   y2_0 = lat2_tmp[n2_in-1];
   for(i2=0; i2<n2_in; i2++) {
@@ -3306,11 +3306,10 @@ int main(int argc, char* argv[])
       printf("\n");
 
       printf("\n     Second input grid box longitude, latitude \n \n");
-      for(i=0; i<n1_in; i++) printf(" %g,", lon1_in[i]*R2D);
+      for(i=0; i<n2_in; i++) printf(" %g,", lon2_in[i]*R2D);
       printf("\n");
-      for(i=0; i<n1_in; i++) printf(" %g,", lat1_in[i]*R2D);
+      for(i=0; i<n2_in; i++) printf(" %g,", lat2_in[i]*R2D);
       printf("\n");
-
 
       printf("\n     output clip grid box longitude, latitude for case %d \n \n",n);
       printf("n_out= %d \n",n_out);

--- a/tools/libfrencutils/create_xgrid.h
+++ b/tools/libfrencutils/create_xgrid.h
@@ -38,8 +38,8 @@ void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *
 void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, double ll_lat,
-void pimod(double x[],int nn);
 	 double ur_lon, double ur_lat, double lon_out[], double lat_out[]);
+void pimod(double x[],int nn);
 int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
 	       const double lon2_in[], const double lat2_in[], int n2_in,
 	       double lon_out[], double lat_out[]);

--- a/tools/libfrencutils/create_xgrid.h
+++ b/tools/libfrencutils/create_xgrid.h
@@ -26,7 +26,9 @@
 #define MV 50
 /* this value is small compare to earth area */
 
+#pragma acc routine seq
 double poly_ctrlon(const double lon[], const double lat[], int n, double clon);
+#pragma acc routine seq
 double poly_ctrlat(const double lon[], const double lat[], int n);
 double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, double clon);
 double box_ctrlat(double ll_lon, double ll_lat, double ur_lon, double ur_lat);
@@ -37,9 +39,8 @@ void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double 
 void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, double ll_lat,
 	 double ur_lon, double ur_lat, double lon_out[], double lat_out[]);
-void pimod(double x[],int nn);
-int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in, 
-	       const double lon2_in[], const double lat2_in[], int n2_in, 
+int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
+	       const double lon2_in[], const double lat2_in[], int n2_in,
 	       double lon_out[], double lat_out[]);
 int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
 			      const double *lat_in, const double *lon_out, const double *lat_out,
@@ -65,8 +66,8 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
 			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
 			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat);
-int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in, 
-			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in, 
+int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in,
+			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in,
 			    double x_out[], double y_out[], double z_out[]);
 int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,

--- a/tools/libfrencutils/create_xgrid.h
+++ b/tools/libfrencutils/create_xgrid.h
@@ -38,6 +38,7 @@ void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *
 void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, double ll_lat,
+void pimod(double x[],int nn);
 	 double ur_lon, double ur_lat, double lon_out[], double lat_out[]);
 int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
 	       const double lon2_in[], const double lat2_in[], int n2_in,

--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -42,6 +42,7 @@
     error handler: will print out error message and then abort
 ***********************************************************/
 int reproduce_siena = 0;
+#pragma acc declare copyin(reproduce_siena)
 
 void set_reproduce_siena_true(void)
 {

--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -49,6 +49,9 @@ void set_reproduce_siena_true(void)
   reproduce_siena = 1;
 }
 
+// TODO openacc support
+// acc_set_error_routine could be used to set a gpu fallback error routine
+// otherwise this might stop region parallelization where used
 void error_handler(const char *msg)
 {
   fprintf(stderr, "FATAL Error: %s\n", msg );

--- a/tools/libfrencutils/mosaic_util.h
+++ b/tools/libfrencutils/mosaic_util.h
@@ -52,15 +52,20 @@ struct Node{
 void error_handler(const char *msg);
 int nearest_index(double value, const double *array, int ia);
 int lon_fix(double *x, double *y, int n_in, double tlon);
+#pragma acc routine seq
 double minval_double(int size, const double *data);
+#pragma acc routine seq
 double maxval_double(int size, const double *data);
+#pragma acc routine seq
 double avgval_double(int size, const double *data);
 void latlon2xyz(int size, const double *lon, const double *lat, double *x, double *y, double *z);
 void xyz2latlon(int size, const double *x, const double *y, const double *z, double *lon, double *lat);
 double box_area(double ll_lon, double ll_lat, double ur_lon, double ur_lat);
+#pragma acc routine seq
 double poly_area(const double lon[], const double lat[], int n);
 double poly_area_dimensionless(const double lon[], const double lat[], int n);
 double poly_area_no_adjust(const double x[], const double y[], int n);
+#pragma acc routine seq
 int fix_lon(double lon[], double lat[], int n, double tlon);
 void tokenize(const char * const string, const char *tokens, unsigned int varlen,
          unsigned int maxvar, char * pstring, unsigned int * const nstr);


### PR DESCRIPTION
See #204, replaces the code changes made there.
 
This compiles a separate version of libfrencutils and fregrid with the openacc flags `-acc -O2 -g -tp haswell -gpu=cc70 -Minfo=accel -Mnoinline`and names the executable `fregrid_gpu`.

I tried not bringing in too many unrelated changes from the existing code, but they were mostly unused variables/routines and trailing whitespace removals so it didn't really make sense to not keep those. Not really sure about the conserve_interp.c file though, wasn't going to include it but ended up just adding a debug macro in case we want it for benchmarking/testing.