### PR TITLE
Changed to use run_and_check function (found in test_utils.bash) in

### DIFF
--- a/t/Test01-check_programs_exist.sh
+++ b/t/Test01-check_programs_exist.sh
@@ -22,42 +22,37 @@
 load test_utils
 
 @test "Check make_hgrid exists and is executable" {
-  run command -v make_hgrid
-  [ "$status" -eq 0 ]
+  run_and_check -v make_hgrid
   run make_hgrid -h
   [ "$status" -eq 2 ]
 }
 
 @test "Check make_vgrid exists and is executable" {
-  run command -v make_vgrid
-  [ "$status" -eq 0 ]
+  run_and_check -v make_vgrid
   run make_vgrid -h
   [ "$status" -eq 1 ]
 }
 
 @test "Check make_solo_mosaic exists and is executable" {
-  run command -v make_solo_mosaic
-  [ "$status" -eq 0 ]
+  run_and_check -v make_solo_mosaic
   run make_solo_mosaic -h
   [ "$status" -eq 2 ]
 }
 
 @test "Check make_topog exists and is executable" {
-  run command -v make_topog
-  [ "$status" -eq 0 ]
+  run_and_check -v make_topog
   run make_topog -h
   [ "$status" -eq 1 ]
 }
 # only run with mpi
 @test "Check make_topog_parallel exists and is executable" {
   [ ! -z $skip_mpi ] && skip "not built with MPI"
-  run command -v make_topog_parallel
-  [ "$status" -eq 0 ]
+  run_and_check -v make_topog_parallel
+
 }
 
 @test "Check coupler_mosaic exists and is executable" {
-  run command -v make_coupler_mosaic
-  [ "$status" -eq 0 ]
+  run_and_check -v make_coupler_mosaic
   run make_coupler_mosaic -h
   [ "$status" -eq 2 ]
 }
@@ -65,13 +60,12 @@ load test_utils
 # only run with mpi
 @test "Check coupler_mosaic_parallel exists and is executable" {
   [ ! -z $skip_mpi ] && skip "not built with MPI"
-  run command -v make_coupler_mosaic_parallel
-  [ "$status" -eq 0 ]
+  run_and_check -v make_coupler_mosaic_parallel
+
 }
 
 @test "Check fregrid exists and is executable" {
-  run command -v fregrid
-  [ "$status" -eq 0 ]
+  run_and_check -v fregrid
   run fregrid -h
   [ "$status" -eq 2 ]
 }
@@ -79,34 +73,30 @@ load test_utils
 # only run with mpi
 @test "Check fregrid_parallel exists and is executable" {
   [ ! -z $skip_mpi ] && skip "not built with MPI"
-  run command -v fregrid_parallel
-  [ "$status" -eq 0 ]
+  run_and_check -v fregrid_parallel
+
 }
 
 @test "Check runoff_regrid exists and is executable" {
-  run command -v runoff_regrid
-  [ "$status" -eq 0 ]
+  run_and_check -v runoff_regrid
   run runoff_regrid -h
   [ "$status" -eq 2 ]
 }
 
 @test "Check river_regrid exists and is executable" {
-  run command -v river_regrid
-  [ "$status" -eq 0 ]
+  run_and_check -v river_regrid
   run river_regrid -h
   [ "$status" -eq 2 ]
 }
 
 @test "Check check_mask exists and is executable" {
-  run command -v check_mask
-  [ "$status" -eq 0 ]
+  run_and_check -v check_mask
   run check_mask -h
   [ "$status" -eq 2 ]
 }
 
 @test "Check remap_land exists and is executable" {
-  run command -v remap_land
-  [ "$status" -eq 0 ]
+  run_and_check -v remap_land
   run remap_land -h
   [ "$status" -eq 1 ]
 }
