### PR TITLE
Working fregrid mapping GED to RLL; Fixed bug of definition of SMALL_…

### DIFF
--- a/cpp/libfrencutils/mosaic_util.h
+++ b/cpp/libfrencutils/mosaic_util.h
@@ -30,7 +30,7 @@
 #endif
 
 
-inline constexpr int SMALL_VALUE = 1.e-10 ;
+const double SMALL_VALUE {1.0E-10};
 
 struct Node{
   double x, y, z, u, u_clip;

--- a/cpp/libfrencutils/mpp.C
+++ b/cpp/libfrencutils/mpp.C
@@ -285,7 +285,7 @@ void mpp_max_double(int count, double *data)
     error handler: will print out error message and then abort
 ***********************************************************/
 
-void mpp_error(char *str)
+void mpp_error(const char * str)
 {
   fprintf(stderr, "Error from pe %d: %s\n", pe, str );
 #ifdef use_libMPI

--- a/cpp/libfrencutils/mpp.h
+++ b/cpp/libfrencutils/mpp.h
@@ -37,7 +37,7 @@ void mpp_send_double(const double* data, int size, int to_pe); /* send data */
 void mpp_send_int(const int* data, int size, int to_pe); /* send data */
 void mpp_recv_double(double* data, int size, int from_pe); /* recv data */
 void mpp_recv_int(int* data, int size, int from_pe); /* recv data */
-void mpp_error(char *str);
+void mpp_error(const char *str);
 void mpp_sum_int(int count, int *data);
 void mpp_sum_double(int count, double *data);
 void mpp_min_double(int count, double *data);

--- a/cpp/libfrencutils/tool_util.C
+++ b/cpp/libfrencutils/tool_util.C
@@ -61,7 +61,7 @@ void get_file_path(const char *file, char *dir)
 
   /* get the diretory */
 
-  strptr = const_cast<char*>(strrchr(file, '/'));
+  strptr = strrchr(const_cast<char*>(file), '/');
   if(strptr) {
     len = strptr - file;
     strncpy(dir, file, len);


### PR DESCRIPTION
Working fregrid mapping GED to RLL; Fixed bug of definition of SMALL_VALUE in mosaic_util.C. Fixed one const casting in tool_util.C. Added a cast in mpp.C to get rid of somw warnings.