### PR TITLE
Code for changing poly_area by rotating polar polygons away from pole.

### DIFF
--- a/tools/libfrencutils/constant.h
+++ b/tools/libfrencutils/constant.h
@@ -24,8 +24,18 @@
 #define RADIUS        (6371000.)
 #define STRING        255
 
+#include <math.h>
+
 #ifndef M_PI
-#define M_PI		(3.14159265358979323846)
+#define M_PI	(3.14159265358979323846)
+#endif
+
+#ifndef M_PI_2
+#define M_PI_2  (1.57079632679489661923)
+#endif
+
+#ifndef M_SQRT2
+#define M_SQRT2  (1.41421356237309504880)
 #endif
 
 #define R2D (180/M_PI)

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -235,6 +235,8 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     tmpy[j1*nx1p+i1] = lat_in[j1];
   }
   /* This is just a temporary fix to solve the issue that there is one point in zonal direction */
+  //TODO: Finish this "temporary fix"
+  exit(-1);
   if(nx1 > 1)
      get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);
   else
@@ -1284,7 +1286,7 @@ int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
   }
   //Some grid boxes near North Pole are clipped wrong (issue #42 )
   //The following heuristic fix seems to work. Why?
-  if(gttwopi){pimod(lon_tmp,n1_in);pimod(lon2_tmp,n2_in);} 
+  if(gttwopi){pimod(lon_tmp,n1_in);pimod(lon2_tmp,n2_in);}
 
   x2_0 = lon2_tmp[n2_in-1];
   y2_0 = lat2_tmp[n2_in-1];
@@ -2785,7 +2787,7 @@ int main(int argc, char* argv[])
     case 14:
       /****************************************************************
        test clip_2dx2d_great_cirle case 14: Cubic sphere grid at tile = 3, point (i=24,j=1)
-         identical grid boxes 
+         identical grid boxes
       ****************************************************************/
       /*
       nlon1 = 1;
@@ -2835,7 +2837,7 @@ int main(int argc, char* argv[])
 
     case 16:
       /*Must give [[-57.748, -30, -30, -97.6, -97.6],
-                   [89.876, 89.891, 90, 90, 89.9183]]*/ 
+                   [89.876, 89.891, 90, 90, 89.9183]]*/
       n1_in = 6; n2_in = 5;
       double lon1_16[] = {82.400,  82.400, 262.400, 262.400, 326.498, 379.641};
       double lat1_16[] = {89.835,  90.000,  90.000,  89.847,  89.648,  89.642};
@@ -2877,11 +2879,11 @@ int main(int argc, char* argv[])
       /*Must give nothing*/
     case 19:
       /****************************************************************
-        test clip_2dx2d 2: two boxes that include the North Pole 
+        test clip_2dx2d 2: two boxes that include the North Pole
                            one has vertices on the tripolar fold
                            the other is totally outside the first
                            This actually happens for some stretched grid
-                           configurations  mosaic_c256r25tlat32.0_om4p25 
+                           configurations  mosaic_c256r25tlat32.0_om4p25
         The test gives wrong answers!
       ****************************************************************/
       n1_in = 6; n2_in = 5;
@@ -2898,7 +2900,7 @@ int main(int argc, char* argv[])
 
     case 20:
       /*Must give
- n_out= 5 
+ n_out= 5
  122.176, 150, 150, 82.4, 82.4,
  89.761, 89.789, 90, 90, 89.8429,
        */      n1_in = 6; n2_in = 5;
@@ -2915,10 +2917,10 @@ int main(int argc, char* argv[])
 
     case 21:
       /*Must give
- n_out= 5 
+ n_out= 5
  60.000,  82.400,  82.400,  60.000],
  89.889,  89.843,  90.000,  90.000]
-       */      
+       */
       n1_in = 6; n2_in = 5;
       double lon1_21[] = {82.400,  82.400, 262.400, 262.400, 326.498, 379.641};
       double lat1_21[] = {89.835,  90.000,  90.000,  89.847,  89.648,  89.642};
@@ -2934,7 +2936,7 @@ int main(int argc, char* argv[])
     case 26:
       /*Side crosses SP (Right cell).
 	Must give same box
-      */      
+      */
       n1_in = 4; n2_in = 4;
       double lon1_22[] = {209.68793552504,158.60256162113,82.40000000000,262.40000000000};
       double lat1_22[] = {-89.11514201451,-89.26896927380,-89.82370183256, -89.46584623220};
@@ -2950,8 +2952,8 @@ int main(int argc, char* argv[])
     case 23:
       /*Side does not cross SP (Right cell).
 	Must give same box
-      */      
-      
+      */
+
       n1_in = 4; n2_in = 4;
       double lon1_23[] = {158.60256162113,121.19651597620,82.40000000000,82.40000000000};
       double lat1_23[] = {-89.26896927380,-88.85737639760,-89.10746816044,-89.82370183256};