@@ -114,51 +104,44 @@ load test_utils
 # only run with mpi
 @test "Check remap_land_parallel exists and is executable" {
   [ ! -z $skip_mpi ] && skip "not built with MPI"
-  run command -v remap_land_parallel
-  [ "$status" -eq 0 ]
+  run_and_check -v remap_land_parallel
+
 }
 
 @test "Check make_regional_mosaic exists and is executable" {
-  run command -v make_regional_mosaic
-  [ "$status" -eq 0 ]
+  run_and_check -v make_regional_mosaic
   run make_regional_mosaic -h
   [ "$status" -eq 2 ]
 }
 
 @test "Check mppncscatter exists and is executable" {
-  run command -v mppncscatter
-  [ "$status" -eq 0 ]
+  run_and_check -v mppncscatter
 }
 
 @test "Check mppnccombine exists and is executable" {
-  run command -v mppnccombine
-  [ "$status" -eq 0 ]
+  run_and_check -v mppnccombine
   run mppnccombine -h
   [ "$status" -eq 1 ]
 }
 
 @test "Check combine-ncc exists and is executable" {
-  run command -v combine-ncc
-  [ "$status" -eq 0 ]
+  run_and_check -v combine-ncc
 }
 
 @test "Check decompress-ncc exists and is executable" {
-  run command -v decompress-ncc
-  [ "$status" -eq 0 ]
+  run_and_check -v decompress-ncc
 }
 
 @test "Check cr_lake_files exists and is executable" {
-     run command -v cr_lake_files
-     [ "$status" -eq 0 ]
+     run_and_check -v cr_lake_files
+
 }
 
 @test "Check cp_river_vars exists and is executable" {
-     run command -v cp_river_vars
-     [ "$status" -eq 0 ]
+     run_and_check -v cp_river_vars
 }
 
 @test "Check rmv_parallel_rivers exists and is executable" {
-     run command -v rmv_parallel_rivers
-     [ "$status" -eq 0 ]
+     run_and_check -v rmv_parallel_rivers
 }
 

--- a/t/Test02-mppnccombine.sh
+++ b/t/Test02-mppnccombine.sh
@@ -30,6 +30,6 @@ load test_utils
   mppnccombine \
       mppnccombine_output.nc \
       mppnccombine.nc.????
-  [ -e mppnccombine_output.nc ]
+  run_and_check [ -e mppnccombine_output.nc ]
   ncdump -h mppnccombine_output.nc
 }

--- a/t/Test03-grid_coupled_model.sh
+++ b/t/Test03-grid_coupled_model.sh
@@ -76,7 +76,7 @@ load test_utils
 		--vgrid ocean_vgrid.nc \
 		--output topog_parallel.nc
 
-       nccmp -md topog.nc topog_parallel.nc
+    run_and_check  nccmp -md topog.nc topog_parallel.nc
   fi
 
 
@@ -113,8 +113,9 @@ load test_utils
 		--ocean_topog  ../topog.nc \
 		--mosaic_name grid_spec  \
 		--area_ratio_thresh 1.e-10
+
       # compare any created files to non-parallel (exclude directory differences)
-      nccmp -md --exclude=atm_mosaic_dir --exclude=lnd_mosaic_dir --exclude=ocn_mosaic_dir \
+      run_and_check nccmp -md --exclude=atm_mosaic_dir --exclude=lnd_mosaic_dir --exclude=ocn_mosaic_dir \
                 --exclude=ocn_topog_dir grid_spec.nc ../grid_spec.nc
   fi
 }

--- a/t/Test04-grid_coupled_nest.sh
+++ b/t/Test04-grid_coupled_nest.sh
@@ -128,7 +128,7 @@ ncgen -o OCCAM_p5degree.nc $BATS_TEST_DIRNAME/Test03-input/OCCAM_p5degree.ncl
                         --land_mosaic ../land_mosaic.nc --ocean_mosaic ../ocean_mosaic.nc \
                         --ocean_topog  ../topog.nc --interp_order 1 --mosaic_name grid_spec
       # directory paths should differ
-      nccmp -md --exclude=atm_mosaic_dir --exclude=lnd_mosaic_dir --exclude=ocn_mosaic_dir \
+      run_and_check nccmp -md --exclude=atm_mosaic_dir --exclude=lnd_mosaic_dir --exclude=ocn_mosaic_dir \
                 --exclude=ocn_topog_dir grid_spec.nc ../grid_spec.nc
   fi
 }

