### PR TITLE
Create structures for list arrays and Add OpenACC data transfer directives 

### DIFF
--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -95,7 +95,7 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 
 
       //allocate memory for the lists
-      out_minmaxavglists = malloc_minmaxavg_lists(nx_out*ny_out, &out_minmaxavglists);
+      malloc_minmaxavg_lists(nx_out*ny_out, &out_minmaxavglists);
 
 #define MAX_V 8
 #pragma acc enter data create(out_minmaxavglists)

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -85,6 +85,14 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
     for(n=0; n<ntiles_out; n++) {
 
       Minmaxavg_lists out_minmaxavg_lists;
+      out_minmaxavg_lists.lon_list=NULL;
+      out_minmaxavg_lists.lat_list=NULL;
+      out_minmaxavg_lists.lon_min_list=NULL;
+      out_minmaxavg_lists.lat_min_list=NULL;
+      out_minmaxavg_lists.lon_max_list=NULL;
+      out_minmaxavg_lists.lat_max_list=NULL;
+      out_minmaxavg_lists.n_list=NULL;
+      out_minmaxavg_lists.lon_avg=NULL;
 
       nx_out = grid_out[n].nxc;
       ny_out = grid_out[n].nyc;

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -93,6 +93,7 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 #pragma acc enter data copyin(grid_out[n].lonc[0:(nx_out+1)*(ny_out+1)], \
                               grid_out[n].latc[0:(nx_out+1)*(ny_out+1)])
 
+
       //allocate memory for the lists
       out_minmaxavglists = malloc_minmaxavg_lists(nx_out*ny_out, &out_minmaxavglists);
 
@@ -160,6 +161,7 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
                                                mask, i_in, j_in, i_out, j_out, xgrid_area);
             for(i=0; i<nxgrid; i++) j_in[i] += jstart;
             free(mask);
+#pragma acc exit data delete(mask)
           } //opcode CONSERVE_ORDER1
 
           else if(opcode & CONSERVE_ORDER2) {
@@ -176,7 +178,8 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 #ifdef _OPENACC
             nxgrid = create_xgrid_2dx2d_order2_acc(&nx_in, &ny_now, &nx_out, &ny_out, grid_in[m].lonc+jstart*(nx_in+1),
                                                    grid_in[m].latc+jstart*(nx_in+1),  grid_out[n].lonc,  grid_out[n].latc,
-                                                   &out_minmaxavglists, mask, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+                                                   &out_minmaxavglists, mask, i_in, j_in, i_out, j_out,
+                                                   xgrid_area, xgrid_clon, xgrid_clat);
 #else
             nxgrid = create_xgrid_2dx2d_order2(&nx_in, &ny_now, &nx_out, &ny_out, grid_in[m].lonc+jstart*(nx_in+1),
                                                grid_in[m].latc+jstart*(nx_in+1),  grid_out[n].lonc,  grid_out[n].latc,

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -86,11 +86,6 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 
       Minmaxavglists out_minmaxavglists;
 
-      double *lon_out_min_list=NULL, *lon_out_max_list=NULL, *lon_out_avg=NULL;
-      double *lat_out_min_list=NULL, *lat_out_max_list=NULL;
-      double *lon_out_list=NULL, *lat_out_list=NULL;
-      int *n2_list=NULL;
-
       nx_out = grid_out[n].nxc;
       ny_out = grid_out[n].nyc;
       interp[n].nxgrid = 0;

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -84,7 +84,7 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
     //START NTILES_OUT
     for(n=0; n<ntiles_out; n++) {
 
-      Minmaxavglists out_minmaxavglists;
+      Minmaxavg_lists out_minmaxavg_lists;
 
       nx_out = grid_out[n].nxc;
       ny_out = grid_out[n].nyc;
@@ -95,22 +95,22 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 
 
       //allocate memory for the lists
-      malloc_minmaxavg_lists(nx_out*ny_out, &out_minmaxavglists);
+      malloc_minmaxavg_lists(nx_out*ny_out, &out_minmaxavg_lists);
 
 #define MAX_V 8
-#pragma acc enter data create(out_minmaxavglists)
-#pragma acc enter data create(out_minmaxavglists.lon_list[0:MAX_V*nx_out*ny_out], \
-                              out_minmaxavglists.lat_list[0:MAX_V*nx_out*ny_out], \
-                              out_minmaxavglists.lon_min_list[0:nx_out*ny_out], \
-                              out_minmaxavglists.lon_max_list[0:nx_out*ny_out], \
-                              out_minmaxavglists.lat_min_list[0:nx_out*ny_out], \
-                              out_minmaxavglists.lat_max_list[0:nx_out*ny_out], \
-                              out_minmaxavglists.n_list[0:nx_out*ny_out], \
-                              out_minmaxavglists.lon_avg[0:nx_out*ny_out] )
+#pragma acc enter data create(out_minmaxavg_lists)
+#pragma acc enter data create(out_minmaxavg_lists.lon_list[0:MAX_V*nx_out*ny_out], \
+                              out_minmaxavg_lists.lat_list[0:MAX_V*nx_out*ny_out], \
+                              out_minmaxavg_lists.lon_min_list[0:nx_out*ny_out], \
+                              out_minmaxavg_lists.lon_max_list[0:nx_out*ny_out], \
+                              out_minmaxavg_lists.lat_min_list[0:nx_out*ny_out], \
+                              out_minmaxavg_lists.lat_max_list[0:nx_out*ny_out], \
+                              out_minmaxavg_lists.n_list[0:nx_out*ny_out], \
+                              out_minmaxavg_lists.lon_avg[0:nx_out*ny_out] )
 
 
       //compute the list values
-      get_minmaxavg_lists(nx_out, ny_out, grid_out[n].lonc, grid_out[n].latc, &out_minmaxavglists);
+      get_minmaxavg_lists(nx_out, ny_out, grid_out[n].lonc, grid_out[n].latc, &out_minmaxavg_lists);
 
       //START NTILES_IN
       for(m=0; m<ntiles_in; m++) {
@@ -178,7 +178,7 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 #ifdef _OPENACC
             nxgrid = create_xgrid_2dx2d_order2_acc(&nx_in, &ny_now, &nx_out, &ny_out, grid_in[m].lonc+jstart*(nx_in+1),
                                                    grid_in[m].latc+jstart*(nx_in+1),  grid_out[n].lonc,  grid_out[n].latc,
-                                                   &out_minmaxavglists, mask, i_in, j_in, i_out, j_out,
+                                                   &out_minmaxavg_lists, mask, i_in, j_in, i_out, j_out,
                                                    xgrid_area, xgrid_clon, xgrid_clat);
 #else
             nxgrid = create_xgrid_2dx2d_order2(&nx_in, &ny_now, &nx_out, &ny_out, grid_in[m].lonc+jstart*(nx_in+1),
@@ -280,8 +280,8 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
         malloc_xgrid_arrays(zero, &i_in, &j_in, &i_out, &j_out, &xgrid_area, &xgrid_clon , &xgrid_clat);
 #pragma acc exit data delete(grid_in[m].latc, grid_in[m].lonc)
       } // ntiles_in
-      malloc_minmaxavg_lists(zero, &out_minmaxavglists);
-#pragma acc exit data delete(out_minmaxavglists)
+      malloc_minmaxavg_lists(zero, &out_minmaxavg_lists);
+#pragma acc exit data delete(out_minmaxavg_lists)
 #pragma acc exit data delete(grid_out[n].latc, grid_out[n].lonc)
     } // ntimes_out
 

--- a/tools/fregrid/globals.h
+++ b/tools/fregrid/globals.h
@@ -245,6 +245,6 @@ typedef struct{
   double *lon_list;
   double *lat_list;
   int *n_list;
-} Minmaxavglists;
+} Minmaxavg_lists;
 
 #endif

--- a/tools/fregrid/globals.h
+++ b/tools/fregrid/globals.h
@@ -96,7 +96,7 @@ typedef struct {
   char   area_name[STRING];
   int    do_regrid;
   int    is_axis_data;
-  int    dimsize[5];  
+  int    dimsize[5];
 } Var_config;
 
 typedef struct {
@@ -121,11 +121,11 @@ typedef struct {
   int  bndid;
   int  size;
   nc_type type;
-  char cart; 
+  char cart;
   int  bndtype;
   int  is_defined;
   double *bnddata;
-  double *data; 
+  double *data;
 } Axis_config;
 
 typedef struct {
@@ -235,5 +235,16 @@ typedef struct{
   double *f_max;
   double *f_min;
 } Monotone_config;
+
+typedef struct{
+  double *lat_min_list;
+  double *lat_max_list;
+  double *lon_min_list;
+  double *lon_max_list;
+  double *lon_avg;
+  double *lon_list;
+  double *lat_list;
+  int *n_list;
+} Minmaxavglists;
 
 #endif

--- a/tools/libfrencutils/Makefile.am
+++ b/tools/libfrencutils/Makefile.am
@@ -27,7 +27,7 @@ if WITH_OPENACC
   libfrencutils_gpu_a_CFLAGS = $(CC_OPENACC_FLAGS) $(AM_CFLAGS)
 endif
 
-AM_CFLAGS = $(NETCDF_CFLAGS)
+AM_CFLAGS = $(NETCDF_CFLAGS) -I$(top_srcdir)/tools/fregrid
 
 libfrencutils_a_SOURCES = affinity.c \
                           constant.h \

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -150,14 +150,14 @@ int create_xgrid_1dx2d_order2_(const int *nlon_in, const int *nlat_in, const int
 {
   int nxgrid;
   nxgrid = create_xgrid_1dx2d_order2(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in, i_in,
-                                     j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+             j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
   return nxgrid;
 
 };
 int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -214,7 +214,7 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 
       if (  (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
   xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-        min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
   if(xarea/min_area > AREA_RATIO_THRESH ) {
     xgrid_area[nxgrid] = xarea;
     xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
@@ -244,21 +244,21 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   mask is on grid lon_in/lat_in.
 *******************************************************************************/
 int create_xgrid_2dx1d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-             const double *mask_in, int *i_in, int *j_in, int *i_out,
-             int *j_out, double *xgrid_area)
+       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+       const double *mask_in, int *i_in, int *j_in, int *i_out,
+       int *j_out, double *xgrid_area)
 {
   int nxgrid;
 
   nxgrid = create_xgrid_2dx1d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
-             i_in, j_in, i_out, j_out, xgrid_area);
+       i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
 
 };
 int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
-            const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *mask_in, int *i_in, int *j_in, int *i_out,
-            int *j_out, double *xgrid_area)
+      const double *lat_in, const double *lon_out, const double *lat_out,
+      const double *mask_in, int *i_in, int *j_in, int *i_out,
+      int *j_out, double *xgrid_area)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -317,7 +317,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
   Xarea = poly_area ( x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
   min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
   if( Xarea/min_area > AREA_RATIO_THRESH ) {
-          xgrid_area[nxgrid] = Xarea;
+    xgrid_area[nxgrid] = Xarea;
     i_in[nxgrid]    = i1;
     j_in[nxgrid]    = j1;
     i_out[nxgrid]   = i2;
@@ -345,21 +345,21 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
   mask is on grid lon_in/lat_in.
 ********************************************************************************/
 int create_xgrid_2dx1d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-             const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-             double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+       double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_2dx1d_order2(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in, i_in,
-                                     j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+             j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
   return nxgrid;
 
 };
 
 int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -451,22 +451,22 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
 *******************************************************************************/
 #ifndef __AIX
 int create_xgrid_2dx2d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-             const double *mask_in, int *i_in, int *j_in, int *i_out,
-             int *j_out, double *xgrid_area)
+       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+       const double *mask_in, int *i_in, int *j_in, int *i_out,
+       int *j_out, double *xgrid_area)
 {
   int nxgrid;
 
   nxgrid = create_xgrid_2dx2d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
-             i_in, j_in, i_out, j_out, xgrid_area);
+       i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
 
 };
 #endif
 int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *mask_in, int *i_in, int *j_in, int *i_out,
-            int *j_out, double *xgrid_area)
+      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+      const double *mask_in, int *i_in, int *j_in, int *i_out,
+      int *j_out, double *xgrid_area)
 {
 
 #define MAX_V 8
@@ -553,8 +553,8 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
   lat_out_list = (double *)malloc(MAX_V*nx2*ny2*sizeof(double));
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) shared(nx2,ny2,nx2p,lon_out,lat_out,lat_out_min_list, \
-                                              lat_out_max_list,lon_out_min_list,lon_out_max_list, \
-                                              lon_out_avg,n2_list,lon_out_list,lat_out_list)
+                lat_out_max_list,lon_out_min_list,lon_out_max_list, \
+                lon_out_avg,n2_list,lon_out_list,lat_out_list)
 #endif
   for(ij=0; ij<nx2*ny2; ij++){
     int i2, j2, n, n0, n1, n2, n3, n2_in, l;
@@ -587,10 +587,10 @@ nxgrid = 0;
 
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) shared(nblocks,nx1,ny1,nx1p,mask_in,lon_in,lat_in, \
-                                              istart2,iend2,nx2,lat_out_min_list,lat_out_max_list, \
-                                              n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
-                                              lon_out_max_list,lon_out_avg,area_in,area_out, \
-                                              pxgrid_area,pnxgrid,pi_in,pj_in,pi_out,pj_out,pstart,nthreads)
+                istart2,iend2,nx2,lat_out_min_list,lat_out_max_list, \
+                n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
+                lon_out_max_list,lon_out_avg,area_in,area_out, \
+                pxgrid_area,pnxgrid,pi_in,pj_in,pi_out,pj_out,pstart,nthreads)
 #endif
   for(m=0; m<nblocks; m++) {
     int i1, j1, ij;
@@ -628,13 +628,13 @@ nxgrid = 0;
   }
   lon_out_min = lon_out_min_list[ij];
   lon_out_max = lon_out_max_list[ij];