@@ -2967,7 +2969,7 @@ int main(int argc, char* argv[])
     case 24:
       /*Side crosses SP (Left cell). Added twin poles.
 	Must give the same box
-      */      
+      */
       n1_in = 6; n2_in = 6;
       double lon1_24[] = {262.40000000000,262.40000000000,82.4,82.4,6.19743837887,-44.88793552504};
       double lat1_24[] = {-89.46584623220,-90.0,         -90.0,-89.82370183256, -89.26896927380, -89.11514201451};
@@ -2980,9 +2982,9 @@ int main(int argc, char* argv[])
       memcpy(lat2_in,lat2_24,sizeof(lat2_in));
       break;
     case 25:
-      /*Side crosses SP (Left cell). 
+      /*Side crosses SP (Left cell).
 	Must givethe same box
-      */      
+      */
       n1_in = 4; n2_in = 4;
       double lon1_25[] = {262.40000000000,82.4,6.19743837887,-44.88793552504};
       double lat1_25[] = {-89.46584623220, -89.82370183256, -89.26896927380, -89.11514201451};
@@ -2997,7 +2999,7 @@ int main(int argc, char* argv[])
     case 22:
       /*Side does not cross SP (Left cell).
 	Must give same box
-      */       
+      */
       n1_in = 4; n2_in = 4;
       double lon1_26[] = {82.4,82.4,43.60348402380,6.19743837887};
       double lat1_26[] = {-89.82370183256, -89.10746816044, -88.85737639760, -89.26896927380};
@@ -3110,7 +3112,7 @@ int main(int argc, char* argv[])
       printf("\n");
       for(i=0; i<n2_in; i++) printf(" %g,", lat2_in[i]*R2D);
       printf("\n");
-      
+
 
       printf("     output clip grid box longitude, latitude, area= %g \n ",area_out);
       printf("n_out= %d \n",n_out);
@@ -3118,7 +3120,7 @@ int main(int argc, char* argv[])
       printf("\n");
       for(i=0; i<n_out; i++) printf(" %g,", lat_out[i]*R2D);
       printf("\n");
-      if(area1>1.0e14 || area2>1.0e14 || area_out>1.0e14) printf("Error in calculating area !\n");  
+      if(area1>1.0e14 || area2>1.0e14 || area_out>1.0e14) printf("Error in calculating area !\n");
       if(n==16 || n==20) printf("Must result n_out=5!\n");
       if(n==21) printf("Must result n_out=4!\n");
       if(n==15 || n==17) printf("Must result the second box!\n");

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -235,8 +235,7 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     tmpy[j1*nx1p+i1] = lat_in[j1];
   }
   /* This is just a temporary fix to solve the issue that there is one point in zonal direction */
-  //TODO: Finish this "temporary fix"
-  exit(-1);
+  // TODO: Finish this "temporary fix"
   if(nx1 > 1)
      get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);
   else

--- a/tools/libfrencutils/create_xgrid.h
+++ b/tools/libfrencutils/create_xgrid.h
@@ -33,13 +33,13 @@ double box_ctrlat(double ll_lon, double ll_lat, double ur_lon, double ur_lat);
 int get_maxxgrid(void);
 void get_grid_area(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
-void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
+//void get_grid_area_dimensionless(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 void get_grid_area_no_adjust(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 int clip(const double lon_in[], const double lat_in[], int n_in, double ll_lon, double ll_lat,
 	 double ur_lon, double ur_lat, double lon_out[], double lat_out[]);
 void pimod(double x[],int nn);
-int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in, 
-	       const double lon2_in[], const double lat2_in[], int n2_in, 
+int clip_2dx2d(const double lon1_in[], const double lat1_in[], int n1_in,
+	       const double lon2_in[], const double lat2_in[], int n2_in,
 	       double lon_out[], double lat_out[]);
 int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
 			      const double *lat_in, const double *lon_out, const double *lat_out,
@@ -65,8 +65,8 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
 			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
 			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat);
-int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in, 
-			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in, 
+int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const double z1_in[], int n1_in,
+			    const double x2_in[], const double y2_in[], const double z2_in [], int n2_in,
 			    double x_out[], double y_out[], double z_out[]);
 int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
 			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,

--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -37,17 +37,28 @@
 #define EPSLN10 (1.e-10)
 #define EPSLN15 (1.e-15)
 #define EPSLN30 (1.e-30)
+
+const double from_pole_threshold_rad = 0.0174533;  // 1.0 deg
+
+int reproduce_siena = 0;
+int rotate_poly_flag = 0;
+double the_rotation_matrix[3][3] = { 0 };
+
+void set_reproduce_siena_true(void){
+  reproduce_siena = 1;
+}
+
+void set_rotate_poly_true(void){
+  rotate_poly_flag = 1;
+  set_the_rotation_matrix();
+}
+
+
+
 /***********************************************************
     void error_handler(char *str)
     error handler: will print out error message and then abort
 ***********************************************************/
