### PR TITLE
update to create_grid_2dx2d_order2 for GPUs with std::copy_if

### DIFF
--- a/cpp/search/BBox3D.h
+++ b/cpp/search/BBox3D.h
@@ -95,6 +95,11 @@ namespace nct {
             return true;
           }
         }
+      inline static bool intersect_gpu(const BBox3D &A, const BBox3D &B) {
+          int r = bool(A.lo[0] > B.hi[0]) + bool( A.lo[1] > B.hi[1]) + bool (A.lo[2] > B.hi[2])
+           + bool( A.hi[0] < B.lo[0]) + bool (A.hi[1] < B.lo[1]) + bool (A.hi[2] < B.lo[2]);
+         return (r == 0);
+      }
 
         inline static bool intersect(const BBox3D &A, DistanceInterval<float> &di, const int dim) {
           if (A.lo[dim] > di.getFar() || A.hi[dim] < di.getNear()) {


### PR DESCRIPTION
 create_grid_2dx2d_order2 for GPUs was updated with missing mask check and missing fix_poly call.
Added or cleaned up miscellaneous comments. GPU code was tested with weight generation
for cubic sphere grids to regular lat-long grids, and cubic sphere grids to cubic sphere grids.