--- a/t/Test12-mppnscatter.sh
+++ b/t/Test12-mppnscatter.sh
@@ -48,6 +48,6 @@ prepare_input_data ()
    mppnccombine -64 output/$test_file ${test_file}.????
 
   # Compare output
-   nccmp -w format -md output/$test_file input/$test_file
+   run_and_check nccmp -w format -md output/$test_file input/$test_file
 
 }

--- a/t/Test15-regrid_land.sh
+++ b/t/Test15-regrid_land.sh
@@ -64,7 +64,7 @@ load test_utils
 		--output_file out_parallel.nc  \
 		--remap_file remap_file.nc
 
-    nccmp -md out.nc out_parallel.nc
+    run_and_check nccmp -md out.nc out_parallel.nc
   fi
 
 # remap other fields

--- a/t/Test17-combine-ncc.sh
+++ b/t/Test17-combine-ncc.sh
@@ -29,7 +29,7 @@ load test_utils
   combine-ncc \
       combine-ncc.atmos_daily.nc.copy \
       combine-ncc_output.nc
-  [ -e combine-ncc_output.nc ]
-  ncdump -h combine-ncc_output.nc
+  run_and_check [ -e combine-ncc_output.nc ]
+  run_and_check ncdump -h combine-ncc_output.nc
 
 }

--- a/t/Test18-decompress-ncc.sh
+++ b/t/Test18-decompress-ncc.sh
@@ -29,6 +29,6 @@ load test_utils
    decompress-ncc \
       decompress-ncc.atmos_daily.nc.copy \
       decompress-ncc_output.nc
-  [ -e decompress-ncc_output.nc ]
-  ncdump -h decompress-ncc_output.nc
+  run_and_check  [ -e decompress-ncc_output.nc ]
+  run_and_check ncdump -h decompress-ncc_output.nc
 }

--- a/t/Test21-reference_mppnccombine.sh
+++ b/t/Test21-reference_mppnccombine.sh
@@ -33,12 +33,12 @@ load test_utils
    mppnccombine \
       mppnccombine_output.nc \
       mppnccombine.nc.????
-  [ -e mppnccombine_output.nc ]
+  run_and_check [ -e mppnccombine_output.nc ]
   ncdump -h mppnccombine_output.nc
 
-  [ -e $top_srcdir/t/Test02-reference/mppnccombine_output.nc ]
+  run_and_check [ -e $top_srcdir/t/Test02-reference/mppnccombine_output.nc ]
 
   nccmp -V
 
-  nccmp -d mppnccombine_output.nc  $top_srcdir/t/Test02-reference/mppnccombine_output.nc
+  run_and_check nccmp -d mppnccombine_output.nc  $top_srcdir/t/Test02-reference/mppnccombine_output.nc
 }

--- a/t/Test22-reference_combine-ncc.sh
+++ b/t/Test22-reference_combine-ncc.sh
@@ -30,12 +30,12 @@ load test_utils
    combine-ncc \
       combine-ncc.atmos_daily.nc.copy \
       combine-ncc_output.nc
-  [ -e combine-ncc_output.nc ]
+  run_and_check [ -e combine-ncc_output.nc ]
   ncdump -h combine-ncc_output.nc
 
-  [ -e $top_srcdir/t/Test17-reference/combine-ncc_output.nc ]
+  run_and_check [ -e $top_srcdir/t/Test17-reference/combine-ncc_output.nc ]
 
-  nccmp -V
+  run_and_check  nccmp -V
 
-  nccmp -d combine-ncc_output.nc  $top_srcdir/t/Test17-reference/combine-ncc_output.nc
+  run_and_check  nccmp -d combine-ncc_output.nc  $top_srcdir/t/Test17-reference/combine-ncc_output.nc
 }

--- a/t/Test23-reference_decompress-ncc.sh
+++ b/t/Test23-reference_decompress-ncc.sh
@@ -29,12 +29,12 @@ load test_utils
    decompress-ncc \
       decompress-ncc.atmos_daily.nc.copy \
       decompress-ncc_output.nc
-  [ -e decompress-ncc_output.nc ]
+  run_and_check [ -e decompress-ncc_output.nc ]
   ncdump -h decompress-ncc_output.nc
 