-int reproduce_siena = 0;
-
-void set_reproduce_siena_true(void)
-{
-  reproduce_siena = 1;
-}
-
 void error_handler(const char *msg)
 {
   fprintf(stderr, "FATAL Error: %s\n", msg );
@@ -56,7 +67,7 @@ void error_handler(const char *msg)
 #else
   exit(1);
 #endif
-}; /* error_handler */
+} /* error_handler */
 
 /*********************************************************************
 
@@ -100,15 +111,15 @@ int nearest_index(double value, const double *array, int ia)
     }
   return index;
 
-};
+}
 
 /******************************************************************/
 
 void tokenize(const char * const string, const char *tokens, unsigned int varlen,
          unsigned int maxvar, char * pstring, unsigned int * const nstr)
 {
-  size_t i, j, nvar, len, ntoken;
-  int found, n;
+  size_t i, j, nvar, len, ntoken, n;
+  int found;
 
   nvar = 0; j = 0;
   len = strlen(string);
@@ -160,7 +171,7 @@ double maxval_double(int size, const double *data)
 
   return maxval;
 
-}; /* maxval_double */
+} /* maxval_double */
 
 
 /*******************************************************************************
@@ -179,7 +190,7 @@ double minval_double(int size, const double *data)
 
   return minval;
 
-}; /* minval_double */
+} /* minval_double */
 
 /*******************************************************************************
   double avgval_double(int size, double *data)
@@ -196,7 +207,7 @@ double avgval_double(int size, const double *data)
 
   return avgval;
 
-}; /* avgval_double */
+} /* avgval_double */
 
 
 /*******************************************************************************
@@ -223,7 +234,7 @@ void xyz2latlon( int np, const double *x, const double *y, const double *z, doub
 {
 
   double xx, yy, zz;
-  double dist, sinp;
+  double dist;
   int i;
 
   for(i=0; i<np; i++) {
@@ -253,16 +264,18 @@ void xyz2latlon( int np, const double *x, const double *y, const double *z, doub
 double box_area(double ll_lon, double ll_lat, double ur_lon, double ur_lat)
 {
   double dx = ur_lon-ll_lon;
-  double area;
 
   if(dx > M_PI)  dx = dx - 2.0*M_PI;
   if(dx < -M_PI) dx = dx + 2.0*M_PI;
 
   return (dx*(sin(ur_lat)-sin(ll_lat))*RADIUS*RADIUS ) ;
 
-}; /* box_area */
+} /* box_area */
 
 
+//TODO: Determine if poly_area_dimensionless can be deleted.
+//  Possibly functions that call it (e.g. get_grid_area_dimensionless)
+// can also be deleted.
 /*------------------------------------------------------------------------------
   double poly_area(const x[], const y[], int n)
   obtains area of input polygon by line integrating -sin(lat)d(lon)
@@ -287,7 +300,7 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
     if(dx < -M_PI) dx = dx + 2.0*M_PI;
     if (dx==0.0) continue;
 
-    if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
+    if ( fabs(lat1-lat2) < SMALL_VALUE) // cheap area calculation along latitude
       area -= dx*sin(0.5*(lat1+lat2));
     else {
       if(reproduce_siena) {
@@ -301,14 +314,13 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
     }
   }
   if(fabs(area) > HPI) {
-    printf("Error in poly_area_dimensionless: Large values for poly_area_dimensionless: %19.15f\n", area); 
-  } 
+    printf("Error in poly_area_dimensionless: Large values for poly_area_dimensionless: %19.15f\n", area);
+  }
   if(area < 0)
     return (-area/(4*M_PI));
   else
     return (area/(4*M_PI));
-
-}; /* poly_area */
+}
 
 /*------------------------------------------------------------------------------
   double poly_area(const x[], const y[], int n)
@@ -321,25 +333,25 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
              Spherical Coordinates, P. Jones, Monthly Weather Review, 1998, vol127, p2204
   The following is an implementation of equation (12) in the above paper:
      \int dA = \int_c [-sin(lat)] dlon
-  
+
   An alternative derivation of line integrating -sin(lat)d(lon) formula:
-  Consider a vector function in spherical coordinates (r,lon,lat) 
+  Consider a vector function in spherical coordinates (r,lon,lat)
   with only a lon component :
-      A=(0, (1-sin(lat))/cos(lat)/r , 0)  
-  Then  
-      Curl(A)=(1/r**2 , 0, 0) .  
-  Now consider any loop C on the suface of the sphere enclosing an area S 
-  and apply the Stokes theorem: 
-      \integral_surface_S Curl(A).da = \integral_loop_C A.dl 
+      A=(0, (1-sin(lat))/cos(lat)/r , 0)
+  Then
+      Curl(A)=(1/r**2 , 0, 0) .
+  Now consider any loop C on the suface of the sphere enclosing an area S
+  and apply the Stokes theorem:
+      \integral_surface_S Curl(A).da = \integral_loop_C A.dl
   where da and dl are the vectorial suface and line elements on sphere:
       da=(da, 0, 0) and dl=(0, R*cos(lat)*d(lon), R*d(lat)).
   We get
       \integral_surface_S Curl(A) = \integral_surface_S (da/r**2) = S/R**2
   and
-      \integral_loop_C A.dl = \integral_loop_C (1-sin(lat))*d(lon) 
+      \integral_loop_C A.dl = \integral_loop_C (1-sin(lat))*d(lon)
 
   Hence per Stokes formula:
-      S/R**2 = \integral_loop_C d(lon) - \integral_loop_C sin(lat)*d(lon). 
+      S/R**2 = \integral_loop_C d(lon) - \integral_loop_C sin(lat)*d(lon).
              = I1 - I2
 
   Now the approximation used for the second loop integral
@@ -350,7 +362,7 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
   If d(lon)/d(lat) is assumed constant over a loop segment, given that the segments
   used here are the sides of a grid cell, then we can take it outside the integral
     sum_over_loop_segments \integral_loop_C sin(lat)*d(lat) *d(lon)/d(lat)
-   =sum_over_loop_segments delta(lon)/delta(lat) \int_segment sin(lat)*d(lat) 
+   =sum_over_loop_segments delta(lon)/delta(lat) \int_segment sin(lat)*d(lat)
    =sum_over_grid_cell_sides (lon2-lon1)/(lat2-lat1) * (-(cos(lat2)-cos(lat1)))
    =sum_over_grid_cell_sides (lon2-lon1)/(lat2-lat1) * (2*sin(0.5*(lat2+lat1))*sin(0.5*(lat2-lat1)))
 
@@ -376,7 +388,7 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
    as the next vertex in the cell (which is 90 degrees or close to 90 degrees appart) the contribution to I1 shifts into -I2
    and we can again assume I1=0. This scheme is implemented in subroutine fix_lon() which is always called before poly_area().
    That is why in the implementation below I1 is totally absent.
-    
+
    In some pathological grid cells that do not have a pole vertex, I1 may not come out zero due to ambiguities in choosing
    d(lon) mod 2pi and we have to be careful in the implementation to deal with those grid cells.
    As we saw the approximation for I2 is based on the assumtion that  d(lon)/d(lat) is
@@ -385,12 +397,12 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
    i.e., lat = lat1 + (lon-lon1)*(lat2-lat1)/(lon2-lon1)
    This assumption breaks down if the segment passes through a pole, e.g. along a longitude great circle where
    lon abruptly changes by pi as it goes through the pole like in the following two grid cells:
-       x----x----x  
+       x----x----x
        |    |    |
        |   Pole  |
        |    |    |
        |    |    |
-       x----x----x  
+       x----x----x
     x denotes the grid points.
     We can diagnose such situations
       either via I1=sum(dlons) coming out as 2*pi instead of 0, in that case we can correct the area by 2*pi
@@ -412,66 +424,125 @@ double poly_area_dimensionless(const double x[], const double y[], int n)
   So, I2=\integral dx sin(arctan(tan(lat0)*cos(x-lon0)))  can be shown to give an accurate estimate of grid
   cell areas surrounding the pole without a bump.
    ----------------------------------------------------------------------------*/