-        dx = lon_out_avg[ij] - lon_in_avg;
+  dx = lon_out_avg[ij] - lon_in_avg;
   if(dx < -M_PI ) {
     lon_out_min += TPI;
     lon_out_max += TPI;
     for (l=0; l<n2_in; l++) x2_in[l] += TPI;
   }
-        else if (dx >  M_PI) {
+  else if (dx >  M_PI) {
     lon_out_min -= TPI;
     lon_out_max -= TPI;
     for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
@@ -645,14 +645,14 @@ nxgrid = 0;
   */
   if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
   if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
-          double min_area;
+    double min_area;
     int    nn;
     xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
     min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
     if( xarea/min_area > AREA_RATIO_THRESH ) {
       pnxgrid[m]++;
-            if(pnxgrid[m]>= MAXXGRID/nthreads)
-        error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
+      if(pnxgrid[m]>= MAXXGRID/nthreads)
+  error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
       nn = pstart[m] + pnxgrid[m]-1;
 
       pxgrid_area[nn] = xarea;
@@ -722,22 +722,22 @@ nxgrid = 0;
 ********************************************************************************/
 #ifndef __AIX
 int create_xgrid_2dx2d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-             const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-             double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+       double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_2dx2d_order2(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in, i_in,
-                                     j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+             j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
   return nxgrid;
 
 };
 #endif
 #ifdef _OPENACC
 int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
 #define MAX_V 8
@@ -848,14 +848,14 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   }
   lon_out_min = lon_out_min_list[ij];
   lon_out_max = lon_out_max_list[ij];
-        dx = lon_out_avg[ij] - lon_in_avg;
+  dx = lon_out_avg[ij] - lon_in_avg;
   if(dx < -M_PI ) {
     lon_out_min += TPI;
     lon_out_max += TPI;
 #pragma acc loop seq
     for (l=0; l<n2_in; l++) x2_in[l] += TPI;
   }
-        else if (dx >  M_PI) {
+  else if (dx >  M_PI) {
     lon_out_min -= TPI;
     lon_out_max -= TPI;
 #pragma acc loop seq
@@ -868,7 +868,7 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
   n_out = 1;
   if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
-          double min_area;
+    double min_area;
     xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
     min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
     if( xarea/min_area > AREA_RATIO_THRESH ) {
@@ -904,9 +904,9 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 };/* get_xgrid_2Dx2D_order2 */
 #else
 int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
 #define MAX_V 8
@@ -997,8 +997,8 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   lon_out_list = (double *)malloc(MAX_V*nx2*ny2*sizeof(double));
   lat_out_list = (double *)malloc(MAX_V*nx2*ny2*sizeof(double));
 #pragma omp parallel for default(none) shared(nx2,ny2,nx2p,lon_out,lat_out,lat_out_min_list, \
-                                              lat_out_max_list,lon_out_min_list,lon_out_max_list, \
-                                              lon_out_avg,n2_list,lon_out_list,lat_out_list)
+                lat_out_max_list,lon_out_min_list,lon_out_max_list, \
+                lon_out_avg,n2_list,lon_out_list,lat_out_list)
   for(ij=0; ij<nx2*ny2; ij++){
     int i2, j2, n, n0, n1, n2, n3, n2_in, l;
     double x2_in[MV], y2_in[MV];
@@ -1029,11 +1029,11 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 nxgrid = 0;
 
 #pragma omp parallel for default(none) shared(nblocks,nx1,ny1,nx1p,mask_in,lon_in,lat_in, \
-                                              istart2,iend2,nx2,lat_out_min_list,lat_out_max_list, \
-                                              n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
-                                              lon_out_max_list,lon_out_avg,area_in,area_out, \
-                                              pxgrid_area,pnxgrid,pxgrid_clon,pxgrid_clat,pi_in, \
-                                              pj_in,pi_out,pj_out,pstart,nthreads)
+                istart2,iend2,nx2,lat_out_min_list,lat_out_max_list, \
+                n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
+                lon_out_max_list,lon_out_avg,area_in,area_out, \
+                pxgrid_area,pnxgrid,pxgrid_clon,pxgrid_clat,pi_in, \
+                pj_in,pi_out,pj_out,pstart,nthreads)
   for(m=0; m<nblocks; m++) {
     int i1, j1, ij;
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
@@ -1070,13 +1070,13 @@ nxgrid = 0;
   }
   lon_out_min = lon_out_min_list[ij];
   lon_out_max = lon_out_max_list[ij];
-        dx = lon_out_avg[ij] - lon_in_avg;
+  dx = lon_out_avg[ij] - lon_in_avg;
   if(dx < -M_PI ) {
     lon_out_min += TPI;
     lon_out_max += TPI;
     for (l=0; l<n2_in; l++) x2_in[l] += TPI;
   }
-        else if (dx >  M_PI) {
+  else if (dx >  M_PI) {
     lon_out_min -= TPI;
     lon_out_max -= TPI;
     for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
@@ -1087,14 +1087,14 @@ nxgrid = 0;
  *      */
   if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
   if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
-          double min_area;
+    double min_area;
     int nn;
     xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
     min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
     if( xarea/min_area > AREA_RATIO_THRESH ) {
       pnxgrid[m]++;
-            if(pnxgrid[m]>= MAXXGRID/nthreads)
-        error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
+      if(pnxgrid[m]>= MAXXGRID/nthreads)
+  error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
       nn = pstart[m] + pnxgrid[m]-1;
       pxgrid_area[nn] = xarea;
       pxgrid_clon[nn] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
@@ -1163,22 +1163,22 @@ nxgrid = 0;
 
 #ifndef __AIX
 int create_xgrid_great_circle_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out,
-            mask_in, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+      mask_in, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
 
   return nxgrid;
 };
 #endif
 
 int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
   int nx1, nx2, ny1, ny2, nx1p, nx2p, ny1p, ny2p, nxgrid, n1_in, n2_in;
@@ -1240,7 +1240,7 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
       x2_in[3] = x2[n3]; y2_in[3] = y2[n3]; z2_in[3] = z2[n3];
 
       if (  (n_out = clip_2dx2d_great_circle( x1_in, y1_in, z1_in, n1_in, x2_in, y2_in, z2_in, n2_in,
-                x_out, y_out, z_out)) > 0) {
+    x_out, y_out, z_out)) > 0) {
   xarea = great_circle_area ( n_out, x_out, y_out, z_out ) * mask_in[j1*nx1+i1];
   min_area = min(area1[j1*nx1+i1], area2[j2*nx2+i2]);
   if( xarea/min_area > AREA_RATIO_THRESH ) {

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -39,8 +39,8 @@
   and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds.
 *******************************************************************************/
 int create_xgrid_1dx2d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-             const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out, double *xgrid_area)
+                               const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                               const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out, double *xgrid_area)
 {
   int nxgrid;
 

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -82,7 +82,7 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
   /* This is just a temporary fix to solve the issue that there is one point in zonal direction */
   // TODO: Finish this "temporary fix"
   if(nx1 > 1)
-     get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);
+    get_grid_area(nlon_in, nlat_in, tmpx, tmpy, area_in);
   else
     get_grid_area_no_adjust(nlon_in, nlat_in, tmpx, tmpy, area_in);
 
@@ -92,9 +92,9 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
 
   for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
 
-    ll_lon = lon_in[i1];   ll_lat = lat_in[j1];
-    ur_lon = lon_in[i1+1]; ur_lat = lat_in[j1+1];
-    for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
+      ll_lon = lon_in[i1];   ll_lat = lat_in[j1];
+      ur_lon = lon_in[i1+1]; ur_lat = lat_in[j1+1];
+      for(j2=0; j2<ny2; j2++) for(i2=0; i2<nx2; i2++) {
       int n_in, n_out;
       double Xarea;
 
@@ -144,20 +144,20 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
   and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds.
 ********************************************************************************/
 int create_xgrid_1dx2d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-             const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-             double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+                               const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                               const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                               double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_1dx2d_order2(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in, i_in,
-             j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+                                     j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
   return nxgrid;
 
 };
 int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+                              const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                              const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                              double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -201,9 +201,9 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
       y_in[2] = lat_out[(j2+1)*nx2p+i2+1];
       y_in[3] = lat_out[(j2+1)*nx2p+i2];
       if (  (y_in[0]<=ll_lat) && (y_in[1]<=ll_lat)
-      && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
+            && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
       if (  (y_in[0]>=ur_lat) && (y_in[1]>=ur_lat)
-      && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
+            && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
 
       x_in[0] = lon_out[j2*nx2p+i2];
       x_in[1] = lon_out[j2*nx2p+i2+1];
@@ -213,19 +213,19 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
       lon_in_avg = avgval_double(n_in, x_in);
 
       if (  (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-  if(xarea/min_area > AREA_RATIO_THRESH ) {
-    xgrid_area[nxgrid] = xarea;
-    xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
-    xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
-    i_in[nxgrid]    = i1;
-    j_in[nxgrid]    = j1;
-    i_out[nxgrid]   = i2;
-    j_out[nxgrid]   = j2;
-    ++nxgrid;
-    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-  }
+        xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+        min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+        if(xarea/min_area > AREA_RATIO_THRESH ) {
+          xgrid_area[nxgrid] = xarea;
+          xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
+          xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
+          i_in[nxgrid]    = i1;
+          j_in[nxgrid]    = j1;
+          i_out[nxgrid]   = i2;
+          j_out[nxgrid]   = j2;
+          ++nxgrid;
+          if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+        }
       }
     }
   }
@@ -244,21 +244,21 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   mask is on grid lon_in/lat_in.
 *******************************************************************************/
 int create_xgrid_2dx1d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-       const double *mask_in, int *i_in, int *j_in, int *i_out,
-       int *j_out, double *xgrid_area)
+                               const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                               const double *mask_in, int *i_in, int *j_in, int *i_out,
+                               int *j_out, double *xgrid_area)
 {
   int nxgrid;
 
   nxgrid = create_xgrid_2dx1d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
-       i_in, j_in, i_out, j_out, xgrid_area);
+                                     i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
 
 };
 int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
-      const double *lat_in, const double *lon_out, const double *lat_out,
-      const double *mask_in, int *i_in, int *j_in, int *i_out,
-      int *j_out, double *xgrid_area)
+                              const double *lat_in, const double *lon_out, const double *lat_out,
+                              const double *mask_in, int *i_in, int *j_in, int *i_out,
+                              int *j_out, double *xgrid_area)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -302,9 +302,9 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
       y_in[2] = lat_in[(j1+1)*nx1p+i1+1];
       y_in[3] = lat_in[(j1+1)*nx1p+i1];
       if (  (y_in[0]<=ll_lat) && (y_in[1]<=ll_lat)
-      && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
+            && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
       if (  (y_in[0]>=ur_lat) && (y_in[1]>=ur_lat)
-      && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
+            && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
 
       x_in[0] = lon_in[j1*nx1p+i1];
       x_in[1] = lon_in[j1*nx1p+i1+1];
@@ -314,17 +314,17 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
 
       if ( (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-  Xarea = poly_area ( x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-  if( Xarea/min_area > AREA_RATIO_THRESH ) {
-    xgrid_area[nxgrid] = Xarea;
-    i_in[nxgrid]    = i1;
-    j_in[nxgrid]    = j1;
-    i_out[nxgrid]   = i2;
-    j_out[nxgrid]   = j2;
-    ++nxgrid;
-    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-  }
+        Xarea = poly_area ( x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+        min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+        if( Xarea/min_area > AREA_RATIO_THRESH ) {
+          xgrid_area[nxgrid] = Xarea;
+          i_in[nxgrid]    = i1;
+          j_in[nxgrid]    = j1;
+          i_out[nxgrid]   = i2;
+          j_out[nxgrid]   = j2;
+          ++nxgrid;
+          if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+        }
       }
     }
   }
@@ -345,21 +345,21 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
   mask is on grid lon_in/lat_in.
 ********************************************************************************/
 int create_xgrid_2dx1d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-       double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+                               const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                               const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                               double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_2dx1d_order2(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in, i_in,
-             j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+                                     j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
   return nxgrid;
 
 };
 
 int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+                              const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                              const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                              double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -418,19 +418,19 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
       lon_in_avg = avgval_double(n_in, x_in);
 
       if (  (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-  if(xarea/min_area > AREA_RATIO_THRESH ) {
-    xgrid_area[nxgrid] = xarea;
-    xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
-    xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
-    i_in[nxgrid]  = i1;
-    j_in[nxgrid]  = j1;
-    i_out[nxgrid] = i2;
-    j_out[nxgrid] = j2;
-    ++nxgrid;
-    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-  }
+        xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+        min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+        if(xarea/min_area > AREA_RATIO_THRESH ) {
+          xgrid_area[nxgrid] = xarea;
+          xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
+          xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
+          i_in[nxgrid]  = i1;
+          j_in[nxgrid]  = j1;
+          i_out[nxgrid] = i2;
+          j_out[nxgrid] = j2;
+          ++nxgrid;
+          if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+        }
       }
     }
   }
@@ -451,22 +451,22 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
 *******************************************************************************/
 #ifndef __AIX
 int create_xgrid_2dx2d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-       const double *mask_in, int *i_in, int *j_in, int *i_out,
-       int *j_out, double *xgrid_area)
+                               const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                               const double *mask_in, int *i_in, int *j_in, int *i_out,
+                               int *j_out, double *xgrid_area)
 {
   int nxgrid;
 
   nxgrid = create_xgrid_2dx2d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
-       i_in, j_in, i_out, j_out, xgrid_area);
+                                     i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
 
 };
 #endif
 int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-      const double *mask_in, int *i_in, int *j_in, int *i_out,
