### PR TITLE
Include 4-dimensional (i.e. diurnal) output in default split-vars processing

### DIFF
--- a/postprocessing/split_ncvars/split_ncvars.pl
+++ b/postprocessing/split_ncvars/split_ncvars.pl
@@ -139,7 +139,7 @@ foreach my $file (@ifiles) {
     # generate variable list (if not user supplied)
     if (!@varlist) {
         if (!$Opt{STATIC}) {
-	    print tailname($list_ncvars)." -t0123 $file\n" if $Opt{VERBOSE} > 1;
+	    print tailname($list_ncvars)." -t01234 $file\n" if $Opt{VERBOSE} > 1;
 	    @varlist = split /\n/, `$list_ncvars -t01234 $file`;
         } else {
 	    print tailname($list_ncvars)." -s0123 $file\n" if $Opt{VERBOSE} > 1;

--- a/postprocessing/split_ncvars/split_ncvars.pl
+++ b/postprocessing/split_ncvars/split_ncvars.pl
@@ -140,7 +140,7 @@ foreach my $file (@ifiles) {
     if (!@varlist) {
         if (!$Opt{STATIC}) {
 	    print tailname($list_ncvars)." -t0123 $file\n" if $Opt{VERBOSE} > 1;
-	    @varlist = split /\n/, `$list_ncvars -t0123 $file`;
+	    @varlist = split /\n/, `$list_ncvars -t01234 $file`;
         } else {
 	    print tailname($list_ncvars)." -s0123 $file\n" if $Opt{VERBOSE} > 1;
 	    @varlist = split /\n/, `$list_ncvars -s0123 $file`;
@@ -789,7 +789,7 @@ sub variable_log {
 
   open (OUT,"> $prtfile") || die "Cannot open $prtfile for output";
 
-  foreach my $var (split /\n/, `$list_ncvars -t0123 $ncfile`) {
+  foreach my $var (split /\n/, `$list_ncvars -t01234 $ncfile`) {
     my @out;
     $var =~ s/^\s+//; $var =~ s/\s+$//;
     push @out, $var;


### PR DESCRIPTION
resolves #241 