-  [ -e $top_srcdir/t/Test18-reference/decompress-ncc_output.nc ]
+  run_and_check [ -e $top_srcdir/t/Test18-reference/decompress-ncc_output.nc ]
 
-  nccmp -V
+  run_and_check nccmp -V
 
-  nccmp -d decompress-ncc_output.nc  $top_srcdir/t/Test18-reference/decompress-ncc_output.nc
+  run_and_check nccmp -d decompress-ncc_output.nc  $top_srcdir/t/Test18-reference/decompress-ncc_output.nc
 }

--- a/t/Test24-reference_fregrid.sh
+++ b/t/Test24-reference_fregrid.sh
@@ -56,15 +56,15 @@ load test_utils
 		--output_mosaic latlon_mosaic.nc   \
 		--check_conserve
 
-   [ -e ocean_temp_salt.res.latlon.nc ]
-   [ -e $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc ]
+   run_and_check [ -e ocean_temp_salt.res.latlon.nc ]
+   run_and_check [ -e $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc ]
 
-   nccmp -V
+   run_and_check nccmp -V
 
-   nccmp -d  ocean_temp_salt.res.latlon.nc  $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc
+   run_and_check nccmp -d  ocean_temp_salt.res.latlon.nc  $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc
 
-   [ -e latlon_mosaic.nc ]
-   [ -e $top_srcdir/t/Test20-reference/latlon_mosaic.nc ]
+   run_and_check [ -e latlon_mosaic.nc ]
+   run_and_check [ -e $top_srcdir/t/Test20-reference/latlon_mosaic.nc ]
 
-   nccmp -d  latlon_mosaic.nc  $top_srcdir/t/Test20-reference/latlon_mosaic.nc
+   run_and_check  nccmp -d  latlon_mosaic.nc  $top_srcdir/t/Test20-reference/latlon_mosaic.nc
 }

--- a/t/Test25-hydrology.sh
+++ b/t/Test25-hydrology.sh
@@ -47,6 +47,6 @@ load test_utils
 
   #Run wrapper hydrology script
   run $top_srcdir/tools/simple_hydrog/share/make_simple_hydrog.csh -f 0. -t 1.e-5 -m $top_srcdir/t/Test25-input/grid_spec.nc
-  [ "$status" -eq 0 ]
+  run_and_check [ "$status" -eq 0 ]
 
 }

--- a/t/Test26-reference_fregrid_gcc.sh
+++ b/t/Test26-reference_fregrid_gcc.sh
@@ -56,16 +56,16 @@ load test_utils
 		--output_mosaic latlon_mosaic.nc   \
 		--check_conserve
 
-   [ -e ocean_temp_salt.res.latlon.nc ]
-   [ -e $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc ]
+   run_and_check [ -e ocean_temp_salt.res.latlon.nc ]
+   run_and_check [ -e $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc ]
 
-   nccmp -V
+   run_and_check nccmp -V
 
    # checks values with float tolerance to bypass any result differences from compilers
-   nccmp -d -t 0.000001  ocean_temp_salt.res.latlon.nc  $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc
+   run_and_check nccmp -d -t 0.000001  ocean_temp_salt.res.latlon.nc  $top_srcdir/t/Test20-reference/ocean_temp_salt.res.latlon.nc
 
-   [ -e latlon_mosaic.nc ]
-   [ -e $top_srcdir/t/Test20-reference/latlon_mosaic.nc ]
+   run_and_check [ -e latlon_mosaic.nc ]
+   run_and_check [ -e $top_srcdir/t/Test20-reference/latlon_mosaic.nc ]
 
-   nccmp -d  latlon_mosaic.nc  $top_srcdir/t/Test20-reference/latlon_mosaic.nc
+   run_and_check nccmp -d  latlon_mosaic.nc  $top_srcdir/t/Test20-reference/latlon_mosaic.nc
 }

--- a/t/Test31-fregrid_stretched.sh
+++ b/t/Test31-fregrid_stretched.sh
@@ -1,65 +1,84 @@
 #!/usr/bin/env bats