-      int *j_out, double *xgrid_area)
+                              const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                              const double *mask_in, int *i_in, int *j_in, int *i_out,
+                              int *j_out, double *xgrid_area)
 {
 
 #define MAX_V 8
@@ -587,10 +587,10 @@ nxgrid = 0;
 
 #if defined(_OPENMP)
 #pragma omp parallel for default(none) shared(nblocks,nx1,ny1,nx1p,mask_in,lon_in,lat_in, \
-                istart2,iend2,nx2,lat_out_min_list,lat_out_max_list, \
-                n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
-                lon_out_max_list,lon_out_avg,area_in,area_out, \
-                pxgrid_area,pnxgrid,pi_in,pj_in,pi_out,pj_out,pstart,nthreads)
+                                              istart2,iend2,nx2,lat_out_min_list,lat_out_max_list, \
+                                              n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
+                                              lon_out_max_list,lon_out_avg,area_in,area_out, \
+                                              pxgrid_area,pnxgrid,pi_in,pj_in,pi_out,pj_out,pstart,nthreads)
 #endif
   for(m=0; m<nblocks; m++) {
     int i1, j1, ij;
@@ -612,58 +612,56 @@ nxgrid = 0;
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
       for(ij=istart2[m]; ij<=iend2[m]; ij++) {
-  int n_out, i2, j2, n2_in;
-  double xarea, dx, lon_out_min, lon_out_max;
-  double x2_in[MAX_V], y2_in[MAX_V];
+        int n_out, i2, j2, n2_in;
+        double xarea, dx, lon_out_min, lon_out_max;
+        double x2_in[MAX_V], y2_in[MAX_V];
 
-  i2 = ij%nx2;
-  j2 = ij/nx2;
+        i2 = ij%nx2;
+        j2 = ij/nx2;
 
-  if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
-  /* adjust x2_in according to lon_in_avg*/
-  n2_in = n2_list[ij];
-  for(l=0; l<n2_in; l++) {
-    x2_in[l] = lon_out_list[ij*MAX_V+l];
-    y2_in[l] = lat_out_list[ij*MAX_V+l];
-  }
-  lon_out_min = lon_out_min_list[ij];
-  lon_out_max = lon_out_max_list[ij];
-  dx = lon_out_avg[ij] - lon_in_avg;
-  if(dx < -M_PI ) {
-    lon_out_min += TPI;
-    lon_out_max += TPI;
-    for (l=0; l<n2_in; l++) x2_in[l] += TPI;
-  }
-  else if (dx >  M_PI) {
-    lon_out_min -= TPI;
-    lon_out_max -= TPI;
-    for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
-  }
+        if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
+        /* adjust x2_in according to lon_in_avg*/
+        n2_in = n2_list[ij];
+        for(l=0; l<n2_in; l++) {
+          x2_in[l] = lon_out_list[ij*MAX_V+l];
+          y2_in[l] = lat_out_list[ij*MAX_V+l];
+        }
+        lon_out_min = lon_out_min_list[ij];
+        lon_out_max = lon_out_max_list[ij];
+        dx = lon_out_avg[ij] - lon_in_avg;
+        if(dx < -M_PI ) {
+          lon_out_min += TPI;
+          lon_out_max += TPI;
+          for (l=0; l<n2_in; l++) x2_in[l] += TPI;
+        }
+        else if (dx >  M_PI) {
+          lon_out_min -= TPI;
+          lon_out_max -= TPI;
+          for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
+        }
 
   /* x2_in should in the same range as x1_in after lon_fix, so no need to
      consider cyclic condition
   */
-  if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
-  if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
-    double min_area;
-    int    nn;
-    xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-    min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-    if( xarea/min_area > AREA_RATIO_THRESH ) {
-      pnxgrid[m]++;
-      if(pnxgrid[m]>= MAXXGRID/nthreads)
-  error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
-      nn = pstart[m] + pnxgrid[m]-1;
+        if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
+        if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
+          double min_area;
+          int    nn;
+          xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+          min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+          if( xarea/min_area > AREA_RATIO_THRESH ) {
+            pnxgrid[m]++;
+            if(pnxgrid[m]>= MAXXGRID/nthreads)
+              error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
+            nn = pstart[m] + pnxgrid[m]-1;
 
-      pxgrid_area[nn] = xarea;
-      pi_in[nn]       = i1;
-      pj_in[nn]       = j1;
-      pi_out[nn]      = i2;
-      pj_out[nn]      = j2;
-    }
-
-  }
-
+            pxgrid_area[nn] = xarea;
+            pi_in[nn]       = i1;
+            pj_in[nn]       = j1;
+            pi_out[nn]      = i2;
+            pj_out[nn]      = j2;
+          }
+        }
       }
     }
   }
@@ -682,13 +680,13 @@ nxgrid = 0;
     nxgrid = 0;
     for(m=0; m<nblocks; m++) {
       for(i=0; i<pnxgrid[m]; i++) {
-  nn = pstart[m] + i;
-  i_in[nxgrid] = pi_in[nn];
-  j_in[nxgrid] = pj_in[nn];
-  i_out[nxgrid] = pi_out[nn];
-  j_out[nxgrid] = pj_out[nn];
-  xgrid_area[nxgrid] = pxgrid_area[nn];
-  nxgrid++;
+        nn = pstart[m] + i;
+        i_in[nxgrid] = pi_in[nn];
+        j_in[nxgrid] = pj_in[nn];
+        i_out[nxgrid] = pi_out[nn];
+        j_out[nxgrid] = pj_out[nn];
+        xgrid_area[nxgrid] = pxgrid_area[nn];
+        nxgrid++;
       }
     }
     free(pi_in);
@@ -722,22 +720,22 @@ nxgrid = 0;
 ********************************************************************************/
 #ifndef __AIX
 int create_xgrid_2dx2d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-       double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+                               const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                               const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                               double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_2dx2d_order2(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in, i_in,
-             j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+                                     j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
   return nxgrid;
 
 };
 #endif
 #ifdef _OPENACC
 int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+                              const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                              const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                              double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
 #define MAX_V 8
@@ -772,17 +770,17 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   lat_out_list = (double *)malloc(MAX_V*nx2*ny2*sizeof(double));
   nxgrid = 0;
 #pragma acc kernels copyin(lon_out[0:(nx2+1)*(ny2+1)], lat_out[0:(nx2+1)*(ny2+1)], mask_in[0:nx1*ny1], \
-      area_in[0:nx1*ny1], area_out[0:nx2*ny2],	\
-      lon_in[0:(nx1+1)*(ny1+1)], lat_in[0:(nx1+1)*(ny1+1)], \
-      nx1, ny1, nx2, ny2, nx1p, nx2p)	\
+                           area_in[0:nx1*ny1], area_out[0:nx2*ny2],     \
+                           lon_in[0:(nx1+1)*(ny1+1)], lat_in[0:(nx1+1)*(ny1+1)], \
+                           nx1, ny1, nx2, ny2, nx1p, nx2p)              \
   create(lon_out_list[0:MAX_V*nx2*ny2], lat_out_list[0:MAX_V*nx2*ny2],	\
-   lat_out_min_list[0:nx2*ny2], lat_out_max_list[0:nx2*ny2],	\
-   lon_out_min_list[0:nx2*ny2], lon_out_max_list[0:nx2*ny2],	\
-   lon_out_avg[0:nx2*ny2], n2_list[0:nx2*ny2])			\
+         lat_out_min_list[0:nx2*ny2], lat_out_max_list[0:nx2*ny2],      \
+         lon_out_min_list[0:nx2*ny2], lon_out_max_list[0:nx2*ny2],      \
+         lon_out_avg[0:nx2*ny2], n2_list[0:nx2*ny2])                    \
   copyout(xgrid_area[0:mxxgrid], xgrid_clon[0:mxxgrid], xgrid_clat[0:mxxgrid], \
-   i_in[0:mxxgrid], j_in[0:mxxgrid], i_out[0:mxxgrid],j_out[0:mxxgrid])\
+          i_in[0:mxxgrid], j_in[0:mxxgrid], i_out[0:mxxgrid],j_out[0:mxxgrid]) \
   copy(nxgrid)
-{
+  {
 #pragma acc loop independent
   for(ij=0; ij<nx2*ny2; ij++){
     int i2, j2, n, n0, n1, n2, n3, n2_in, l;
@@ -831,58 +829,58 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
       lon_in_avg = avgval_double(n1_in, x1_in);
 #pragma acc loop independent //reduction(+:nxgrid)
       for(ij=0; ij<nx2*ny2; ij++) {
-  int n_out, i2, j2, n2_in, l;
-  double xarea, dx, lon_out_min, lon_out_max;
-  double x2_in[MAX_V], y2_in[MAX_V],  x_out[MV], y_out[MV];;
+        int n_out, i2, j2, n2_in, l;
+        double xarea, dx, lon_out_min, lon_out_max;
+        double x2_in[MAX_V], y2_in[MAX_V],  x_out[MV], y_out[MV];;
 
-  i2 = ij%nx2;
-  j2 = ij/nx2;
+        i2 = ij%nx2;
+        j2 = ij/nx2;
 
-  if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
-  /* adjust x2_in according to lon_in_avg*/
-  n2_in = n2_list[ij];
+        if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
+        /* adjust x2_in according to lon_in_avg*/
+        n2_in = n2_list[ij];
 #pragma acc loop seq
-  for(l=0; l<n2_in; l++) {
-    x2_in[l] = lon_out_list[ij*MAX_V+l];
-    y2_in[l] = lat_out_list[ij*MAX_V+l];
-  }
-  lon_out_min = lon_out_min_list[ij];
-  lon_out_max = lon_out_max_list[ij];
-  dx = lon_out_avg[ij] - lon_in_avg;
-  if(dx < -M_PI ) {
-    lon_out_min += TPI;
-    lon_out_max += TPI;
+        for(l=0; l<n2_in; l++) {
+          x2_in[l] = lon_out_list[ij*MAX_V+l];
+          y2_in[l] = lat_out_list[ij*MAX_V+l];
+        }
+        lon_out_min = lon_out_min_list[ij];
+        lon_out_max = lon_out_max_list[ij];
+        dx = lon_out_avg[ij] - lon_in_avg;
+        if(dx < -M_PI ) {
+          lon_out_min += TPI;
+          lon_out_max += TPI;
 #pragma acc loop seq
-    for (l=0; l<n2_in; l++) x2_in[l] += TPI;
-  }
-  else if (dx >  M_PI) {
-    lon_out_min -= TPI;
-    lon_out_max -= TPI;
+          for (l=0; l<n2_in; l++) x2_in[l] += TPI;
+        }
+        else if (dx >  M_PI) {
+          lon_out_min -= TPI;
+          lon_out_max -= TPI;
 #pragma acc loop seq
-    for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
-  }
+          for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
+        }
 
-  /* x2_in should in the same range as x1_in after lon_fix, so no need to
-     consider cyclic condition
-  */
-  if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
-  n_out = 1;
-  if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
-    double min_area;
-    xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-    min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-    if( xarea/min_area > AREA_RATIO_THRESH ) {
-      xgrid_area[nxgrid] = xarea;
-      xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
-      xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
-      i_in[nxgrid]       = i1;
-      j_in[nxgrid]       = j1;
-      i_out[nxgrid]      = i2;
-      j_out[nxgrid]      = j2;
+        /* x2_in should in the same range as x1_in after lon_fix, so no need to
+           consider cyclic condition
+        */
+        if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
+        n_out = 1;
+        if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
+          double min_area;
+          xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+          min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+          if( xarea/min_area > AREA_RATIO_THRESH ) {
+            xgrid_area[nxgrid] = xarea;
+            xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
+            xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
+            i_in[nxgrid]       = i1;
+            j_in[nxgrid]       = j1;
+            i_out[nxgrid]      = i2;
+            j_out[nxgrid]      = j2;
 #pragma atomic update
-      nxgrid++;
-    }
-  }
+            nxgrid++;
+          }
+        }
       }
     }
  }
@@ -904,9 +902,9 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 };/* get_xgrid_2Dx2D_order2 */
 #else
 int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+                              const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                              const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                              double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
 #define MAX_V 8
@@ -997,8 +995,8 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   lon_out_list = (double *)malloc(MAX_V*nx2*ny2*sizeof(double));
   lat_out_list = (double *)malloc(MAX_V*nx2*ny2*sizeof(double));
 #pragma omp parallel for default(none) shared(nx2,ny2,nx2p,lon_out,lat_out,lat_out_min_list, \
