### PR TITLE
Modified create_xgrid for reproducibility

### DIFF
--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -982,7 +982,7 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
 #pragma acc loop independent reduction(+:nxgrid)
-      for(ij=0; ij<=nx2*ny2; ij++) {
+      for(ij=0; ij<nx2*ny2; ij++) {
 	int n_out, i2, j2, n2_in;
 	double xarea, dx, lon_out_min, lon_out_max;
 	double x2_in[MAX_V], y2_in[MAX_V];

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -964,7 +964,6 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
     }
   }
 
-  //#pragma acc loop seq
 #pragma acc loop independent collapse(2) //reduction(+:nxgrid)
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n0, n1, n2, n3, n1_in;
@@ -1442,13 +1441,13 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
   /* clip polygon with each boundary of the polygon */
   /* We treat lon1_in/lat1_in as clip polygon and lon2_in/lat2_in as subject polygon */
   n_out = n1_in;
-  //#pragma acc loop seq
+#pragma acc loop seq
   for(i1=0; i1<n1_in; i1++) {
     lon_tmp[i1] = lon1_in[i1];
     lat_tmp[i1] = lat1_in[i1];
     if(lon_tmp[i1]>TPI || lon_tmp[i1]<0.0) gttwopi = 1;
   }
-  //#pragma acc loop seq
+#pragma acc loop seq
   for(i2=0; i2<n2_in; i2++) {
     lon2_tmp[i2] = lon2_in[i2];
     lat2_tmp[i2] = lat2_in[i2];
@@ -1465,7 +1464,7 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
     x1_0 = lon_tmp[n_out-1];
     y1_0 = lat_tmp[n_out-1];
     inside_last = inside_edge( x2_0, y2_0, x2_1, y2_1, x1_0, y1_0);
-    //#pragma acc loop seq
+#pragma acc loop seq
     for(i1=0, i_out=0; i1<n_out; i1++) {
       x1_1 = lon_tmp[i1];
       y1_1 = lat_tmp[i1];
@@ -1499,7 +1498,7 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
       inside_last = inside;
     }
     if(!(n_out=i_out)) return 0;
-    //#pragma acc loop seq
+#pragma acc loop seq
     for(i1=0; i1<n_out; i1++) {
       lon_tmp[i1] = lon_out[i1];
       lat_tmp[i1] = lat_out[i1];


### PR DESCRIPTION
In this PR, the `create_xgrid_2dx2d_order2` subroutine has been modified to fix reproducibility issues when running on GPUs.