-double poly_area(const double x[], const double y[], int n)
-{
+double poly_area_main(const double x[], const double y[], int n) {
   double area = 0.0;
-  int    i;
+  int i;
 
-  for (i=0;i<n;i++) {
-    int ip = (i+1) % n;
-    double dx = (x[ip]-x[i]);
+  for (i = 0; i < n; i++) {
+    int ip = (i + 1) % n;
+    double dx = (x[ip] - x[i]);
     double lat1, lat2;
     double dy, dat;
 
     lat1 = y[ip];
     lat2 = y[i];
-    if(dx > M_PI)  dx = dx - 2.0*M_PI;
-    if(dx < -M_PI) dx = dx + 2.0*M_PI;
+    if (dx > M_PI)
+      dx = dx - 2.0 * M_PI;
+    if (dx < -M_PI)
+      dx = dx + 2.0 * M_PI;
     /*Sides that go through a pole contribute PI regardless of their direction and extent.*/
-    if(fabs(dx+M_PI)< SMALL_VALUE || fabs(dx-M_PI)< SMALL_VALUE){
+    if (fabs(dx + M_PI) < SMALL_VALUE || fabs(dx - M_PI) < SMALL_VALUE) {
       area += M_PI;
-      continue; //next i
+      continue;  // next i
     }
     /*
      We have to be careful in implementing sin(0.5*(lat2-lat1))/(0.5*(lat2-lat1))
      in the limit of lat1=lat2 where it becomes 1. Note that in that limit we get the well known formula
      for the area of a section of sphere bounded by two longitudes and two latitude circles.
     */
-    if ( fabs(lat1-lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
-      area -= dx*sin(0.5*(lat1+lat2));
+    if (fabs(lat1 - lat2) < SMALL_VALUE) /* cheap area calculation along latitude */
+      area -= dx * sin(0.5 * (lat1 + lat2));
     else {
-      if(reproduce_siena) {
-	area += dx*(cos(lat1)-cos(lat2))/(lat1-lat2);
-      }
-      else {
-	//This expression is a trig identity with the above reproduce_siena case
-	dy = 0.5*(lat1-lat2);
-	dat = sin(dy)/dy;
-	area -= dx*sin(0.5*(lat1+lat2))*dat; 
+      if (reproduce_siena) {
+        area += dx * (cos(lat1) - cos(lat2)) / (lat1 - lat2);
+      } else {
+        // This expression is a trig identity with the above reproduce_siena case
+        dy = 0.5 * (lat1 - lat2);
+        dat = sin(dy) / dy;
+        area -= dx * sin(0.5 * (lat1 + lat2)) * dat;
       }
     }
   }
-  if(fabs(area) > HPI) printf("WARNING poly_area: Large values for area: %19.15f\n", area);
-  if(area < 0)
-     return -area*RADIUS*RADIUS;
-  else
-     return area*RADIUS*RADIUS;
 
-}; /* poly_area */
+
+  if (fabs(area) > HPI)
+    printf("WARNING poly_area: Large values for area: %19.15f\n", area);
+  if (area < 0)
+    return -area * RADIUS * RADIUS;
+  else
+    return area * RADIUS * RADIUS;
+} /* poly_area_main */
+
+/*
+  Calculate the area of a polygon with the original poly_area function,
+  exept that for those polygons that are polar, if the global poly_are_flag
+  is set, the area is calculated by first rotating a copy of the polygon away
+  from the pole and calculating the area of the rotated polygon instead.
+  Polar means having any of its verices cloase to a pole, or an edge crossing
+  a pole.
+
+  This routine is here merely for improving the accuracy of the are calculation
+  in the given conditions.
+  TODO: The tiling error reported by make_coupler mosaic may be non-zero when
+  using this feature. This may be developped in the future.
+*/
+double poly_area(const double xo[], const double yo[], int n) {
+  double area_pa = 0.0;
+  double area_par = 0.0;
+  int pole = 0;
+  int crosses = 0;
+
+  double xr[8];  // rotated lon
+  double yr[8];  // rotated lat
+
+  if (rotate_poly_flag == 0) {
+    area_pa = poly_area_main(xo, yo, n);
+    return area_pa;
+  } else {
+    // anything near enough to the pole gets rotated
+    pole = is_near_pole(yo, n);
+    crosses = crosses_pole(xo, n);
+    if (crosses == 1 && pole == 0) {
+      error_handler("crosses == 1 && pole == 0");
+    }
+
+    if (pole == 1) {
+      if (n > 8) {
+        error_handler("poly_area: n > 8. n=%d,n");
+      }
+      rotate_poly(xo, yo, n, xr, yr);
+
+      int pole2 = is_near_pole(yr, n);
+      if (pole2 == 1) {
+        error_handler("poly_area: pole2 == 1");
+      }
+      area_par = poly_area_main(xr, yr, n);
+    } else {
+      area_pa = poly_area_main(xo, yo, n);
+    }
+
+    if (pole == 1) {
+      return area_par;
+    } else {
+      return area_pa;
+    }
+  }
+}
 
 /*An alternate implementation of poly_area for future developments. Under construction.*/
+//TODO:
 double poly_area2(const double x[], const double y[], int n)
 {
   double area = 0.0;
   double dx,dy,dat,lat1,lat2,avg_y,hdy,da,dxs= 0.0;
-  int    i,j,ip;
-  int hasPole=0, hasBadxm=0, hasBadxp=0;
+  int    i, ip;
+  int hasBadxm=0, hasBadxp=0;
   for (i=0;i<n;i++) {
     ip = (i+1) % n;
     dx = (x[ip]-x[i]);
     if(fabs(dx+M_PI) < SMALL_VALUE) hasBadxm=1;
     if(fabs(dx-M_PI) < SMALL_VALUE) hasBadxp=1;
-    if(y[i]==-HPI || y[i]==HPI) hasPole=1;
+    // if(y[i]==-HPI || y[i]==HPI) hasPole=1;
   }
   for (i=0;i<n;i++) {
     ip = (i+1) % n;
@@ -520,7 +591,7 @@ double poly_area2(const double x[], const double y[], int n)
      return -area*RADIUS*RADIUS;
   else
      return area*RADIUS*RADIUS;
-}; /* poly_area2 */
+} /* poly_area2 */
 /* Note how one of the two cells straddling the SP has a wrong sign for "dx=-pi"
    producing an excess area of -2pi.
    Also note how the fix_lon is needed to insert twin poles at SP to correct the
@@ -575,7 +646,7 @@ double poly_area_no_adjust(const double x[], const double y[], int n)
      return area*RADIUS*RADIUS;
   else
      return area*RADIUS*RADIUS;
-}; /* poly_area_no_adjust */
+} /* poly_area_no_adjust */
 
 int delete_vtx(double x[], double y[], int n, int n_del)
 {
@@ -621,7 +692,7 @@ int fix_lon(double x[], double y[], int n, double tlon)
   }
 
   /* all pole points must be paired */
-  /* The reason is poly_area() function needs a contribution equal to the angle (in radians) 
+  /* The reason is poly_area() function needs a contribution equal to the angle (in radians)
      between the sides that connect to the pole. */
   for (i=0;i<nn;i++) if (fabs(y[i])>=HPI-TOLORENCE) {
     int im=(i+nn-1)%nn, ip=(i+1)%nn;
@@ -646,7 +717,8 @@ int fix_lon(double x[], double y[], int n, double tlon)
   /*If a polygon side passes through a Pole insert twin vertices at the Pole*/
   /*A fix is also directly applied to poly_area to handle this case.*/
   for (i=0;i<nn;i++) {
-    int im=(i+nn-1)%nn, ip=(i+1)%nn;
+    int im=(i+nn-1)%nn;
+    // ip=(i+1)%nn;
     double dx = x[i]-x[im];
     if(fabs(dx+M_PI)< SMALL_VALUE || fabs(dx-M_PI)< SMALL_VALUE){
       double x1=x[im];
@@ -699,7 +771,7 @@ double great_circle_distance(double *p1, double *p2)
   dist = RADIUS*beta;
   return dist;
 
-}; /* great_circle_distance */
+} /* great_circle_distance */
 
 
 /* Compute the great circle area of a polygon on a sphere */
@@ -778,7 +850,7 @@ double spherical_angle(const double *v1, const double *v2, const double *v3)
   }
 
   return angle;
-}; /* spherical_angle */
+} /* spherical_angle */
 
 /*------------------------------------------------------------------------------
   double spherical_excess_area(p_lL, p_uL, p_lR, p_uR)
@@ -820,7 +892,7 @@ double spherical_excess_area(const double* p_ll, const double* p_ul,
 
   return area;
 
-}; /* spherical_excess_area */
+} /* spherical_excess_area */
 
 
 /*----------------------------------------------------------------------
@@ -835,7 +907,7 @@ void vect_cross(const double *p1, const double *p2, double *e )
   e[1] = p1[2]*p2[0] - p1[0]*p2[2];
   e[2] = p1[0]*p2[1] - p1[1]*p2[0];
 
-}; /* vect_cross */
+} /* vect_cross */
 
 
 /*----------------------------------------------------------------------
@@ -868,7 +940,7 @@ void normalize_vect(double *e)
   pdot = sqrt( pdot );
 
   for(k=0; k<3; k++) e[k] /= pdot;
-};
+}
 
 
 /*------------------------------------------------------------------
@@ -896,7 +968,7 @@ void unit_vect_latlon(int size, const double *lon, const double *lat, double *vl
     vlat[3*n+1] = -sin_lat*sin_lon;
     vlat[3*n+2] =  cos_lat;
   }
-}; /* unit_vect_latlon */
+} /* unit_vect_latlon */
 
 
 /* Intersect a line and a plane
@@ -1587,3 +1659,93 @@ int inside_a_polygon_(double *lon1, double *lat1, int *npts, double *lon2, doubl
 
 }
 #endif
+
+/*
+  is_near_pole() reuturns 1 if a polygon has any point with a latitude
+  within a threshold from the CGS poles (i.e. near +- Pi/2).
+   Otherwise returns 0.
+*/
+int is_near_pole(const double y[], int n) {
+  int pole = 0;
+  for (int i = 0; i < n; i++) {
+    if ((fabs(y[i]) + from_pole_threshold_rad) > M_PI_2 ) {
+      pole = 1;
+      break;
+    }
+  }
+  return pole;
+}
+
+/*
+  crosses_pole() returns 1 iff one line segment of the polygon has its end at opposit
+  sides of a pole. i.e. if the longitudes are seperated by about Pi. Note, for realistic
+  data (not huge polygons), if crosses_pole() reutrns 1, so should is_near_pole().
+*/
+int crosses_pole(const double x[] , int n) {
+  int has_cl = 0;
+  for (int i = 0; i < n; i++) {
+    int im = (i + n - 1) % n;
+    //int  ip = (i + 1) % n;
+    double dx = x[i] - x[im];
+    if (fabs(dx + M_PI) < SMALL_VALUE || fabs(dx - M_PI) < SMALL_VALUE) {
+      has_cl = 1;
+      break;
+    }
+  }
+  return has_cl;
+}
+
+/*
+  Set the_rotation_matrix  global variable.
+  The rotation is 45 degrees and about the vector with orign at
+  earths center and the direction <0,1,1>/SQRT(2).  I.e. a big
+  rotation away from the pole if what is being rotaed is near a pole.
+  For rotation matricies formulas and examples, see F.S.Hill, Computer
+  Graphics Using OpenGL, @nd ed., Chapter 5.3.
+*/
+void set_the_rotation_matrix() {
+  static const double is2 = 1.0 /M_SQRT2;
+
+  static const double m00 = 0;
+  static const double m01 = - is2;
+  static const double m02 = is2;
+  static const double m11 = 1.0/2;
+  static const double m12 = 0.5;
+
+  static const double m[3][3] = { {m00, m01, m02}, {m02, m11, m12},{m01, m12, m11} };
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      the_rotation_matrix[i][j] = m[i][j];
+    }
+  }
+}
+
+/* Rotate point given the passed in rotation matrix  */
+void rotate_point(double rv[], double rmat [][3]) {
+  double v[3];
+
+  for (int i = 0; i < 3; i++) {
+    v[i] = 0.0;
+    for (int j = 0; j < 3; j++) {
+      v[i] += rmat[i][j] * rv[j];
+    }
+  }
+  for (int i = 0; i < 3; i++) {
+    rv[i] = v[i];
+  }
+}
+
+/*
+  Rotate polygon defined by x[], y[] points and store in xr[], yr[]*/
+void rotate_poly(const double x[], const double y[], const int n, double xr[], double yr[]) {
+  double sv[2]; //a rotated lat/lon
+  double rv[3]; //rotated xyz point
+  for (int i = 0; i < n; i++) {
+    latlon2xyz(1, &x[i], &y[i], &rv[0], &rv[1], &rv[2]);
+    rotate_point(rv, the_rotation_matrix);
+    xyz2latlon(1, &rv[0], &rv[1], &rv[2], &sv[0], &sv[1]);
+    xr[i] = sv[0];
+    yr[i] = sv[1];
+  }
+}