-                lat_out_max_list,lon_out_min_list,lon_out_max_list, \
-                lon_out_avg,n2_list,lon_out_list,lat_out_list)
+                                              lat_out_max_list,lon_out_min_list,lon_out_max_list, \
+                                              lon_out_avg,n2_list,lon_out_list,lat_out_list)
   for(ij=0; ij<nx2*ny2; ij++){
     int i2, j2, n, n0, n1, n2, n3, n2_in, l;
     double x2_in[MV], y2_in[MV];
@@ -1029,12 +1027,12 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 nxgrid = 0;
 
 #pragma omp parallel for default(none) shared(nblocks,nx1,ny1,nx1p,mask_in,lon_in,lat_in, \
-                istart2,iend2,nx2,lat_out_min_list,lat_out_max_list, \
-                n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
-                lon_out_max_list,lon_out_avg,area_in,area_out, \
-                pxgrid_area,pnxgrid,pxgrid_clon,pxgrid_clat,pi_in, \
-                pj_in,pi_out,pj_out,pstart,nthreads)
-  for(m=0; m<nblocks; m++) {
+                                              istart2,iend2,nx2,lat_out_min_list,lat_out_max_list, \
+                                              n2_list,lon_out_list,lat_out_list,lon_out_min_list, \
+                                              lon_out_max_list,lon_out_avg,area_in,area_out, \
+                                              pxgrid_area,pnxgrid,pxgrid_clon,pxgrid_clat,pi_in, \
+                                              pj_in,pi_out,pj_out,pstart,nthreads)
+ for(m=0; m<nblocks; m++) {
     int i1, j1, ij;
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n0, n1, n2, n3, l,n1_in;
@@ -1054,57 +1052,57 @@ nxgrid = 0;
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
       for(ij=istart2[m]; ij<=iend2[m]; ij++) {
-  int n_in, n_out, i2, j2, n2_in;
-  double xarea, dx, lon_out_min, lon_out_max;
-  double x2_in[MAX_V], y2_in[MAX_V];
+        int n_in, n_out, i2, j2, n2_in;
+        double xarea, dx, lon_out_min, lon_out_max;
+        double x2_in[MAX_V], y2_in[MAX_V];
 
-  i2 = ij%nx2;
-  j2 = ij/nx2;
+        i2 = ij%nx2;
+        j2 = ij/nx2;
 
-  if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
-  /* adjust x2_in according to lon_in_avg*/
-  n2_in = n2_list[ij];
-  for(l=0; l<n2_in; l++) {
-    x2_in[l] = lon_out_list[ij*MAX_V+l];
-    y2_in[l] = lat_out_list[ij*MAX_V+l];
-  }
-  lon_out_min = lon_out_min_list[ij];
-  lon_out_max = lon_out_max_list[ij];
-  dx = lon_out_avg[ij] - lon_in_avg;
-  if(dx < -M_PI ) {
-    lon_out_min += TPI;
-    lon_out_max += TPI;
-    for (l=0; l<n2_in; l++) x2_in[l] += TPI;
-  }
-  else if (dx >  M_PI) {
-    lon_out_min -= TPI;
-    lon_out_max -= TPI;
-    for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
-  }
+        if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
+        /* adjust x2_in according to lon_in_avg*/
+        n2_in = n2_list[ij];
+        for(l=0; l<n2_in; l++) {
+          x2_in[l] = lon_out_list[ij*MAX_V+l];
+          y2_in[l] = lat_out_list[ij*MAX_V+l];
+        }
+        lon_out_min = lon_out_min_list[ij];
+        lon_out_max = lon_out_max_list[ij];
+        dx = lon_out_avg[ij] - lon_in_avg;
+        if(dx < -M_PI ) {
+          lon_out_min += TPI;
+          lon_out_max += TPI;
+          for (l=0; l<n2_in; l++) x2_in[l] += TPI;
+        }
+        else if (dx >  M_PI) {
+          lon_out_min -= TPI;
+          lon_out_max -= TPI;
+          for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
+        }
 
-  /* x2_in should in the same range as x1_in after lon_fix, so no need to
- *     consider cyclic condition
- *      */
-  if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
-  if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
-    double min_area;
-    int nn;
-    xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-    min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-    if( xarea/min_area > AREA_RATIO_THRESH ) {
-      pnxgrid[m]++;
-      if(pnxgrid[m]>= MAXXGRID/nthreads)
-  error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
-      nn = pstart[m] + pnxgrid[m]-1;
-      pxgrid_area[nn] = xarea;
-      pxgrid_clon[nn] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
-      pxgrid_clat[nn] = poly_ctrlat (x_out, y_out, n_out );
-      pi_in[nn]       = i1;
-      pj_in[nn]       = j1;
-      pi_out[nn]      = i2;
-      pj_out[nn]      = j2;
-    }
-  }
+        /* x2_in should in the same range as x1_in after lon_fix, so no need to
+         *     consider cyclic condition
+         *      */
+        if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
+        if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
+          double min_area;
+          int nn;
+          xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+          min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+          if( xarea/min_area > AREA_RATIO_THRESH ) {
+            pnxgrid[m]++;
+            if(pnxgrid[m]>= MAXXGRID/nthreads)
+              error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
+            nn = pstart[m] + pnxgrid[m]-1;
+            pxgrid_area[nn] = xarea;
+            pxgrid_clon[nn] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
+            pxgrid_clat[nn] = poly_ctrlat (x_out, y_out, n_out );
+            pi_in[nn]       = i1;
+            pj_in[nn]       = j1;
+            pi_out[nn]      = i2;
+            pj_out[nn]      = j2;
+          }
+        }
       }
     }
   }
@@ -1125,15 +1123,15 @@ nxgrid = 0;
     nxgrid = 0;
     for(m=0; m<nblocks; m++) {
       for(i=0; i<pnxgrid[m]; i++) {
-  nn = pstart[m] + i;
-  i_in[nxgrid] = pi_in[nn];
-  j_in[nxgrid] = pj_in[nn];
-  i_out[nxgrid] = pi_out[nn];
-  j_out[nxgrid] = pj_out[nn];
-  xgrid_area[nxgrid] = pxgrid_area[nn];
-  xgrid_clon[nxgrid] = pxgrid_clon[nn];
-  xgrid_clat[nxgrid] = pxgrid_clat[nn];
-  nxgrid++;
+        nn = pstart[m] + i;
+        i_in[nxgrid] = pi_in[nn];
+        j_in[nxgrid] = pj_in[nn];
+        i_out[nxgrid] = pi_out[nn];
+        j_out[nxgrid] = pj_out[nn];
+        xgrid_area[nxgrid] = pxgrid_area[nn];
+        xgrid_clon[nxgrid] = pxgrid_clon[nn];
+        xgrid_clat[nxgrid] = pxgrid_clat[nn];
+        nxgrid++;
       }
     }
     free(pi_in);
@@ -1163,22 +1161,22 @@ nxgrid = 0;
 
 #ifndef __AIX
 int create_xgrid_great_circle_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+                               const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                               const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                               double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out,
-      mask_in, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+                                     mask_in, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
 
   return nxgrid;
 };
 #endif
 
 int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+                              const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                              const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                              double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
   int nx1, nx2, ny1, ny2, nx1p, nx2p, ny1p, ny2p, nxgrid, n1_in, n2_in;
@@ -1240,23 +1238,23 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
       x2_in[3] = x2[n3]; y2_in[3] = y2[n3]; z2_in[3] = z2[n3];
 
       if (  (n_out = clip_2dx2d_great_circle( x1_in, y1_in, z1_in, n1_in, x2_in, y2_in, z2_in, n2_in,
-    x_out, y_out, z_out)) > 0) {
-  xarea = great_circle_area ( n_out, x_out, y_out, z_out ) * mask_in[j1*nx1+i1];
-  min_area = min(area1[j1*nx1+i1], area2[j2*nx2+i2]);
-  if( xarea/min_area > AREA_RATIO_THRESH ) {
+                                              x_out, y_out, z_out)) > 0) {
+        xarea = great_circle_area ( n_out, x_out, y_out, z_out ) * mask_in[j1*nx1+i1];
+        min_area = min(area1[j1*nx1+i1], area2[j2*nx2+i2]);
+        if( xarea/min_area > AREA_RATIO_THRESH ) {
 #ifdef debug_test_create_xgrid
-    printf("(i2,j2)=(%d,%d), (i1,j1)=(%d,%d), xarea=%g\n", i2, j2, i1, j1, xarea);
+          printf("(i2,j2)=(%d,%d), (i1,j1)=(%d,%d), xarea=%g\n", i2, j2, i1, j1, xarea);
 #endif
-    xgrid_area[nxgrid] = xarea;
-    xgrid_clon[nxgrid] = 0; /*z1l: will be developed very soon */
-    xgrid_clat[nxgrid] = 0;
-    i_in[nxgrid]       = i1;
-    j_in[nxgrid]       = j1;
-    i_out[nxgrid]      = i2;
-    j_out[nxgrid]      = j2;
-    ++nxgrid;
-    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-  }
+          xgrid_area[nxgrid] = xarea;
+          xgrid_clon[nxgrid] = 0; /*z1l: will be developed very soon */
+          xgrid_clat[nxgrid] = 0;
+          i_in[nxgrid]       = i1;
+          j_in[nxgrid]       = j1;
+          i_out[nxgrid]      = i2;
+          j_out[nxgrid]      = j2;
+          ++nxgrid;
+          if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+        }
       }
     }
   }

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+#include "globals.h"
 #include "mosaic_util.h"
 #include "create_xgrid.h"
 #include "create_xgrid_util.h"
@@ -38,21 +39,21 @@
   and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds.
 *******************************************************************************/
 int create_xgrid_1dx2d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out, double *xgrid_area)
+             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+             const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out, double *xgrid_area)
 {
   int nxgrid;
 
   nxgrid = create_xgrid_1dx2d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
-			       i_in, j_in, i_out, j_out, xgrid_area);
+             i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
 
 };
 
 int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
-			      const double *lat_in, const double *lon_out, const double *lat_out,
-			      const double *mask_in, int *i_in, int *j_in, int *i_out,
-			      int *j_out, double *xgrid_area)
+            const double *lat_in, const double *lon_out, const double *lat_out,
+            const double *mask_in, int *i_in, int *j_in, int *i_out,
+            int *j_out, double *xgrid_area)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -102,9 +103,9 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
       y_in[2] = lat_out[(j2+1)*nx2p+i2+1];
       y_in[3] = lat_out[(j2+1)*nx2p+i2];
       if (  (y_in[0]<=ll_lat) && (y_in[1]<=ll_lat)
-	    && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
+      && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
       if (  (y_in[0]>=ur_lat) && (y_in[1]>=ur_lat)
-	    && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
+      && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
 
       x_in[0] = lon_out[j2*nx2p+i2];
       x_in[1] = lon_out[j2*nx2p+i2+1];
@@ -113,17 +114,17 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
 
       if ( (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-	Xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-	min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	if( Xarea/min_area > AREA_RATIO_THRESH ) {
-      	  xgrid_area[nxgrid] = Xarea;
-	  i_in[nxgrid]    = i1;
-	  j_in[nxgrid]    = j1;
-	  i_out[nxgrid]   = i2;
-	  j_out[nxgrid]   = j2;
-	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-	}
+  Xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+  if( Xarea/min_area > AREA_RATIO_THRESH ) {
+          xgrid_area[nxgrid] = Xarea;
+    i_in[nxgrid]    = i1;
+    j_in[nxgrid]    = j1;
+    i_out[nxgrid]   = i2;
+    j_out[nxgrid]   = j2;
+    ++nxgrid;
+    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+  }
       }
     }
   }
@@ -143,9 +144,9 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
   and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds.
 ********************************************************************************/
 int create_xgrid_1dx2d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-			       double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+             const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+             double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_1dx2d_order2(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in, i_in,
@@ -154,9 +155,9 @@ int create_xgrid_1dx2d_order2_(const int *nlon_in, const int *nlat_in, const int
 
 };
 int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -200,9 +201,9 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
       y_in[2] = lat_out[(j2+1)*nx2p+i2+1];
       y_in[3] = lat_out[(j2+1)*nx2p+i2];
       if (  (y_in[0]<=ll_lat) && (y_in[1]<=ll_lat)
-	    && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
+      && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
       if (  (y_in[0]>=ur_lat) && (y_in[1]>=ur_lat)
-	    && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
+      && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
 
       x_in[0] = lon_out[j2*nx2p+i2];
       x_in[1] = lon_out[j2*nx2p+i2+1];
@@ -212,19 +213,19 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
       lon_in_avg = avgval_double(n_in, x_in);
 
       if (  (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
         min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	if(xarea/min_area > AREA_RATIO_THRESH ) {
-	  xgrid_area[nxgrid] = xarea;
-	  xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
-	  xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
-	  i_in[nxgrid]    = i1;
-	  j_in[nxgrid]    = j1;
-	  i_out[nxgrid]   = i2;
-	  j_out[nxgrid]   = j2;
-	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-	}
+  if(xarea/min_area > AREA_RATIO_THRESH ) {
+    xgrid_area[nxgrid] = xarea;
+    xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
+    xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
+    i_in[nxgrid]    = i1;
+    j_in[nxgrid]    = j1;
+    i_out[nxgrid]   = i2;
+    j_out[nxgrid]   = j2;
+    ++nxgrid;
+    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+  }
       }
     }
   }
@@ -243,21 +244,21 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   mask is on grid lon_in/lat_in.
 *******************************************************************************/
 int create_xgrid_2dx1d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			       const double *mask_in, int *i_in, int *j_in, int *i_out,
-			       int *j_out, double *xgrid_area)
+             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+             const double *mask_in, int *i_in, int *j_in, int *i_out,
+             int *j_out, double *xgrid_area)
 {
   int nxgrid;
 
   nxgrid = create_xgrid_2dx1d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
-			       i_in, j_in, i_out, j_out, xgrid_area);
+             i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
 
 };
 int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