+
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+#
+# FRE-NCTools is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FRE-NCTools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FRE-NCTools.  If not, see
+# <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+load test_utils
+
 # test stretched grid
 
 @test "Test stretched grid data lats 32.0 34.0 35.4" {
 
-  if [ ! -d "Test31" ] 
+  if [ ! -d "Test31" ]
   then
   		mkdir Test31
   fi
 
   cd Test31
-   cp $top_srcdir/t/Test31-input/ocean_hgrid.nc . 
+   cp $top_srcdir/t/Test31-input/ocean_hgrid.nc .
    cp $top_srcdir/t/Test31-input/ocean_mosaic.nc .
    cp $top_srcdir/t/Test31-input/ocean_topog.nc .
 
-#Make streetched grid 
-  run command make_hgrid \
+#Make streetched grid
+  run_and_check make_hgrid \
                --grid_type gnomonic_ed --do_schmidt \
                --stretch_factor 2.5 \
                --target_lon 262.4 \
                --target_lat 32.0 \
                --nlon 512 \
                --grid_name C256_grid_32.0
-  [ "$status" -eq 0 ]
 
-  run command make_hgrid \
+  run_and_check make_hgrid \
                --grid_type gnomonic_ed --do_schmidt \
                --stretch_factor 2.5 \
                --target_lon 262.4 \
                --target_lat 32.0 \
                --nlon 512 \
                --grid_name C256_grid_34.0
-  [ "$status" -eq 0 ]
 
-  run command make_hgrid \
+
+ run_and_check make_hgrid \
                --grid_type gnomonic_ed --do_schmidt \
                --stretch_factor 2.5 \
                --target_lon 262.4 \
                --target_lat 35.4 \
                --nlon 512 \
                --grid_name C256_grid_35.4
-  [ "$status" -eq 0 ]
-
 
 #Create stretched grid mosaic
-  run command make_solo_mosaic \
+  run_and_check make_solo_mosaic \
                 --num_tiles 6 \
                 --dir ./ \
                 --mosaic_name C256_mosaic_32.0 --tile_file C256_grid_32.0.tile1.nc,C256_grid_32.0.tile2.nc,C256_grid_32.0.tile3.nc,C256_grid_32.0.tile4.nc,C256_grid_32.0.tile5.nc,C256_grid_32.0.tile6.nc
-  [ "$status" -eq 0 ]
 
-  run command make_solo_mosaic \
+
+  run_and_check make_solo_mosaic \
                 --num_tiles 6 \
                 --dir ./ \
                 --mosaic_name C256_mosaic_34.0 --tile_file C256_grid_34.0.tile1.nc,C256_grid_34.0.tile2.nc,C256_grid_34.0.tile3.nc,C256_grid_34.0.tile4.nc,C256_grid_34.0.tile5.nc,C256_grid_34.0.tile6.nc
-  [ "$status" -eq 0 ]
 
-  run command make_solo_mosaic \
+
+  run_and_check make_solo_mosaic \
                 --num_tiles 6 \
                 --dir ./ \
                 --mosaic_name C256_mosaic_35.4 --tile_file C256_grid_35.4.tile1.nc,C256_grid_35.4.tile2.nc,C256_grid_35.4.tile3.nc,C256_grid_35.4.tile4.nc,C256_grid_35.4.tile5.nc,C256_grid_35.4.tile6.nc
-  [ "$status" -eq 0 ]
 
 # stretched grid lats 32.0 34.0 35.4
   run bash -c 'fregrid \
@@ -75,8 +94,7 @@
                 | awk 'NR==4' | rev | cut -c39-49 | rev'
   var_32_0=$(echo $output | awk '{ print sprintf("%.9f", $1); }')
   echo $output
-  expr ${var_32_0} \< 0.00001
-  [ "$status" -eq 0 ] 
+  run_and_check expr ${var_32_0} \< 0.00001
 
   run bash -c 'fregrid \
                 --input_mosaic C256_mosaic_34.0.nc \
@@ -91,8 +109,8 @@
                 | awk 'NR==4' | rev | cut -c39-49 | rev'
   var_34_0=$(echo $output | awk '{ print sprintf("%.9f", $1); }')
   echo $output
-  expr ${var_34_0} \< 0.00001  
-  [ "$status" -eq 0 ]
+  run_and_check expr ${var_34_0} \< 0.00001
+
 
   run bash -c 'fregrid \
                 --input_mosaic C256_mosaic_35.4.nc \
@@ -107,9 +125,8 @@
                 | awk 'NR==4' | rev | cut -c39-49 | rev'
   var_35_4=$(echo $output | awk '{ print sprintf("%.9f", $1); }')
   echo $output
-  expr ${var_35_4} \< 0.00001
-  [ "$status" -eq 0 ] 
- 
+  run_and_check expr ${var_35_4} \< 0.00001
+
   cd ..
 #  rm -rf Test31
 }