--- a/tools/libfrencutils/mosaic_util.h
+++ b/tools/libfrencutils/mosaic_util.h
@@ -20,13 +20,10 @@
 
 #ifndef _MOSAIC_UTIL_H
 #define _MOSAIC_UTIL_H 1
+#endif
 
 #ifndef RANGE_CHECK_CRITERIA
 #define RANGE_CHECK_CRITERIA 0.05
-#endif
-
-#ifndef _MATH_H
-#include <math.h>
 #endif
 
 /* override the `fabs` function based on the type */
@@ -113,5 +110,12 @@ void setInbound(struct Node *interList, struct Node *list);
 int isInside(struct Node *node);
 void set_reproduce_siena_true(void);
 
+void set_rotate_poly_true(void);
+int is_near_pole(const double y[], int n);
+int crosses_pole(const double x[], int n);
+void rotate_point( double rv[], double rmat [][3]);
+void rotate_poly(const double x[], const double y[], const int n,
+  double xr[], double yr[]);
+void set_the_rotation_matrix();
 
-#endif
+

--- a/tools/make_coupler_mosaic/make_coupler_mosaic.c
+++ b/tools/make_coupler_mosaic/make_coupler_mosaic.c
@@ -125,11 +125,14 @@ char *usage[] = {
   "                               The default value is 1.e-6                                      ",
   "                                                                                              ",
   "--check                        check the tiling error",
-  "",
+  " ",
   "--print_memory                 debug memory usage when it is set                       ",
-  "  ",
+  " ",
   "--reproduce_siena              Set to reproduce siena shared codes results              ",
   "    ",
+  "--rotate_poly                  Set to calculate polar polygon areas by caculating the area of a copy ",
+  "                               of the polygon, with the copy being rotated far away from the pole. ",
+  " ",
   "--verbose                      Set --verbose to print out messages during running.        ",
   "",
 
@@ -405,6 +408,7 @@ int main (int argc, char *argv[])
   int    tile_parent, is_parent, ie_parent, js_parent, je_parent;
   int    print_memory=0;
   int    reproduce_siena=0;
+  int    rotate_poly=0;
 
   static struct option long_options[] = {
     {"atmos_mosaic",         required_argument, NULL, 'a'},
@@ -420,6 +424,7 @@ int main (int argc, char *argv[])
     {"verbose",              no_argument,       NULL, 'v'},
     {"print_memory",         no_argument,       NULL, 'p'},
     {"reproduce_siena",      no_argument,       NULL, 'q'},
+    {"rotate_poly",          no_argument,       NULL, 'u'},
     {NULL, 0, NULL, 0}
   };
 
@@ -470,6 +475,9 @@ int main (int argc, char *argv[])
     case 'q':
       reproduce_siena = 1;
       break;
+    case 'u':
+      rotate_poly = 1;
+      break;
     case '?':
       errflg++;
     }