-			      const double *lat_in, const double *lon_out, const double *lat_out,
-			      const double *mask_in, int *i_in, int *j_in, int *i_out,
-			      int *j_out, double *xgrid_area)
+            const double *lat_in, const double *lon_out, const double *lat_out,
+            const double *mask_in, int *i_in, int *j_in, int *i_out,
+            int *j_out, double *xgrid_area)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -301,9 +302,9 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
       y_in[2] = lat_in[(j1+1)*nx1p+i1+1];
       y_in[3] = lat_in[(j1+1)*nx1p+i1];
       if (  (y_in[0]<=ll_lat) && (y_in[1]<=ll_lat)
-	    && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
+      && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
       if (  (y_in[0]>=ur_lat) && (y_in[1]>=ur_lat)
-	    && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
+      && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
 
       x_in[0] = lon_in[j1*nx1p+i1];
       x_in[1] = lon_in[j1*nx1p+i1+1];
@@ -313,17 +314,17 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
 
       if ( (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-	Xarea = poly_area ( x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-	min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	if( Xarea/min_area > AREA_RATIO_THRESH ) {
-      	  xgrid_area[nxgrid] = Xarea;
-	  i_in[nxgrid]    = i1;
-	  j_in[nxgrid]    = j1;
-	  i_out[nxgrid]   = i2;
-	  j_out[nxgrid]   = j2;
-	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-	}
+  Xarea = poly_area ( x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+  if( Xarea/min_area > AREA_RATIO_THRESH ) {
+          xgrid_area[nxgrid] = Xarea;
+    i_in[nxgrid]    = i1;
+    j_in[nxgrid]    = j1;
+    i_out[nxgrid]   = i2;
+    j_out[nxgrid]   = j2;
+    ++nxgrid;
+    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+  }
       }
     }
   }
@@ -344,9 +345,9 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
   mask is on grid lon_in/lat_in.
 ********************************************************************************/
 int create_xgrid_2dx1d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-			       double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+             const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+             double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_2dx1d_order2(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in, i_in,
@@ -356,9 +357,9 @@ int create_xgrid_2dx1d_order2_(const int *nlon_in, const int *nlat_in, const int
 };
 
 int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;
@@ -404,9 +405,9 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
       y_in[2] = lat_in[(j1+1)*nx1p+i1+1];
       y_in[3] = lat_in[(j1+1)*nx1p+i1];
       if (  (y_in[0]<=ll_lat) && (y_in[1]<=ll_lat)
-	    && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
+      && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
       if (  (y_in[0]>=ur_lat) && (y_in[1]>=ur_lat)
-	    && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
+      && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
 
       x_in[0] = lon_in[j1*nx1p+i1];
       x_in[1] = lon_in[j1*nx1p+i1+1];
@@ -417,19 +418,19 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
       lon_in_avg = avgval_double(n_in, x_in);
 
       if (  (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-	xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-	min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	if(xarea/min_area > AREA_RATIO_THRESH ) {
-	  xgrid_area[nxgrid] = xarea;
-	  xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
-	  xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
-	  i_in[nxgrid]  = i1;
-	  j_in[nxgrid]  = j1;
-	  i_out[nxgrid] = i2;
-	  j_out[nxgrid] = j2;
-	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-	}
+  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+  if(xarea/min_area > AREA_RATIO_THRESH ) {
+    xgrid_area[nxgrid] = xarea;
+    xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
+    xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
+    i_in[nxgrid]  = i1;
+    j_in[nxgrid]  = j1;
+    i_out[nxgrid] = i2;
+    j_out[nxgrid] = j2;
+    ++nxgrid;
+    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+  }
       }
     }
   }
@@ -450,22 +451,22 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
 *******************************************************************************/
 #ifndef __AIX
 int create_xgrid_2dx2d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			       const double *mask_in, int *i_in, int *j_in, int *i_out,
-			       int *j_out, double *xgrid_area)
+             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+             const double *mask_in, int *i_in, int *j_in, int *i_out,
+             int *j_out, double *xgrid_area)
 {
   int nxgrid;
 
   nxgrid = create_xgrid_2dx2d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
-			       i_in, j_in, i_out, j_out, xgrid_area);
+             i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
 
 };
 #endif
 int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			      const double *mask_in, int *i_in, int *j_in, int *i_out,
-			      int *j_out, double *xgrid_area)
+            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+            const double *mask_in, int *i_in, int *j_in, int *i_out,
+            int *j_out, double *xgrid_area)
 {
 
 #define MAX_V 8
@@ -611,57 +612,57 @@ nxgrid = 0;
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
       for(ij=istart2[m]; ij<=iend2[m]; ij++) {
-	int n_out, i2, j2, n2_in;
-	double xarea, dx, lon_out_min, lon_out_max;
-	double x2_in[MAX_V], y2_in[MAX_V];
+  int n_out, i2, j2, n2_in;
+  double xarea, dx, lon_out_min, lon_out_max;
+  double x2_in[MAX_V], y2_in[MAX_V];
 
-	i2 = ij%nx2;
-	j2 = ij/nx2;
+  i2 = ij%nx2;
+  j2 = ij/nx2;
 
-	if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
-	/* adjust x2_in according to lon_in_avg*/
-	n2_in = n2_list[ij];
-	for(l=0; l<n2_in; l++) {
-	  x2_in[l] = lon_out_list[ij*MAX_V+l];
-	  y2_in[l] = lat_out_list[ij*MAX_V+l];
-	}
-	lon_out_min = lon_out_min_list[ij];
-	lon_out_max = lon_out_max_list[ij];
+  if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
+  /* adjust x2_in according to lon_in_avg*/
+  n2_in = n2_list[ij];
+  for(l=0; l<n2_in; l++) {
+    x2_in[l] = lon_out_list[ij*MAX_V+l];
+    y2_in[l] = lat_out_list[ij*MAX_V+l];
+  }
+  lon_out_min = lon_out_min_list[ij];
+  lon_out_max = lon_out_max_list[ij];
         dx = lon_out_avg[ij] - lon_in_avg;
-	if(dx < -M_PI ) {
-	  lon_out_min += TPI;
-	  lon_out_max += TPI;
-	  for (l=0; l<n2_in; l++) x2_in[l] += TPI;
-	}
+  if(dx < -M_PI ) {
+    lon_out_min += TPI;
+    lon_out_max += TPI;
+    for (l=0; l<n2_in; l++) x2_in[l] += TPI;
+  }
         else if (dx >  M_PI) {
-	  lon_out_min -= TPI;
-	  lon_out_max -= TPI;
-	  for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
-	}
+    lon_out_min -= TPI;
+    lon_out_max -= TPI;
+    for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
+  }
 
-	/* x2_in should in the same range as x1_in after lon_fix, so no need to
-	   consider cyclic condition
-	*/
-	if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
-	if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
+  /* x2_in should in the same range as x1_in after lon_fix, so no need to
+     consider cyclic condition
+  */
+  if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
+  if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
           double min_area;
-	  int    nn;
-	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	  if( xarea/min_area > AREA_RATIO_THRESH ) {
-	    pnxgrid[m]++;
+    int    nn;
+    xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+    min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+    if( xarea/min_area > AREA_RATIO_THRESH ) {
+      pnxgrid[m]++;
             if(pnxgrid[m]>= MAXXGRID/nthreads)
-	      error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
-	    nn = pstart[m] + pnxgrid[m]-1;
+        error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
+      nn = pstart[m] + pnxgrid[m]-1;
 
-	    pxgrid_area[nn] = xarea;
-	    pi_in[nn]       = i1;
-	    pj_in[nn]       = j1;
-	    pi_out[nn]      = i2;
-	    pj_out[nn]      = j2;
-	  }
+      pxgrid_area[nn] = xarea;
+      pi_in[nn]       = i1;
+      pj_in[nn]       = j1;
+      pi_out[nn]      = i2;
+      pj_out[nn]      = j2;
+    }
 
-	}
+  }
 
       }
     }
@@ -681,13 +682,13 @@ nxgrid = 0;
     nxgrid = 0;
     for(m=0; m<nblocks; m++) {
       for(i=0; i<pnxgrid[m]; i++) {
-	nn = pstart[m] + i;
-	i_in[nxgrid] = pi_in[nn];
-	j_in[nxgrid] = pj_in[nn];
-	i_out[nxgrid] = pi_out[nn];
-	j_out[nxgrid] = pj_out[nn];
-	xgrid_area[nxgrid] = pxgrid_area[nn];
-	nxgrid++;
+  nn = pstart[m] + i;
+  i_in[nxgrid] = pi_in[nn];
+  j_in[nxgrid] = pj_in[nn];
+  i_out[nxgrid] = pi_out[nn];
+  j_out[nxgrid] = pj_out[nn];
+  xgrid_area[nxgrid] = pxgrid_area[nn];
+  nxgrid++;
       }
     }
     free(pi_in);
@@ -721,9 +722,9 @@ nxgrid = 0;
 ********************************************************************************/
 #ifndef __AIX
 int create_xgrid_2dx2d_order2_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			       const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-			       double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+             const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+             double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_2dx2d_order2(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in, i_in,
@@ -734,9 +735,9 @@ int create_xgrid_2dx2d_order2_(const int *nlon_in, const int *nlat_in, const int
 #endif
 #ifdef _OPENACC
 int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
 #define MAX_V 8
@@ -771,15 +772,15 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   lat_out_list = (double *)malloc(MAX_V*nx2*ny2*sizeof(double));
   nxgrid = 0;
 #pragma acc kernels copyin(lon_out[0:(nx2+1)*(ny2+1)], lat_out[0:(nx2+1)*(ny2+1)], mask_in[0:nx1*ny1], \
-			area_in[0:nx1*ny1], area_out[0:nx2*ny2],	\
-			lon_in[0:(nx1+1)*(ny1+1)], lat_in[0:(nx1+1)*(ny1+1)], \
-			nx1, ny1, nx2, ny2, nx1p, nx2p)	\
+      area_in[0:nx1*ny1], area_out[0:nx2*ny2],	\
+      lon_in[0:(nx1+1)*(ny1+1)], lat_in[0:(nx1+1)*(ny1+1)], \
+      nx1, ny1, nx2, ny2, nx1p, nx2p)	\
   create(lon_out_list[0:MAX_V*nx2*ny2], lat_out_list[0:MAX_V*nx2*ny2],	\
-	 lat_out_min_list[0:nx2*ny2], lat_out_max_list[0:nx2*ny2],	\
-	 lon_out_min_list[0:nx2*ny2], lon_out_max_list[0:nx2*ny2],	\
-	 lon_out_avg[0:nx2*ny2], n2_list[0:nx2*ny2])			\
+   lat_out_min_list[0:nx2*ny2], lat_out_max_list[0:nx2*ny2],	\
+   lon_out_min_list[0:nx2*ny2], lon_out_max_list[0:nx2*ny2],	\
+   lon_out_avg[0:nx2*ny2], n2_list[0:nx2*ny2])			\
   copyout(xgrid_area[0:mxxgrid], xgrid_clon[0:mxxgrid], xgrid_clat[0:mxxgrid], \
-	 i_in[0:mxxgrid], j_in[0:mxxgrid], i_out[0:mxxgrid],j_out[0:mxxgrid])\
+   i_in[0:mxxgrid], j_in[0:mxxgrid], i_out[0:mxxgrid],j_out[0:mxxgrid])\
   copy(nxgrid)
 {
 #pragma acc loop independent
@@ -828,60 +829,60 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
       lon_in_min = minval_double(n1_in, x1_in);
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
-#pragma acc loop independent //reduction(+:nxgrid) 
+#pragma acc loop independent //reduction(+:nxgrid)
       for(ij=0; ij<nx2*ny2; ij++) {
-	int n_out, i2, j2, n2_in, l;
-	double xarea, dx, lon_out_min, lon_out_max;
-	double x2_in[MAX_V], y2_in[MAX_V],  x_out[MV], y_out[MV];;
+  int n_out, i2, j2, n2_in, l;
+  double xarea, dx, lon_out_min, lon_out_max;
+  double x2_in[MAX_V], y2_in[MAX_V],  x_out[MV], y_out[MV];;
 
-	i2 = ij%nx2;
-	j2 = ij/nx2;
+  i2 = ij%nx2;
+  j2 = ij/nx2;
 
-	if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
-	/* adjust x2_in according to lon_in_avg*/
-	n2_in = n2_list[ij];
+  if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
+  /* adjust x2_in according to lon_in_avg*/
+  n2_in = n2_list[ij];
 #pragma acc loop seq
-	for(l=0; l<n2_in; l++) {
-	  x2_in[l] = lon_out_list[ij*MAX_V+l];
-	  y2_in[l] = lat_out_list[ij*MAX_V+l];
-	}
-	lon_out_min = lon_out_min_list[ij];
-	lon_out_max = lon_out_max_list[ij];
+  for(l=0; l<n2_in; l++) {
+    x2_in[l] = lon_out_list[ij*MAX_V+l];
+    y2_in[l] = lat_out_list[ij*MAX_V+l];
+  }
+  lon_out_min = lon_out_min_list[ij];
+  lon_out_max = lon_out_max_list[ij];
         dx = lon_out_avg[ij] - lon_in_avg;
-	if(dx < -M_PI ) {
-	  lon_out_min += TPI;
-	  lon_out_max += TPI;
+  if(dx < -M_PI ) {
+    lon_out_min += TPI;
+    lon_out_max += TPI;
 #pragma acc loop seq
-	  for (l=0; l<n2_in; l++) x2_in[l] += TPI;
-	}
+    for (l=0; l<n2_in; l++) x2_in[l] += TPI;
+  }
         else if (dx >  M_PI) {
-	  lon_out_min -= TPI;
-	  lon_out_max -= TPI;
+    lon_out_min -= TPI;
+    lon_out_max -= TPI;
 #pragma acc loop seq
-	  for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
-	}
+    for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
+  }
 
-	/* x2_in should in the same range as x1_in after lon_fix, so no need to
-	   consider cyclic condition
-	*/
-	if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
-	n_out = 1;
-	if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
+  /* x2_in should in the same range as x1_in after lon_fix, so no need to
+     consider cyclic condition
+  */
+  if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
+  n_out = 1;
+  if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
           double min_area;
-	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	  if( xarea/min_area > AREA_RATIO_THRESH ) {
-	    xgrid_area[nxgrid] = xarea;
-	    xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
-	    xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
-	    i_in[nxgrid]       = i1;
-	    j_in[nxgrid]       = j1;
-	    i_out[nxgrid]      = i2;
-	    j_out[nxgrid]      = j2;
+    xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+    min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+    if( xarea/min_area > AREA_RATIO_THRESH ) {
+      xgrid_area[nxgrid] = xarea;
+      xgrid_clon[nxgrid] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
+      xgrid_clat[nxgrid] = poly_ctrlat (x_out, y_out, n_out );
+      i_in[nxgrid]       = i1;
+      j_in[nxgrid]       = j1;
+      i_out[nxgrid]      = i2;
+      j_out[nxgrid]      = j2;
 #pragma atomic update
-	    nxgrid++;	    
-	  }
-	}
+      nxgrid++;
+    }
+  }
       }
     }
  }
