### PR TITLE
Update gfdl site config files

### DIFF
--- a/site-configs/gfdl-ws/env.sh
+++ b/site-configs/gfdl-ws/env.sh
@@ -32,19 +32,19 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # Variables to control versions used
-env_version=v0.17
+env_version=2023.01
 gcc_version=11.2.0
-ncc_version=4.8.1
-ncf_version=4.5.3
-mpi_version=3.4.2
+ncc_version=4.9.0
+ncf_version=4.6.0
+mpi_version=4.0.2
 
 # Ensure the base spack modules are first in MODULEPATH
-module remove-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel7-x86_64
-module prepend-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel7-x86_64
+module remove-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
+module prepend-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
 
 # bats and nccmp are needed for tests
-module load bats/0.4.0
-module load nccmp/1.9.0.1
+module load bats
+module load nccmp
 
 # Load the GCC compilers
 module load gcc/$gcc_version

--- a/site-configs/gfdl/env.sh
+++ b/site-configs/gfdl/env.sh
@@ -32,22 +32,22 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # Variables to control versions used
-env_version=v0.17
+env_version=2023.01
 gcc_version=11.2.0
-ncc_version=4.8.1
-ncf_version=4.5.3
-mpi_version=3.4.2
+ncc_version=4.9.0
+ncf_version=4.6.0
+mpi_version=4.0.2
 
 # Ensure the base spack modules are first in MODULEPATH
 module remove-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel7-x86_64
 module prepend-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel7-x86_64
 
 # bats and nccmp are needed for tests
-module load bats/0.4.0
-module load nccmp/1.9.0.1
+module load bats
+module load nccmp
 # Need newer autoconf/automake than what pan has at the system level
-module load autoconf/2.69
-module load automake/1.16.3
+module load autoconf
+module load automake
 
 # Load the GCC compilers
 module load gcc/$gcc_version

--- a/site-configs/ncrc/env.sh
+++ b/site-configs/ncrc/env.sh
@@ -34,8 +34,8 @@
 module rm PrgEnv-pgi PrgEnv-intel PrgEnv-gnu PrgEnv-cray
 module load PrgEnv-gnu/6.0.10
 module load gcc/12.1.0
-module load cray-hdf5/1.12.2.3
-module load cray-netcdf/4.9.0.3
+module load cray-hdf5/1.12.1.3
+module load cray-netcdf/4.8.1.3
 module load nccmp
 
 # Add bats to PATH


### PR DESCRIPTION
- Updates to use GFDL SW release 2023.01 for PAN and GFDL-WS
- Slight version downgrade for gaea C3/C4 config, as the latest hdf5/netcdf versions do not work