@@ -493,6 +501,8 @@ int main (int argc, char *argv[])
   if(!lmosaic) lmosaic = amosaic;
 
   if(reproduce_siena) set_reproduce_siena_true();
+
+  if(rotate_poly) set_rotate_poly_true();
 
   /*mosaic_file can not have the same name as amosaic, lmosaic or omosaic, also the file name of
     amosaic, lmosaic, omosaic can not be "mosaic.nc"

--- a/tools/make_hgrid/make_hgrid.c
+++ b/tools/make_hgrid/make_hgrid.c
@@ -307,6 +307,10 @@ char *usage[] = {
   "   --non_length_angle         When specified, will not output length(dx,dy) and  ",
   "                              angle (angle_dx, angle_dy)                         ",
   "                                                                                 ",
+  "   --rotate_poly              Set to calculate polar polygon areas by caculating ",
+  "                              the area of a copy of the polygon, with the copy   ",
+  "                              being rotated far away from the pole.              ",
+  "                                                                                 ",
   "   --verbose                  Will print out running time message when this      ",
   "                              option is set. Otherwise the run will be silent    ",
   "                              when there is no error.                            ",
@@ -566,6 +570,7 @@ int main(int argc, char* argv[])
   char entry[MAXBOUNDS*STRINGLEN];
   int n, errflg, c, i;
   int option_index;
+  int    rotate_poly=0;
 
   static struct option long_options[] = {
                                          {"grid_type",       required_argument, NULL, 'a'},
@@ -605,6 +610,7 @@ int main(int argc, char* argv[])
                                          {"no_length_angle", no_argument,       NULL, 'M'},
                                          {"angular_midpoint", no_argument,      NULL, 'N'},
                                          {"help",            no_argument,       NULL, 'h'},
+                                         {"rotate_poly",     no_argument,       NULL, 'n'},
                                          {"verbose",         no_argument,       NULL, 'v'},
 
                                          {0, 0, 0, 0},
@@ -744,6 +750,9 @@ int main(int argc, char* argv[])
     case 'N':
       use_angular_midpoint = 1;
       break;
+    case 'n':
+      rotate_poly = 1;
+      break;
     case 'v':
       verbose = 1;
       break;
@@ -769,6 +778,8 @@ int main(int argc, char* argv[])
     strcat(history, " ");
     strcat(history, argv[i]);
   }
+
+  if(rotate_poly) set_rotate_poly_true();
 
   if(mpp_pe() == mpp_root_pe() && verbose) printf("==>NOTE: the grid type is %s\n",grid_type);
 

--- a/tools/make_topog/make_topog.c
+++ b/tools/make_topog/make_topog.c
@@ -237,6 +237,10 @@ char *usage[] = {
   "   --min_thickness #             inimum vertical thickness allowed. with default value   ",
   "                                 0.1. Increase or decrease this number as needed.        ",
   "                                                                                         ",
+  "   --rotate_poly                 Set to calculate polar polygon areas by caculating the  ",
+  "                                 area of a copy of the polygon, with the copy being      ",
+  "                                 rotated far away from the pole.                                    ",
+  "                                                                                         ",
   "   --help                        Print out this message and then exit.                   ",
   "                                                                                         ",
   "   --verbose                     Will print out running time message when this           ",
@@ -314,6 +318,7 @@ int main(int argc, char* argv[])
   int    cyclic_x, cyclic_y, tripolar_grid;
   int    errflg = (argc == 1);
   int    option_index, i, c;
+  int    rotate_poly=0;
   unsigned int verbose = 0;
 
   /*
@@ -366,6 +371,7 @@ int main(int argc, char* argv[])
     {"fraction_full_cell",          required_argument, NULL, 'R'},
     {"dont_open_very_this_cell",    no_argument,       NULL, 'S'},
     {"min_thickness",               required_argument, NULL, 'T'},
+    {"rotate_poly",                 no_argument,       NULL, 'z'},
     {"help",                        no_argument,       NULL, 'h'},
     {"verbose",                     no_argument,       NULL, 'V'},
     {0, 0, 0, 0},
@@ -514,6 +520,9 @@ int main(int argc, char* argv[])
     case 'T':
       min_thickness = atof(optarg);
       break;
+    case 'z':
+      rotate_poly = 1;
+      break;
     case 'V':
       verbose = 1;
       break;
@@ -530,6 +539,7 @@ int main(int argc, char* argv[])
     }
   }
 
+  if(rotate_poly) set_rotate_poly_true();
 
   /* Write out arguments value  */
   if(mpp_pe() == mpp_root_pe() && verbose) printf("NOTE from make_topog ==> the topog_type is: %s\n",topog_type);


### PR DESCRIPTION
This PR does the following:
1) adds the  command-line option rotate_poly to make_hgrid, make_coupler_mosaic, and make_topog to use
 the polar polygon rotation feature for the purpose of helping the calculation of the area of polar polygons.
2) Creates a wrapper to the original poly_area function so that for polar polygons,
  if the global poly_are_flag  is set, the area is calculated by first rotating a copy of the polygon away
  from the pole and calculating the area of the rotated polygon instead.
 3) Fixes some non-critical typos in constants.h and adds two more constants.
 4) Removes some post function definition semicolons. This to remove some compile-time warnings.

This PR is not intended as a final fix to the motivating issue (https://github.com/NOAA-GFDL/FRE-NCtools/issues/44), rather it
should be seen just as an option that may improve the area calculations of polar polygons and that ultimately it may be part of
the solution of the original issue and others.
  