@@ -903,9 +904,9 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 };/* get_xgrid_2Dx2D_order2 */
 #else
 int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
 #define MAX_V 8
@@ -1053,57 +1054,57 @@ nxgrid = 0;
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
       for(ij=istart2[m]; ij<=iend2[m]; ij++) {
-	int n_in, n_out, i2, j2, n2_in;
-	double xarea, dx, lon_out_min, lon_out_max;
-	double x2_in[MAX_V], y2_in[MAX_V];
+  int n_in, n_out, i2, j2, n2_in;
+  double xarea, dx, lon_out_min, lon_out_max;
+  double x2_in[MAX_V], y2_in[MAX_V];
 
-	i2 = ij%nx2;
-	j2 = ij/nx2;
+  i2 = ij%nx2;
+  j2 = ij/nx2;
 
-	if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
-	/* adjust x2_in according to lon_in_avg*/
-	n2_in = n2_list[ij];
-	for(l=0; l<n2_in; l++) {
-	  x2_in[l] = lon_out_list[ij*MAX_V+l];
-	  y2_in[l] = lat_out_list[ij*MAX_V+l];
-	}
-	lon_out_min = lon_out_min_list[ij];
-	lon_out_max = lon_out_max_list[ij];
+  if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
+  /* adjust x2_in according to lon_in_avg*/
+  n2_in = n2_list[ij];
+  for(l=0; l<n2_in; l++) {
+    x2_in[l] = lon_out_list[ij*MAX_V+l];
+    y2_in[l] = lat_out_list[ij*MAX_V+l];
+  }
+  lon_out_min = lon_out_min_list[ij];
+  lon_out_max = lon_out_max_list[ij];
         dx = lon_out_avg[ij] - lon_in_avg;
-	if(dx < -M_PI ) {
-	  lon_out_min += TPI;
-	  lon_out_max += TPI;
-	  for (l=0; l<n2_in; l++) x2_in[l] += TPI;
-	}
+  if(dx < -M_PI ) {
+    lon_out_min += TPI;
+    lon_out_max += TPI;
+    for (l=0; l<n2_in; l++) x2_in[l] += TPI;
+  }
         else if (dx >  M_PI) {
-	  lon_out_min -= TPI;
-	  lon_out_max -= TPI;
-	  for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
-	}
+    lon_out_min -= TPI;
+    lon_out_max -= TPI;
+    for (l=0; l<n2_in; l++) x2_in[l] -= TPI;
+  }
 
-	/* x2_in should in the same range as x1_in after lon_fix, so no need to
- * 	   consider cyclic condition
- * 	   	*/
-	if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
-	if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
+  /* x2_in should in the same range as x1_in after lon_fix, so no need to
+ *     consider cyclic condition
+ *      */
+  if(lon_out_min >= lon_in_max || lon_out_max <= lon_in_min ) continue;
+  if (  (n_out = clip_2dx2d( x1_in, y1_in, n1_in, x2_in, y2_in, n2_in, x_out, y_out )) > 0) {
           double min_area;
-	  int nn;
-	  xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-	  if( xarea/min_area > AREA_RATIO_THRESH ) {
-	    pnxgrid[m]++;
+    int nn;
+    xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+    min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+    if( xarea/min_area > AREA_RATIO_THRESH ) {
+      pnxgrid[m]++;
             if(pnxgrid[m]>= MAXXGRID/nthreads)
-	      error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
-	    nn = pstart[m] + pnxgrid[m]-1;
-	    pxgrid_area[nn] = xarea;
-	    pxgrid_clon[nn] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
-	    pxgrid_clat[nn] = poly_ctrlat (x_out, y_out, n_out );
-	    pi_in[nn]       = i1;
-	    pj_in[nn]       = j1;
-	    pi_out[nn]      = i2;
-	    pj_out[nn]      = j2;
-	  }
-	}
+        error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
+      nn = pstart[m] + pnxgrid[m]-1;
+      pxgrid_area[nn] = xarea;
+      pxgrid_clon[nn] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
+      pxgrid_clat[nn] = poly_ctrlat (x_out, y_out, n_out );
+      pi_in[nn]       = i1;
+      pj_in[nn]       = j1;
+      pi_out[nn]      = i2;
+      pj_out[nn]      = j2;
+    }
+  }
       }
     }
   }
@@ -1124,15 +1125,15 @@ nxgrid = 0;
     nxgrid = 0;
     for(m=0; m<nblocks; m++) {
       for(i=0; i<pnxgrid[m]; i++) {
-	nn = pstart[m] + i;
-	i_in[nxgrid] = pi_in[nn];
-	j_in[nxgrid] = pj_in[nn];
-	i_out[nxgrid] = pi_out[nn];
-	j_out[nxgrid] = pj_out[nn];
-	xgrid_area[nxgrid] = pxgrid_area[nn];
-	xgrid_clon[nxgrid] = pxgrid_clon[nn];
-	xgrid_clat[nxgrid] = pxgrid_clat[nn];
-	nxgrid++;
+  nn = pstart[m] + i;
+  i_in[nxgrid] = pi_in[nn];
+  j_in[nxgrid] = pj_in[nn];
+  i_out[nxgrid] = pi_out[nn];
+  j_out[nxgrid] = pj_out[nn];
+  xgrid_area[nxgrid] = pxgrid_area[nn];
+  xgrid_clon[nxgrid] = pxgrid_clon[nn];
+  xgrid_clat[nxgrid] = pxgrid_clat[nn];
+  nxgrid++;
       }
     }
     free(pi_in);
@@ -1162,22 +1163,22 @@ nxgrid = 0;
 
 #ifndef __AIX
 int create_xgrid_great_circle_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
   int nxgrid;
   nxgrid = create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out,
-			      mask_in, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
+            mask_in, i_in, j_in, i_out, j_out, xgrid_area, xgrid_clon, xgrid_clat);
 
   return nxgrid;
 };
 #endif
 
 int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			      const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-			      const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
-			      double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
+            const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+            double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
   int nx1, nx2, ny1, ny2, nx1p, nx2p, ny1p, ny2p, nxgrid, n1_in, n2_in;
@@ -1239,23 +1240,23 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
       x2_in[3] = x2[n3]; y2_in[3] = y2[n3]; z2_in[3] = z2[n3];
 
       if (  (n_out = clip_2dx2d_great_circle( x1_in, y1_in, z1_in, n1_in, x2_in, y2_in, z2_in, n2_in,
-					      x_out, y_out, z_out)) > 0) {
-	xarea = great_circle_area ( n_out, x_out, y_out, z_out ) * mask_in[j1*nx1+i1];
-	min_area = min(area1[j1*nx1+i1], area2[j2*nx2+i2]);
-	if( xarea/min_area > AREA_RATIO_THRESH ) {
+                x_out, y_out, z_out)) > 0) {
+  xarea = great_circle_area ( n_out, x_out, y_out, z_out ) * mask_in[j1*nx1+i1];
+  min_area = min(area1[j1*nx1+i1], area2[j2*nx2+i2]);
+  if( xarea/min_area > AREA_RATIO_THRESH ) {
 #ifdef debug_test_create_xgrid
-	  printf("(i2,j2)=(%d,%d), (i1,j1)=(%d,%d), xarea=%g\n", i2, j2, i1, j1, xarea);
+    printf("(i2,j2)=(%d,%d), (i1,j1)=(%d,%d), xarea=%g\n", i2, j2, i1, j1, xarea);
 #endif
-	  xgrid_area[nxgrid] = xarea;
-	  xgrid_clon[nxgrid] = 0; /*z1l: will be developed very soon */
-	  xgrid_clat[nxgrid] = 0;
-	  i_in[nxgrid]       = i1;
-	  j_in[nxgrid]       = j1;
-	  i_out[nxgrid]      = i2;
-	  j_out[nxgrid]      = j2;
-	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-	}
+    xgrid_area[nxgrid] = xarea;
+    xgrid_clon[nxgrid] = 0; /*z1l: will be developed very soon */
+    xgrid_clat[nxgrid] = 0;
+    i_in[nxgrid]       = i1;
+    j_in[nxgrid]       = j1;
+    i_out[nxgrid]      = i2;
+    j_out[nxgrid]      = j2;
+    ++nxgrid;
+    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+  }
       }
     }
   }
@@ -1274,4 +1275,3 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
   return nxgrid;
 
 };/* create_xgrid_great_circle */
-

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -39,7 +39,7 @@
   and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds.
 *******************************************************************************/
 int create_xgrid_1dx2d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-                               const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
                                const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out, double *xgrid_area)
 {
   int nxgrid;
@@ -51,9 +51,9 @@ int create_xgrid_1dx2d_order1_(const int *nlon_in, const int *nlat_in, const int
 };
 
 int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
-            const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *mask_in, int *i_in, int *j_in, int *i_out,
-            int *j_out, double *xgrid_area)
+       			      const double *lat_in, const double *lon_out, const double *lat_out,
+                              const double *mask_in, int *i_in, int *j_in, int *i_out,
+                              int *j_out, double *xgrid_area)
 {
 
   int nx1, ny1, nx2, ny2, nx1p, nx2p;

--- a/tools/libfrencutils/create_xgrid.c
+++ b/tools/libfrencutils/create_xgrid.c
@@ -39,19 +39,19 @@
   and lon_in,lat_in are 1-D grid bounds, lon_out,lat_out are geographic grid location of grid cell bounds.
 *******************************************************************************/
 int create_xgrid_1dx2d_order1_(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
-			       const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
+                               const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
                                const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out, double *xgrid_area)
 {
   int nxgrid;
 
   nxgrid = create_xgrid_1dx2d_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in, lat_in, lon_out, lat_out, mask_in,
-             i_in, j_in, i_out, j_out, xgrid_area);
+                                     i_in, j_in, i_out, j_out, xgrid_area);
   return nxgrid;
 
 };
 
 int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out, const double *lon_in,
-       			      const double *lat_in, const double *lon_out, const double *lat_out,
+                              const double *lat_in, const double *lon_out, const double *lat_out,
                               const double *mask_in, int *i_in, int *j_in, int *i_out,
                               int *j_out, double *xgrid_area)
 {
@@ -103,9 +103,9 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
       y_in[2] = lat_out[(j2+1)*nx2p+i2+1];
       y_in[3] = lat_out[(j2+1)*nx2p+i2];
       if (  (y_in[0]<=ll_lat) && (y_in[1]<=ll_lat)
-      && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
+            && (y_in[2]<=ll_lat) && (y_in[3]<=ll_lat) ) continue;
       if (  (y_in[0]>=ur_lat) && (y_in[1]>=ur_lat)
-      && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
+            && (y_in[2]>=ur_lat) && (y_in[3]>=ur_lat) ) continue;
 
       x_in[0] = lon_out[j2*nx2p+i2];
       x_in[1] = lon_out[j2*nx2p+i2+1];
@@ -114,17 +114,17 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
       n_in = fix_lon(x_in, y_in, 4, (ll_lon+ur_lon)/2);
 
       if ( (n_out = clip ( x_in, y_in, n_in, ll_lon, ll_lat, ur_lon, ur_lat, x_out, y_out )) > 0 ) {
-  Xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
-  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
-  if( Xarea/min_area > AREA_RATIO_THRESH ) {
+        Xarea = poly_area (x_out, y_out, n_out ) * mask_in[j1*nx1+i1];
+        min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
+        if( Xarea/min_area > AREA_RATIO_THRESH ) {
           xgrid_area[nxgrid] = Xarea;
-    i_in[nxgrid]    = i1;
-    j_in[nxgrid]    = j1;
-    i_out[nxgrid]   = i2;
-    j_out[nxgrid]   = j2;
-    ++nxgrid;
-    if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
-  }
+          i_in[nxgrid]    = i1;
+          j_in[nxgrid]    = j1;
+          i_out[nxgrid]   = i2;
+          j_out[nxgrid]   = j2;
+          ++nxgrid;
+          if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+        }
       }
     }
   }