--- a/t/Test32-fregrid_no_stretched.sh
+++ b/t/Test32-fregrid_no_stretched.sh
@@ -1,55 +1,72 @@
 #!/usr/bin/env bats
-# test no stretched grid 
+
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+#
+# FRE-NCTools is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FRE-NCTools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FRE-NCTools.  If not, see
+# <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+load test_utils
+
+# test no stretched grid
 
 @test "Test no stretched grid data lats 32.0 34.0 35.4" {
 
-  if [ ! -d "Test32" ] 
+  if [ ! -d "Test32" ]
   then
   		mkdir Test32
   fi
 
   cd Test32
-  cp $top_srcdir/t/Test32-input/ocean_hgrid.nc . 
+  cp $top_srcdir/t/Test32-input/ocean_hgrid.nc .
   cp $top_srcdir/t/Test32-input/ocean_mosaic.nc .
   cp $top_srcdir/t/Test32-input/topog.nc .
 
-#Make no stretched grid 
-  run command make_hgrid \
+#Make no stretched grid
+  run_and_check  make_hgrid \
                --grid_type gnomonic_ed \
                --nlon 512 \
                --grid_name C256_grid_32.0
-  [ "$status" -eq 0 ]
 
-  run command make_hgrid \
+  run_and_check  make_hgrid \
                --grid_type gnomonic_ed \
                --nlon 512 \
                --grid_name C256_grid_34.0
-  [ "$status" -eq 0 ]
 
-  run command make_hgrid \
+  run_and_check  make_hgrid \
                --grid_type gnomonic_ed \
                --nlon 512 \
                --grid_name C256_grid_35.4
-  [ "$status" -eq 0 ]
 
 #Create no stretched grid mosaic
-  run command make_solo_mosaic \
+  run_and_check  make_solo_mosaic \
                 --num_tiles 6 \
                 --dir ./ \
                 --mosaic_name C256_mosaic_32.0 --tile_file C256_grid_32.0.tile1.nc,C256_grid_32.0.tile2.nc,C256_grid_32.0.tile3.nc,C256_grid_32.0.tile4.nc,C256_grid_32.0.tile5.nc,C256_grid_32.0.tile6.nc
-  [ "$status" -eq 0 ]
 
-  run command make_solo_mosaic \
+  run_and_check  make_solo_mosaic \
                 --num_tiles 6 \
                 --dir ./ \
                 --mosaic_name C256_mosaic_34.0 --tile_file C256_grid_34.0.tile1.nc,C256_grid_34.0.tile2.nc,C256_grid_34.0.tile3.nc,C256_grid_34.0.tile4.nc,C256_grid_34.0.tile5.nc,C256_grid_34.0.tile6.nc
-  [ "$status" -eq 0 ]
 
-  run command make_solo_mosaic \
+  run_and_check  make_solo_mosaic \
                 --num_tiles 6 \
                 --dir ./ \
                 --mosaic_name C256_mosaic_35.4 --tile_file C256_grid_35.4.tile1.nc,C256_grid_35.4.tile2.nc,C256_grid_35.4.tile3.nc,C256_grid_35.4.tile4.nc,C256_grid_35.4.tile5.nc,C256_grid_35.4.tile6.nc
-  [ "$status" -eq 0 ]
 
 # no stretched grid lats 32.0 34.0 35.4
   run bash -c 'fregrid \
@@ -65,8 +82,7 @@
                 | awk 'NR==4' | rev | cut -c39-49 | rev'
   var_32_0=$(echo $output | awk '{ print sprintf("%.9f", $1); }')
   echo $output
-  expr ${var_32_0} \< 0.00001 
-  [ "$status" -eq 0 ]
+  run_and_check expr ${var_32_0} \< 0.00001
 
   run bash -c 'fregrid \
                 --input_mosaic C256_mosaic_34.0.nc \
@@ -81,8 +97,9 @@
                 | awk 'NR==4' | rev | cut -c39-49 | rev'
   var_34_0=$(echo $output | awk '{ print sprintf("%.9f", $1); }')
   echo $output
-  expr ${var_34_0} \< 0.00001
-  [ "$status" -eq 0 ]
+ run_and_check expr ${var_34_0} \< 0
+  #run_and_check expr ${var_34_0} \< 0.00001
+
 
   run bash -c 'fregrid \
                 --input_mosaic C256_mosaic_35.4.nc \
@@ -97,8 +114,7 @@
                 | awk 'NR==4' | rev | cut -c39-49 | rev'
   var_35_4=$(echo $output | awk '{ print sprintf("%.9f", $1); }')
   echo $output
-  expr ${var_35_4} \< 0.00001
-  [ "$status" -eq 0 ] 
+  run_and_check expr ${var_35_4} \< 0.00001
 
   cd ..
  # rm -rf Test32

--- a/t/Test32-fregrid_no_stretched.sh
+++ b/t/Test32-fregrid_no_stretched.sh
@@ -97,8 +97,7 @@ load test_utils
                 | awk 'NR==4' | rev | cut -c39-49 | rev'
   var_34_0=$(echo $output | awk '{ print sprintf("%.9f", $1); }')
   echo $output
- run_and_check expr ${var_34_0} \< 0
-  #run_and_check expr ${var_34_0} \< 0.00001
+  run_and_check expr ${var_34_0} \< 0.00001
 
 
   run bash -c 'fregrid \

--- a/t/Test33-reference_make_hgrid.sh
+++ b/t/Test33-reference_make_hgrid.sh
@@ -40,7 +40,7 @@ fv3_grids_filelist=""
 for i in 1 2 3 4 5 6
 do
     fv3_file=$fv3_grid_name".tile"$i".nc"
-   [ -e $top_srcdir/t/Test33-reference/$fv3_file ]
+   run_and_check [ -e $top_srcdir/t/Test33-reference/$fv3_file ]
 done
 
 cp $top_srcdir/t/Test33-reference/*.nc .

--- a/t/test_utils.bash
+++ b/t/test_utils.bash
@@ -83,8 +83,8 @@ generate_all_from_ncl(){
   done
 }
 
-# run the command (the argument list; 1st in list is the command) using the bats "run command"
-#  its status function, and theck the status is 0
+# run the command (the argument list; 1st in list is the command) using the bats "run command",
+# theck the status is 0, and echo the output if not.
 function run_and_check()
 {
     local cmd="$*" #Expands the list into a single string; spearating parms with space.


### PR DESCRIPTION
This PR modifies test scripts that checked for answers or function status to use the new run_and_check() function 
found in test_utils.bash. Said function was created in previous PR to echo $output if the status of the
executed command was not 0.

For an example of the output produced in the github CI actions/runs that encounter failures, 
test 32 was forced to fail by giving it a threshold of zero on line 100. This line :
 ```run_and_check expr ${var_34_0} \< 0.00001```
was changed to this:
```run_and_check expr ${var_34_0} \< 0```
The output produced is:
```
FAIL: Test32-fregrid_no_stretched.sh 1 Test no stretched grid data lats 32.0 34.0 35.4
# Test32-fregrid_no_stretched.sh: (from function `run_and_check' in file /__w/FRE-NCtools/FRE-NCtools/t/test_utils.bash, line 95,
# Test32-fregrid_no_stretched.sh: in test file /__w/FRE-NCtools/FRE-NCtools/t/Test32-fregrid_no_stretched.sh, line 100)
# Test32-fregrid_no_stretched.sh: `run_and_check expr ${var_34_0} \< 0' failed
# Test32-fregrid_no_stretched.sh: 9.97102e-07
# Test32-fregrid_no_stretched.sh: 9.97102e-07
# Test32-fregrid_no_stretched.sh: failed: expr 0.000000997 < 0
```