--- a/tools/libfrencutils/create_xgrid_acc.c
+++ b/tools/libfrencutils/create_xgrid_acc.c
@@ -73,9 +73,10 @@ int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const 
 #pragma acc data present(xgrid_area[0:mxxgrid], xgrid_clon[0:mxxgrid], xgrid_clat[0:mxxgrid], \
                          i_in[0:mxxgrid], j_in[0:mxxgrid], i_out[0:mxxgrid],j_out[0:mxxgrid])
 #pragma acc data copyin(area_in[0:nx1*ny1], area_out[0:nx2*ny2])
-#pragma acc kernels copy(nxgrid)
+#pragma acc data copy(nxgrid)
+#pragma acc kernels
 {
-#pragma acc loop independent collapse(2) reduction(+:nxgrid)
+#pragma acc loop independent collapse(2) //reduction(+:nxgrid)
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n0, n1, n2, n3, n1_in;
       double lat_in_min,lat_in_max,lon_in_min,lon_in_max,lon_in_avg;
@@ -92,7 +93,7 @@ int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const 
       lon_in_min = minval_double(n1_in, x1_in);
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
-#pragma acc loop independent reduction(+:nxgrid)
+#pragma acc loop independent //reduction(+:nxgrid)
       for(ij=0; ij<nx2*ny2; ij++) {
         int n_out, i2, j2, n2_in, l;
         double xarea, dx, lon_out_min, lon_out_max;

--- a/tools/libfrencutils/create_xgrid_acc.c
+++ b/tools/libfrencutils/create_xgrid_acc.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+#include "globals.h"
 #include "mosaic_util.h"
 #include "create_xgrid.h"
 #include "create_xgrid_util.h"
@@ -37,10 +38,7 @@
 *******************************************************************************/
 int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
                                   const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-                                  const double *lon_out_min_list, const double *lon_out_max_list, const double *lon_out_avg,
-                                  const double *lat_out_min_list, const double *lat_out_max_list, const int *n2_list,
-                                  const double *lon_out_list, const double *lat_out_list,
-                                  const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                                  Minmaxavglists *out_minmaxavglists, const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
                                   double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
@@ -68,16 +66,16 @@ int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const 
 
 #pragma acc data present(lon_out[0:(nx2+1)*(ny2+1)], lat_out[0:(nx2+1)*(ny2+1)])
 #pragma acc data present(lon_in[0:(nx1+1)*(ny1+1)], lat_in[0:(nx1+1)*(ny1+1)], mask_in[0:nx1*ny1])
-#pragma acc data present(lon_out_list[0:MAX_V*nx2*ny2], lat_out_list[0:MAX_V*nx2*ny2],	\
-                         lat_out_min_list[0:nx2*ny2], lat_out_max_list[0:nx2*ny2], \
-                         lon_out_min_list[0:nx2*ny2], lon_out_max_list[0:nx2*ny2], \
-                         lon_out_avg[0:nx2*ny2], n2_list[0:nx2*ny2])
+#pragma acc data present(out_minmaxavglists->lon_list[0:MAX_V*nx2*ny2], out_minmaxavglists->lat_list[0:MAX_V*nx2*ny2])
+#pragma acc data present(out_minmaxavglists->n_list[0:nx2*ny2], out_minmaxavglists->lon_avg[0:nx2*ny2])
+#pragma acc data present(out_minmaxavglists->lat_min_list[0:nx2*ny2], out_minmaxavglists->lat_max_list[0:nx2*ny2])
+#pragma acc data present(out_minmaxavglists->lon_min_list[0:nx2*ny2], out_minmaxavglists->lon_max_list[0:nx2*ny2])
 #pragma acc data present(xgrid_area[0:mxxgrid], xgrid_clon[0:mxxgrid], xgrid_clat[0:mxxgrid], \
                          i_in[0:mxxgrid], j_in[0:mxxgrid], i_out[0:mxxgrid],j_out[0:mxxgrid])
 #pragma acc data copyin(area_in[0:nx1*ny1], area_out[0:nx2*ny2])
 #pragma acc kernels copy(nxgrid)
 {
-#pragma acc loop independent collapse(2) //reduction(+:nxgrid)
+#pragma acc loop independent collapse(2) reduction(+:nxgrid)
     for(j1=0; j1<ny1; j1++) for(i1=0; i1<nx1; i1++) if( mask_in[j1*nx1+i1] > MASK_THRESH ) {
       int n0, n1, n2, n3, n1_in;
       double lat_in_min,lat_in_max,lon_in_min,lon_in_max,lon_in_avg;
@@ -94,7 +92,7 @@ int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const 
       lon_in_min = minval_double(n1_in, x1_in);
       lon_in_max = maxval_double(n1_in, x1_in);
       lon_in_avg = avgval_double(n1_in, x1_in);
-#pragma acc loop independent //reduction(+:nxgrid)
+#pragma acc loop independent reduction(+:nxgrid)
       for(ij=0; ij<nx2*ny2; ij++) {
         int n_out, i2, j2, n2_in, l;
         double xarea, dx, lon_out_min, lon_out_max;
@@ -103,17 +101,17 @@ int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const 
         i2 = ij%nx2;
         j2 = ij/nx2;
 
-        if(lat_out_min_list[ij] >= lat_in_max || lat_out_max_list[ij] <= lat_in_min ) continue;
+        if(out_minmaxavglists->lat_min_list[ij] >= lat_in_max || out_minmaxavglists->lat_max_list[ij] <= lat_in_min ) continue;
         /* adjust x2_in according to lon_in_avg*/
-        n2_in = n2_list[ij];
+        n2_in = out_minmaxavglists->n_list[ij];
 #pragma acc loop seq
         for(l=0; l<n2_in; l++) {
-          x2_in[l] = lon_out_list[ij*MAX_V+l];
-          y2_in[l] = lat_out_list[ij*MAX_V+l];
+          x2_in[l] = out_minmaxavglists->lon_list[ij*MAX_V+l];
+          y2_in[l] = out_minmaxavglists->lat_list[ij*MAX_V+l];
         }
-        lon_out_min = lon_out_min_list[ij];
-        lon_out_max = lon_out_max_list[ij];
-        dx = lon_out_avg[ij] - lon_in_avg;
+        lon_out_min = out_minmaxavglists->lon_min_list[ij];
+        lon_out_max = out_minmaxavglists->lon_max_list[ij];
+        dx = out_minmaxavglists->lon_avg[ij] - lon_in_avg;
         if(dx < -M_PI ) {
           lon_out_min += TPI;
           lon_out_max += TPI;

--- a/tools/libfrencutils/create_xgrid_acc.c
+++ b/tools/libfrencutils/create_xgrid_acc.c
@@ -38,7 +38,8 @@
 *******************************************************************************/
 int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
                                   const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-                                  Minmaxavglists *out_minmaxavglists, const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+                                  Minmaxavg_lists *out_minmaxavg_lists, const double *mask_in,
+                                  int *i_in, int *j_in, int *i_out, int *j_out,
                                   double *xgrid_area, double *xgrid_clon, double *xgrid_clat)
 {
 
@@ -66,10 +67,10 @@ int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const 
 
 #pragma acc data present(lon_out[0:(nx2+1)*(ny2+1)], lat_out[0:(nx2+1)*(ny2+1)])
 #pragma acc data present(lon_in[0:(nx1+1)*(ny1+1)], lat_in[0:(nx1+1)*(ny1+1)], mask_in[0:nx1*ny1])
-#pragma acc data present(out_minmaxavglists->lon_list[0:MAX_V*nx2*ny2], out_minmaxavglists->lat_list[0:MAX_V*nx2*ny2])
-#pragma acc data present(out_minmaxavglists->n_list[0:nx2*ny2], out_minmaxavglists->lon_avg[0:nx2*ny2])
-#pragma acc data present(out_minmaxavglists->lat_min_list[0:nx2*ny2], out_minmaxavglists->lat_max_list[0:nx2*ny2])
-#pragma acc data present(out_minmaxavglists->lon_min_list[0:nx2*ny2], out_minmaxavglists->lon_max_list[0:nx2*ny2])
+#pragma acc data present(out_minmaxavg_lists->lon_list[0:MAX_V*nx2*ny2], out_minmaxavg_lists->lat_list[0:MAX_V*nx2*ny2])
+#pragma acc data present(out_minmaxavg_lists->n_list[0:nx2*ny2], out_minmaxavg_lists->lon_avg[0:nx2*ny2])
+#pragma acc data present(out_minmaxavg_lists->lat_min_list[0:nx2*ny2], out_minmaxavg_lists->lat_max_list[0:nx2*ny2])
+#pragma acc data present(out_minmaxavg_lists->lon_min_list[0:nx2*ny2], out_minmaxavg_lists->lon_max_list[0:nx2*ny2])
 #pragma acc data present(xgrid_area[0:mxxgrid], xgrid_clon[0:mxxgrid], xgrid_clat[0:mxxgrid], \
                          i_in[0:mxxgrid], j_in[0:mxxgrid], i_out[0:mxxgrid],j_out[0:mxxgrid])
 #pragma acc data copyin(area_in[0:nx1*ny1], area_out[0:nx2*ny2])
@@ -102,17 +103,17 @@ int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const 
         i2 = ij%nx2;
         j2 = ij/nx2;
 
-        if(out_minmaxavglists->lat_min_list[ij] >= lat_in_max || out_minmaxavglists->lat_max_list[ij] <= lat_in_min ) continue;
+        if(out_minmaxavg_lists->lat_min_list[ij] >= lat_in_max || out_minmaxavg_lists->lat_max_list[ij] <= lat_in_min ) continue;
         /* adjust x2_in according to lon_in_avg*/
-        n2_in = out_minmaxavglists->n_list[ij];
+        n2_in = out_minmaxavg_lists->n_list[ij];
 #pragma acc loop seq
         for(l=0; l<n2_in; l++) {
-          x2_in[l] = out_minmaxavglists->lon_list[ij*MAX_V+l];
-          y2_in[l] = out_minmaxavglists->lat_list[ij*MAX_V+l];
+          x2_in[l] = out_minmaxavg_lists->lon_list[ij*MAX_V+l];
+          y2_in[l] = out_minmaxavg_lists->lat_list[ij*MAX_V+l];
         }
-        lon_out_min = out_minmaxavglists->lon_min_list[ij];
-        lon_out_max = out_minmaxavglists->lon_max_list[ij];
-        dx = out_minmaxavglists->lon_avg[ij] - lon_in_avg;
+        lon_out_min = out_minmaxavg_lists->lon_min_list[ij];
+        lon_out_max = out_minmaxavg_lists->lon_max_list[ij];
+        dx = out_minmaxavg_lists->lon_avg[ij] - lon_in_avg;
         if(dx < -M_PI ) {
           lon_out_min += TPI;
           lon_out_max += TPI;

--- a/tools/libfrencutils/create_xgrid_acc.h
+++ b/tools/libfrencutils/create_xgrid_acc.h
@@ -20,11 +20,10 @@
 #ifndef CREATE_XGRID_VER_H_
 #define CREATE_XGRID_VER_H_
 
+#include "globals.h"
+
 int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-            const double *lon_out_min_list, const double *lon_out_max_list, const double *lon_out_avg,
-            const double *lat_out_min_list, const double *lat_out_max_list, const int *n2_list,
-            const double *lon_out_list, const double *lat_out_list,
-            const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+            Minmaxavglists *out_minmaxavglists, const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
             double *xgrid_area, double *xgrid_clon, double *xgrid_clat);
 #endif

--- a/tools/libfrencutils/create_xgrid_acc.h
+++ b/tools/libfrencutils/create_xgrid_acc.h
@@ -24,6 +24,7 @@
 
 int create_xgrid_2dx2d_order2_acc(const int *nlon_in, const int *nlat_in, const int *nlon_out, const int *nlat_out,
             const double *lon_in, const double *lat_in, const double *lon_out, const double *lat_out,
-            Minmaxavglists *out_minmaxavglists, const double *mask_in, int *i_in, int *j_in, int *i_out, int *j_out,
+            Minmaxavg_lists *out_minmaxavg_lists, const double *mask_in,
+            int *i_in, int *j_in, int *i_out, int *j_out,
             double *xgrid_area, double *xgrid_clon, double *xgrid_clat);
 #endif

--- a/tools/libfrencutils/create_xgrid_util.c
+++ b/tools/libfrencutils/create_xgrid_util.c
@@ -44,7 +44,7 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   void malloc_minmaxavg_lists
   allocates lists to hold min, max, avg values of lat/lon coordinates
 *******************************************************************************/
-Minmaxavglists malloc_minmaxavg_lists(const int n, Minmaxavglists *minmaxavglists)
+void malloc_minmaxavg_lists(const int n, Minmaxavglists *minmaxavglists)
 {
 
   if(n>0){

--- a/tools/libfrencutils/create_xgrid_util.c
+++ b/tools/libfrencutils/create_xgrid_util.c
@@ -44,30 +44,28 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
   void malloc_minmaxavg_lists
   allocates lists to hold min, max, avg values of lat/lon coordinates
 *******************************************************************************/
-void malloc_minmaxavg_lists(const int n, Minmaxavglists *minmaxavglists)
+void malloc_minmaxavg_lists(const int n, Minmaxavg_lists *minmaxavg_lists)
 {
 
-  if( !minmaxavglists->lon_min_list ) free(minmaxavglists->lon_min_list);
-  if( !minmaxavglists->lon_max_list ) free(minmaxavglists->lon_max_list);
-  if( !minmaxavglists->lat_min_list ) free(minmaxavglists->lat_min_list);
-  if( !minmaxavglists->lat_max_list ) free(minmaxavglists->lat_max_list);
-  if( !minmaxavglists->n_list)   free(minmaxavglists->n_list);
-  if( !minmaxavglists->lon_avg)  free(minmaxavglists->lon_avg);
-  if( !minmaxavglists->lon_list) free(minmaxavglists->lon_list);
-  if( !minmaxavglists->lat_list) free(minmaxavglists->lat_list);
+  if( !minmaxavg_lists->lon_min_list ) free(minmaxavg_lists->lon_min_list);
+  if( !minmaxavg_lists->lon_max_list ) free(minmaxavg_lists->lon_max_list);
+  if( !minmaxavg_lists->lat_min_list ) free(minmaxavg_lists->lat_min_list);
+  if( !minmaxavg_lists->lat_max_list ) free(minmaxavg_lists->lat_max_list);
+  if( !minmaxavg_lists->n_list)   free(minmaxavg_lists->n_list);
+  if( !minmaxavg_lists->lon_avg)  free(minmaxavg_lists->lon_avg);
+  if( !minmaxavg_lists->lon_list) free(minmaxavg_lists->lon_list);
+  if( !minmaxavg_lists->lat_list) free(minmaxavg_lists->lat_list);
 
   if(n>0){
-    minmaxavglists->lon_min_list=(double *)malloc(n*sizeof(double));
-    minmaxavglists->lon_max_list=(double *)malloc(n*sizeof(double));
-    minmaxavglists->lat_min_list=(double *)malloc(n*sizeof(double));
-    minmaxavglists->lat_max_list=(double *)malloc(n*sizeof(double));
-    minmaxavglists->n_list=(int *)malloc(n*sizeof(int));
-    minmaxavglists->lon_avg=(double *)malloc(n*sizeof(double));
-    minmaxavglists->lon_list=(double *)malloc(MAX_V*n*sizeof(double));
-    minmaxavglists->lat_list=(double *)malloc(MAX_V*n*sizeof(double));
+    minmaxavg_lists->lon_min_list=(double *)malloc(n*sizeof(double));
+    minmaxavg_lists->lon_max_list=(double *)malloc(n*sizeof(double));
+    minmaxavg_lists->lat_min_list=(double *)malloc(n*sizeof(double));
+    minmaxavg_lists->lat_max_list=(double *)malloc(n*sizeof(double));
+    minmaxavg_lists->n_list=(int *)malloc(n*sizeof(int));
+    minmaxavg_lists->lon_avg=(double *)malloc(n*sizeof(double));
+    minmaxavg_lists->lon_list=(double *)malloc(MAX_V*n*sizeof(double));
+    minmaxavg_lists->lat_list=(double *)malloc(MAX_V*n*sizeof(double));
   }
-
-  return *minmaxavglists;
 
 }//malloc_minmaxavg_lists
 
@@ -76,7 +74,7 @@ void malloc_minmaxavg_lists(const int n, Minmaxavglists *minmaxavglists)
   computes lists to hold min, max, avg values of lat/lon coordinates
 *******************************************************************************/
 void get_minmaxavg_lists(const int nx, const int ny, const double *lon, const double *lat,
-                         Minmaxavglists *minmaxavglists)
+                         Minmaxavg_lists *minmaxavg_lists)
 {
 
   int nxp, nyp;
@@ -85,10 +83,10 @@ void get_minmaxavg_lists(const int nx, const int ny, const double *lon, const do
   nyp = ny+1;
 
 #pragma acc data present(lon[0:nxp*nyp], lat[0:nxp*nyp])
-#pragma acc data present(minmaxavglists->lon_list[0:MAX_V*nx*ny], minmaxavglists->lat_list[0:MAX_V*nx*ny])
-#pragma acc data present(minmaxavglists->n_list[0:nx*ny], minmaxavglists->lon_avg[0:nx*ny])
-#pragma acc data present(minmaxavglists->lat_min_list[0:nx*ny], minmaxavglists->lat_max_list[0:nx*ny])
-#pragma acc data present(minmaxavglists->lon_min_list[0:nx*ny], minmaxavglists->lon_max_list[0:nx*ny])
+#pragma acc data present(minmaxavg_lists->lon_list[0:MAX_V*nx*ny], minmaxavg_lists->lat_list[0:MAX_V*nx*ny])
+#pragma acc data present(minmaxavg_lists->n_list[0:nx*ny], minmaxavg_lists->lon_avg[0:nx*ny])
+#pragma acc data present(minmaxavg_lists->lat_min_list[0:nx*ny], minmaxavg_lists->lat_max_list[0:nx*ny])
+#pragma acc data present(minmaxavg_lists->lon_min_list[0:nx*ny], minmaxavg_lists->lon_max_list[0:nx*ny])
 
 #pragma acc parallel loop independent
   for(int ij=0; ij<nx*ny; ij++){
@@ -106,19 +104,19 @@ void get_minmaxavg_lists(const int nx, const int ny, const double *lon, const do
     x_in[2] = lon[n2]; y_in[2] = lat[n2];
     x_in[3] = lon[n3]; y_in[3] = lat[n3];
 
-    minmaxavglists->lat_min_list[n] = minval_double(4, y_in);
-    minmaxavglists->lat_max_list[n] = maxval_double(4, y_in);
+    minmaxavg_lists->lat_min_list[n] = minval_double(4, y_in);
+    minmaxavg_lists->lat_max_list[n] = maxval_double(4, y_in);
     n_in = fix_lon(x_in, y_in, 4, M_PI);
     //Commented out for now.  OpenACC does not like error_handler
     //if(n2_in > MAX_V) error_handler("create_xgrid.c: n_in is greater than MAX_V");
-    minmaxavglists->lon_min_list[n] = minval_double(n_in, x_in);
-    minmaxavglists->lon_max_list[n] = maxval_double(n_in, x_in);
-    minmaxavglists->lon_avg[n] = avgval_double(n_in, x_in);
-    minmaxavglists->n_list[n] = n_in;
+    minmaxavg_lists->lon_min_list[n] = minval_double(n_in, x_in);
+    minmaxavg_lists->lon_max_list[n] = maxval_double(n_in, x_in);
+    minmaxavg_lists->lon_avg[n] = avgval_double(n_in, x_in);
+    minmaxavg_lists->n_list[n] = n_in;
 #pragma acc loop independent
     for(l=0; l<n_in; l++) {
-      minmaxavglists->lon_list[n*MAX_V+l] = x_in[l];
-      minmaxavglists->lat_list[n*MAX_V+l] = y_in[l];
+      minmaxavg_lists->lon_list[n*MAX_V+l] = x_in[l];
+      minmaxavg_lists->lat_list[n*MAX_V+l] = y_in[l];
     }
   }
 

--- a/tools/libfrencutils/create_xgrid_util.c
+++ b/tools/libfrencutils/create_xgrid_util.c
@@ -47,14 +47,38 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
 void malloc_minmaxavg_lists(const int n, Minmaxavg_lists *minmaxavg_lists)
 {
 
-  if( !minmaxavg_lists->lon_min_list ) free(minmaxavg_lists->lon_min_list);
-  if( !minmaxavg_lists->lon_max_list ) free(minmaxavg_lists->lon_max_list);
-  if( !minmaxavg_lists->lat_min_list ) free(minmaxavg_lists->lat_min_list);
-  if( !minmaxavg_lists->lat_max_list ) free(minmaxavg_lists->lat_max_list);
-  if( !minmaxavg_lists->n_list)   free(minmaxavg_lists->n_list);
-  if( !minmaxavg_lists->lon_avg)  free(minmaxavg_lists->lon_avg);
-  if( !minmaxavg_lists->lon_list) free(minmaxavg_lists->lon_list);
-  if( !minmaxavg_lists->lat_list) free(minmaxavg_lists->lat_list);
+  if( minmaxavg_lists->lon_min_list != NULL ) {
+    free(minmaxavg_lists->lon_min_list);
+    minmaxavg_lists-> lon_min_list = NULL;
+  }
+  if( minmaxavg_lists->lon_max_list != NULL ) {
+    free(minmaxavg_lists->lon_max_list);
+    minmaxavg_lists->lon_max_list = NULL;
+  }
+  if( minmaxavg_lists->lat_min_list != NULL ) {
+    free(minmaxavg_lists->lat_min_list);
+    minmaxavg_lists->lat_min_list = NULL;
+  }
+  if( minmaxavg_lists->lat_max_list != NULL ) {
+    free(minmaxavg_lists->lat_max_list);
+    minmaxavg_lists->lat_max_list = NULL;
+  }
+  if( minmaxavg_lists->n_list != NULL ) {
+    free(minmaxavg_lists->n_list);
+    minmaxavg_lists->n_list = NULL;
+  }
+  if( minmaxavg_lists->lon_avg != NULL ) {
+    free(minmaxavg_lists->lon_avg);
+    minmaxavg_lists->lon_avg = NULL;
+  }
+  if( minmaxavg_lists->lon_list != NULL ) {
+    free(minmaxavg_lists->lon_list);
+    minmaxavg_lists->lon_list = NULL;
+  }
+  if( minmaxavg_lists->lat_list != NULL ) {
+    free(minmaxavg_lists->lat_list);
+    minmaxavg_lists->lat_list = NULL;
+  }
 
   if(n>0){
     minmaxavg_lists->lon_min_list=(double *)malloc(n*sizeof(double));

--- a/tools/libfrencutils/create_xgrid_util.c
+++ b/tools/libfrencutils/create_xgrid_util.c
@@ -47,6 +47,15 @@ int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double 
 void malloc_minmaxavg_lists(const int n, Minmaxavglists *minmaxavglists)
 {
 
+  if( !minmaxavglists->lon_min_list ) free(minmaxavglists->lon_min_list);
+  if( !minmaxavglists->lon_max_list ) free(minmaxavglists->lon_max_list);
+  if( !minmaxavglists->lat_min_list ) free(minmaxavglists->lat_min_list);
+  if( !minmaxavglists->lat_max_list ) free(minmaxavglists->lat_max_list);
+  if( !minmaxavglists->n_list)   free(minmaxavglists->n_list);
+  if( !minmaxavglists->lon_avg)  free(minmaxavglists->lon_avg);
+  if( !minmaxavglists->lon_list) free(minmaxavglists->lon_list);
+  if( !minmaxavglists->lat_list) free(minmaxavglists->lat_list);
+
   if(n>0){
     minmaxavglists->lon_min_list=(double *)malloc(n*sizeof(double));
     minmaxavglists->lon_max_list=(double *)malloc(n*sizeof(double));

--- a/tools/libfrencutils/create_xgrid_util.h
+++ b/tools/libfrencutils/create_xgrid_util.h
@@ -28,7 +28,7 @@
 #define MV 50
 /* this value is small compare to earth area */
 
-Minmaxavglists malloc_minmaxavg_lists(const int n, Minmaxavglists *minmaxavglists);
+void malloc_minmaxavg_lists(const int n, Minmaxavglists *minmaxavglists);
 void get_minmaxavg_lists(const int nx, const int ny, const double *lon, const double *lat, Minmaxavglists *minmaxavglists);
 #pragma acc routine seq
 double poly_ctrlon(const double lon[], const double lat[], int n, double clon);

--- a/tools/libfrencutils/create_xgrid_util.h
+++ b/tools/libfrencutils/create_xgrid_util.h
@@ -28,8 +28,8 @@
 #define MV 50
 /* this value is small compare to earth area */
 
-void malloc_minmaxavg_lists(const int n, Minmaxavglists *minmaxavglists);
-void get_minmaxavg_lists(const int nx, const int ny, const double *lon, const double *lat, Minmaxavglists *minmaxavglists);
+void malloc_minmaxavg_lists(const int n, Minmaxavg_lists *minmaxavg_lists);
+void get_minmaxavg_lists(const int nx, const int ny, const double *lon, const double *lat, Minmaxavg_lists *minmaxavg_lists);
 #pragma acc routine seq
 double poly_ctrlon(const double lon[], const double lat[], int n, double clon);
 #pragma acc routine seq

--- a/tools/libfrencutils/create_xgrid_util.h
+++ b/tools/libfrencutils/create_xgrid_util.h
@@ -23,15 +23,13 @@
 #define MAXXGRID 1e6
 #endif
 
+#include "globals.h"
+
 #define MV 50
 /* this value is small compare to earth area */
 
-void malloc_minmaxavg_lists(const int n,
-                            double **lon_min_list, double **lon_max_list, double **lat_min_list, double **lat_max_list,
-                            int **n_list, double **lon_avg, double **lon_list, double **lat_list);
-void get_minmaxavg_lists(const int nx, const int ny, const double *lon, const double *lat,
-                         double *lon_min_list, double *lon_max_list, double *lat_min_list, double *lat_max_list,
-                         int *n_list, double *lon_avg, double *lon_list, double *lat_list);
+Minmaxavglists malloc_minmaxavg_lists(const int n, Minmaxavglists *minmaxavglists);
+void get_minmaxavg_lists(const int nx, const int ny, const double *lon, const double *lat, Minmaxavglists *minmaxavglists);
 #pragma acc routine seq
 double poly_ctrlon(const double lon[], const double lat[], int n, double clon);
 #pragma acc routine seq


### PR DESCRIPTION
In this PR,
- structure `Minmaxavglists` has been declared to hold all "list" arrays pertaining to the output grid
- function  `get_minmaxavg_lists` has been created.  This function computes values for the "list" arrays in structure Minmaxavglists
- `OpenACC` directives to transfer data to/from the device has been added.