### PR TITLE
Create function get_interp

### DIFF
--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -189,34 +189,13 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 
             /* For the purpose of bitiwise reproducing, the following operation is needed. */
             get_CellStruct(m,nx_in, nxgrid, i_in, j_in, xgrid_area, xgrid_clon, xgrid_clat, cell_in);
-            /*g_nxgrid = nxgrid;
-            mpp_sum_int(1, &g_nxgrid);
-            if(g_nxgrid > 0) {
-              g_i_in = (int    *)malloc(g_nxgrid*sizeof(int   ));
-              g_j_in = (int    *)malloc(g_nxgrid*sizeof(int   ));
-              g_area = (double *)malloc(g_nxgrid*sizeof(double));
-              g_clon = (double *)malloc(g_nxgrid*sizeof(double));
-              g_clat = (double *)malloc(g_nxgrid*sizeof(double));
-              mpp_gather_field_int   (nxgrid, i_in,       g_i_in);
-              mpp_gather_field_int   (nxgrid, j_in,       g_j_in);
-              mpp_gather_field_double(nxgrid, xgrid_area, g_area);
-              mpp_gather_field_double(nxgrid, xgrid_clon, g_clon);
-              mpp_gather_field_double(nxgrid, xgrid_clat, g_clat);
-              for(i=0; i<g_nxgrid; i++) {
-                ii = g_j_in[i]*nx_in+g_i_in[i];
-                cell_in[m].area[ii] += g_area[i];
-                cell_in[m].clon[ii] += g_clon[i];
-                cell_in[m].clat[ii] += g_clat[i];
-              }
-              free(g_i_in); free(g_j_in); free(g_area); free(g_clon); free(g_clat);
-            } // if g_nxgrid > 0*/
-          }
+
+          } //opcode CONSERVE_ORDER2
           else
             mpp_error("conserve_interp: interp_method should be CONSERVE_ORDER1 or CONSERVE_ORDER2");
-        } //opcode CONSERVE_ORDER2
+        } // opcode GREAT_CIRCLE or CONSERVE_ORDERs
 
 
-//for all opcodes
         if(nxgrid > 0) {
           nxgrid_prev = interp[n].nxgrid;
           interp[n].nxgrid += nxgrid;

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -137,7 +137,9 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
         }
         else {
 
-          y_min = minval_double((nx_out+1)*(ny_out+1), grid_out[n].latc);
+          get_jstart_jend( nx_out, ny_out, nx_in, ny_in,
+                           grid_out[n].latc, grid_in[m].latc, &jstart, &jend, &ny_now);
+          /*y_min = minval_double((nx_out+1)*(ny_out+1), grid_out[n].latc);
           y_max = maxval_double((nx_out+1)*(ny_out+1), grid_out[n].latc);
           jstart = ny_in; jend = -1;
           for(j=0; j<=ny_in; j++) for(i=0; i<=nx_in; i++) {
@@ -152,7 +154,7 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
             }
           jstart = max(0, jstart-1);
           jend   = min(ny_in-1, jend+1);
-          ny_now = jend-jstart+1;
+          ny_now = jend-jstart+1;*/
 
           if(opcode & CONSERVE_ORDER1) {
             mxxgrid=get_maxxgrid();
@@ -204,64 +206,18 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
         } // opcode GREAT_CIRCLE or CONSERVE_ORDERs
 
 
-        if(nxgrid > 0) {
-          nxgrid_prev = interp[n].nxgrid;
-          interp[n].nxgrid += nxgrid;
-          if(nxgrid_prev == 0 ) {
-            interp[n].i_in   = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
-            interp[n].j_in   = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
-            interp[n].i_out  = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
-            interp[n].j_out  = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
-            interp[n].area   = (double *)malloc(interp[n].nxgrid*sizeof(double));
-            interp[n].t_in   = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
-            for(i=0; i<interp[n].nxgrid; i++) {
-              interp[n].t_in [i] = m;
-              interp[n].i_in [i] = i_in [i];
-              interp[n].j_in [i] = j_in [i];
-              interp[n].i_out[i] = i_out[i];
-              interp[n].j_out[i] = j_out[i];
-              interp[n].area[i]  = xgrid_area[i];
-            }
-            if(opcode & CONSERVE_ORDER2) {
-              interp[n].di_in   = (double *)malloc(interp[n].nxgrid*sizeof(double));
-              interp[n].dj_in   = (double *)malloc(interp[n].nxgrid*sizeof(double));
-              for(i=0; i<interp[n].nxgrid; i++) {
-                interp[n].di_in [i] = xgrid_clon[i]/xgrid_area[i];
-                interp[n].dj_in [i] = xgrid_clat[i]/xgrid_area[i];
-              }
-            }
-          }
-          else {
-            interp[n].i_in   = (int    *)realloc(interp[n].i_in,  interp[n].nxgrid*sizeof(int   ));
-            interp[n].j_in   = (int    *)realloc(interp[n].j_in,  interp[n].nxgrid*sizeof(int   ));
-            interp[n].i_out  = (int    *)realloc(interp[n].i_out, interp[n].nxgrid*sizeof(int   ));
-            interp[n].j_out  = (int    *)realloc(interp[n].j_out, interp[n].nxgrid*sizeof(int   ));
-            interp[n].area   = (double *)realloc(interp[n].area,  interp[n].nxgrid*sizeof(double));
-            interp[n].t_in   = (int    *)realloc(interp[n].t_in,  interp[n].nxgrid*sizeof(int   ));
-            for(i=0; i<nxgrid; i++) {
-              interp[n].t_in [nxgrid_prev+i] = m;
-              interp[n].i_in [nxgrid_prev+i] = i_in [i];
-              interp[n].j_in [nxgrid_prev+i] = j_in [i];
-              interp[n].i_out[nxgrid_prev+i] = i_out[i];
-              interp[n].j_out[nxgrid_prev+i] = j_out[i];
-              interp[n].area [nxgrid_prev+i] = xgrid_area[i];
-            }
-            if(opcode & CONSERVE_ORDER2) {
-              interp[n].di_in   = (double *)realloc(interp[n].di_in, interp[n].nxgrid*sizeof(double));
-              interp[n].dj_in   = (double *)realloc(interp[n].dj_in, interp[n].nxgrid*sizeof(double));
-              for(i=0; i<nxgrid; i++) {
-                interp[n].di_in [i+nxgrid_prev] = xgrid_clon[i]/xgrid_area[i];
-                interp[n].dj_in [i+nxgrid_prev] = xgrid_clat[i]/xgrid_area[i];
-              }
-            }
-          }
-        }  /* if(nxgrid>0) */
+        get_interp( opcode, nxgrid, interp, m, n, i_in, j_in, i_out, j_out,
+                    xgrid_clon, xgrid_clat, xgrid_area );
+
         malloc_xgrid_arrays(zero, &i_in, &j_in, &i_out, &j_out, &xgrid_area, &xgrid_clon , &xgrid_clat);
 #pragma acc exit data delete(grid_in[m].latc, grid_in[m].lonc)
+
       } // ntiles_in
+
       malloc_minmaxavg_lists(zero, &out_minmaxavg_lists);
 #pragma acc exit data delete(out_minmaxavg_lists)
 #pragma acc exit data delete(grid_out[n].latc, grid_out[n].lonc)
+
     } // ntimes_out
 
     if(DEBUG) print_time("time_nxgrid", time_nxgrid);

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -139,22 +139,6 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
 
           get_jstart_jend( nx_out, ny_out, nx_in, ny_in,
                            grid_out[n].latc, grid_in[m].latc, &jstart, &jend, &ny_now);
-          /*y_min = minval_double((nx_out+1)*(ny_out+1), grid_out[n].latc);
-          y_max = maxval_double((nx_out+1)*(ny_out+1), grid_out[n].latc);
-          jstart = ny_in; jend = -1;
-          for(j=0; j<=ny_in; j++) for(i=0; i<=nx_in; i++) {
-              yy = grid_in[m].latc[j*(nx_in+1)+i];
-              if( yy > y_min ) {
-                if(j < jstart ) jstart = j;
-              }
-              if( yy < y_max ) {
-                if(j > jend ) jend = j;
-              }
-
-            }
-          jstart = max(0, jstart-1);
-          jend   = min(ny_in-1, jend+1);
-          ny_now = jend-jstart+1;*/
 
           if(opcode & CONSERVE_ORDER1) {
             mxxgrid=get_maxxgrid();

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -63,6 +63,8 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
     read_remap_file(ntiles_in,ntiles_out, grid_out, interp, opcode);
   }
   else {
+
+    //only needed for order2?
     cell_in    = (CellStruct *)malloc(ntiles_in * sizeof(CellStruct));
     for(m=0; m<ntiles_in; m++) {
       nx_in = grid_in[m].nx;
@@ -156,8 +158,6 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
           } //opcode CONSERVE_ORDER1
 
           else if(opcode & CONSERVE_ORDER2) {
-            int g_nxgrid, *g_i_in, *g_j_in;
-            double *g_area, *g_clon, *g_clat;
 
             time_start = clock();
 

--- a/tools/fregrid/conserve_interp.c
+++ b/tools/fregrid/conserve_interp.c
@@ -54,11 +54,6 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
   double *xgrid_area=NULL, *xgrid_clon=NULL, *xgrid_clat=NULL;
   int mxxgrid, zero=0;
 
-  typedef struct{
-    double *area;
-    double *clon;
-    double *clat;
-  } CellStruct;
   CellStruct *cell_in;
 
   double time_nxgrid=0;
@@ -72,15 +67,11 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
     for(m=0; m<ntiles_in; m++) {
       nx_in = grid_in[m].nx;
       ny_in = grid_in[m].ny;
-      cell_in[m].area = (double *)malloc(nx_in*ny_in*sizeof(double));
-      cell_in[m].clon = (double *)malloc(nx_in*ny_in*sizeof(double));
-      cell_in[m].clat = (double *)malloc(nx_in*ny_in*sizeof(double));
-      for(n=0; n<nx_in*ny_in; n++) {
-        cell_in[m].area[n] = 0;
-        cell_in[m].clon[n] = 0;
-        cell_in[m].clat[n] = 0;
-      }
+      cell_in[m].area = (double *)calloc(nx_in*ny_in,sizeof(double));
+      cell_in[m].clon = (double *)calloc(nx_in*ny_in,sizeof(double));
+      cell_in[m].clat = (double *)calloc(nx_in*ny_in,sizeof(double));
     }
+
     //START NTILES_OUT
     for(n=0; n<ntiles_out; n++) {
 
@@ -197,7 +188,8 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
             for(i=0; i<nxgrid; i++) j_in[i] += jstart;
 
             /* For the purpose of bitiwise reproducing, the following operation is needed. */
-            g_nxgrid = nxgrid;
+            get_CellStruct(m,nx_in, nxgrid, i_in, j_in, xgrid_area, xgrid_clon, xgrid_clat, cell_in);
+            /*g_nxgrid = nxgrid;
             mpp_sum_int(1, &g_nxgrid);
             if(g_nxgrid > 0) {
               g_i_in = (int    *)malloc(g_nxgrid*sizeof(int   ));
@@ -217,7 +209,7 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
                 cell_in[m].clat[ii] += g_clat[i];
               }
               free(g_i_in); free(g_j_in); free(g_area); free(g_clon); free(g_clat);
-            } // if g_nxgrid > 0
+            } // if g_nxgrid > 0*/
           }
           else
             mpp_error("conserve_interp: interp_method should be CONSERVE_ORDER1 or CONSERVE_ORDER2");

--- a/tools/fregrid/conserve_interp_util.c
+++ b/tools/fregrid/conserve_interp_util.c
@@ -1,4 +1,4 @@
-/***********************************************************************
+ /***********************************************************************
  *                   GNU Lesser General Public License
  *
  * This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
@@ -26,6 +26,7 @@
 #include "mpp.h"
 #include "mpp_io.h"
 #include "read_mosaic.h"
+#include "mosaic_util.h"
 #include "conserve_interp_util.h"
 
 /*******************************************************************************
@@ -194,5 +195,99 @@ void get_CellStruct(const int tile_in, const int nx_in, const int nxgrid, int *i
     free(g_clon);
     free(g_clat);
   }
+
+}
+/*******************************************************************************
+void get_interp
+********************************************************************************/
+void get_interp( const int opcode, const int nxgrid, Interp_config *interp, const int m, const int n,
+                 const int *i_in, const int *j_in, const int *i_out, const int *j_out,
+                 const double *xgrid_clon, const double *xgrid_clat, const double *xgrid_area )
+{
+
+  int nxgrid_prev;
+  int i;
+
+  if(nxgrid > 0) {
+    nxgrid_prev = interp[n].nxgrid;
+    interp[n].nxgrid += nxgrid;
+    if(nxgrid_prev == 0 ) {
+      interp[n].i_in   = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
+      interp[n].j_in   = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
+      interp[n].i_out  = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
+      interp[n].j_out  = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
+      interp[n].area   = (double *)malloc(interp[n].nxgrid*sizeof(double));
+      interp[n].t_in   = (int    *)malloc(interp[n].nxgrid*sizeof(int   ));
+      for(i=0; i<interp[n].nxgrid; i++) {
+        interp[n].t_in [i] = m;
+        interp[n].i_in [i] = i_in [i];
+        interp[n].j_in [i] = j_in [i];
+        interp[n].i_out[i] = i_out[i];
+        interp[n].j_out[i] = j_out[i];
+        interp[n].area[i]  = xgrid_area[i];
+      }
+      if(opcode & CONSERVE_ORDER2) {
+        interp[n].di_in   = (double *)malloc(interp[n].nxgrid*sizeof(double));
+        interp[n].dj_in   = (double *)malloc(interp[n].nxgrid*sizeof(double));
+        for(i=0; i<interp[n].nxgrid; i++) {
+          interp[n].di_in [i] = xgrid_clon[i]/xgrid_area[i];
+          interp[n].dj_in [i] = xgrid_clat[i]/xgrid_area[i];
+        }
+      }
+    }
+    else {
+      interp[n].i_in   = (int    *)realloc(interp[n].i_in,  interp[n].nxgrid*sizeof(int   ));
+      interp[n].j_in   = (int    *)realloc(interp[n].j_in,  interp[n].nxgrid*sizeof(int   ));
+      interp[n].i_out  = (int    *)realloc(interp[n].i_out, interp[n].nxgrid*sizeof(int   ));
+      interp[n].j_out  = (int    *)realloc(interp[n].j_out, interp[n].nxgrid*sizeof(int   ));
+      interp[n].area   = (double *)realloc(interp[n].area,  interp[n].nxgrid*sizeof(double));
+      interp[n].t_in   = (int    *)realloc(interp[n].t_in,  interp[n].nxgrid*sizeof(int   ));
+      for(i=0; i<nxgrid; i++) {
+        interp[n].t_in [nxgrid_prev+i] = m;
+        interp[n].i_in [nxgrid_prev+i] = i_in [i];
+        interp[n].j_in [nxgrid_prev+i] = j_in [i];
+        interp[n].i_out[nxgrid_prev+i] = i_out[i];
+        interp[n].j_out[nxgrid_prev+i] = j_out[i];
+        interp[n].area [nxgrid_prev+i] = xgrid_area[i];
+      }
+      if(opcode & CONSERVE_ORDER2) {
+        interp[n].di_in   = (double *)realloc(interp[n].di_in, interp[n].nxgrid*sizeof(double));
+        interp[n].dj_in   = (double *)realloc(interp[n].dj_in, interp[n].nxgrid*sizeof(double));
+        for(i=0; i<nxgrid; i++) {
+          interp[n].di_in [i+nxgrid_prev] = xgrid_clon[i]/xgrid_area[i];
+          interp[n].dj_in [i+nxgrid_prev] = xgrid_clat[i]/xgrid_area[i];
+        }
+      }
+    }
+  }  /* if(nxgrid>0) */
+
+}
+/*******************************************************************************
+void get_jstart_jend
+********************************************************************************/
+void get_jstart_jend( const int nx_out, const int ny_out, const int nx_in, const int ny_in,
+                      const double *lat_out, const double *lat_in,
+                      int *jstart, int *jend, int *ny_now )
+{
+
+  double y_min, y_max, yy ;
+  int i, j;
+
+  y_min = minval_double((nx_out+1)*(ny_out+1), lat_out);
+  y_max = maxval_double((nx_out+1)*(ny_out+1), lat_out);
+  *jstart = ny_in; *jend = -1;
+  for(j=0; j<=ny_in; j++) for(i=0; i<=nx_in; i++) {
+      yy = lat_in[j*(nx_in+1)+i];
+      if( yy > y_min ) {
+        if(j < *jstart ) *jstart = j;
+      }
+      if( yy < y_max ) {
+        if(j > *jend ) *jend = j;
+      }
+
+    }
+  *jstart = max(0, *jstart-1);
+  *jend   = min(ny_in-1, *jend+1);
+  *ny_now = *jend-*jstart+1;
 
 }

--- a/tools/fregrid/conserve_interp_util.c
+++ b/tools/fregrid/conserve_interp_util.c
@@ -1,4 +1,4 @@
- /***********************************************************************
+/***********************************************************************
  *                   GNU Lesser General Public License
  *
  * This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).

--- a/tools/fregrid/conserve_interp_util.c
+++ b/tools/fregrid/conserve_interp_util.c
@@ -160,7 +160,7 @@ void malloc_xgrid_arrays( int nsize, int **i_in, int **j_in, int **i_out, int **
   void get_CellStruct
   Gathers exchange grid information from all ranks and
   stores information in cell_in structure.
-  Cell_in holds stores exchange grid information for each input parent cell
+  Cell_in stores exchange grid information corresponding to each input parent cell
 *******************************************************************************/
 void get_CellStruct(const int tile_in, const int nx_in, const int nxgrid, int *i_in, int *j_in,
                     double *xgrid_area, double *xgrid_clon, double *xgrid_clat,

--- a/tools/fregrid/conserve_interp_util.c
+++ b/tools/fregrid/conserve_interp_util.c
@@ -158,7 +158,9 @@ void malloc_xgrid_arrays( int nsize, int **i_in, int **j_in, int **i_out, int **
 
 /*******************************************************************************
   void get_CellStruct
-  populate CellStruct
+  Gathers exchange grid information from all ranks and
+  stores information in cell_in structure.
+  Cell_in holds stores exchange grid information for each input parent cell
 *******************************************************************************/
 void get_CellStruct(const int tile_in, const int nx_in, const int nxgrid, int *i_in, int *j_in,
                     double *xgrid_area, double *xgrid_clon, double *xgrid_clat,
@@ -198,7 +200,8 @@ void get_CellStruct(const int tile_in, const int nx_in, const int nxgrid, int *i
 
 }
 /*******************************************************************************
-void get_interp
+  void get_interp
+  stores exchange grid information to the interp structure
 ********************************************************************************/
 void get_interp( const int opcode, const int nxgrid, Interp_config *interp, const int m, const int n,
                  const int *i_in, const int *j_in, const int *i_out, const int *j_out,
@@ -263,7 +266,9 @@ void get_interp( const int opcode, const int nxgrid, Interp_config *interp, cons
 
 }
 /*******************************************************************************
-void get_jstart_jend
+  void get_jstart_jend
+  get the starting and ending indices of the input grid that
+  overlaps with the output grid
 ********************************************************************************/
 void get_jstart_jend( const int nx_out, const int ny_out, const int nx_in, const int ny_in,
                       const double *lat_out, const double *lat_in,

--- a/tools/fregrid/conserve_interp_util.h
+++ b/tools/fregrid/conserve_interp_util.h
@@ -27,8 +27,17 @@ void read_remap_file( int ntiles_in, int ntiles_out, Grid_config *grid_out,
 void malloc_xgrid_arrays( int nsize, int **i_in, int **j_in, int **i_out, int **j_out,
                           double **xgrid_area, double **xgrid_clon, double **xgrid_clat );
 
-void get_CellStruct(const tile_in, const int nx_in, const int nxgrid, int *i_in, int *j_in,
+void get_CellStruct(const int tile_in, const int nx_in, const int nxgrid, int *i_in, int *j_in,
                     double *xgrid_area, double *xgrid_clon, double *xgrid_clat,
                     CellStruct *cell_in);
+
+void get_interp( const int opcode, const int nxgrid, Interp_config *interp, const int m, const int n,
+                 const int *i_in, const int *j_in, const int *i_out, const int *j_out,
+                 const double *xgrid_clon, const double *xgrid_clat, const double *xgrid_area ) ;
+
+void get_jstart_jend( const int nx_out, const int ny_out, const int nx_in, const int ny_in,
+                      const double *lat_out, const double *lat_in,
+                      int *jstart, int *jend, int *ny_now ) ;
+
 
 #endif

--- a/tools/fregrid/conserve_interp_util.h
+++ b/tools/fregrid/conserve_interp_util.h
@@ -27,4 +27,8 @@ void read_remap_file( int ntiles_in, int ntiles_out, Grid_config *grid_out,
 void malloc_xgrid_arrays( int nsize, int **i_in, int **j_in, int **i_out, int **j_out,
                           double **xgrid_area, double **xgrid_clon, double **xgrid_clat );
 
+void get_CellStruct(const tile_in, const int nx_in, const int nxgrid, int *i_in, int *j_in,
+                    double *xgrid_area, double *xgrid_clon, double *xgrid_clat,
+                    CellStruct *cell_in);
+
 #endif

--- a/tools/fregrid/globals.h
+++ b/tools/fregrid/globals.h
@@ -237,7 +237,7 @@ typedef struct{
 } Monotone_config;
 
 
-/* Structure that stores exchange grid information
+/* Structure that stores exchange grid information */
 typedef struct{
   double *area;
   double *clon;

--- a/tools/fregrid/globals.h
+++ b/tools/fregrid/globals.h
@@ -236,6 +236,13 @@ typedef struct{
   double *f_min;
 } Monotone_config;
 
+
+typedef struct{
+  double *area;
+  double *clon;
+  double *clat;
+} CellStruct;
+
 typedef struct{
   double *lat_min_list;
   double *lat_max_list;

--- a/tools/fregrid/globals.h
+++ b/tools/fregrid/globals.h
@@ -237,11 +237,12 @@ typedef struct{
 } Monotone_config;
 
 
+/* Structure that stores exchange grid information
 typedef struct{
   double *area;
   double *clon;
   double *clat;
-} CellStruct;
+  } CellStruct;
 
 typedef struct{
   double *lat_min_list;

--- a/tools/libfrencutils/mosaic_util.c
+++ b/tools/libfrencutils/mosaic_util.c
@@ -62,7 +62,6 @@ void set_rotate_poly_true(void){
     void error_handler(char *str)
     error handler: will print out error message and then abort
 ***********************************************************/
-#pragma acc routine seq
 void error_handler(const char *msg)
 {
 
@@ -75,17 +74,17 @@ void error_handler(const char *msg)
   exit(1);
 #endif //ifdef use_libMPI
 
-#else 
+#else
 
   printf("Fatal Error: %s\n", msg);
-#ifdef use_libMPI
-  MPI_Abort(MPI_COMM_WORLD, -1);
-#else
-  //exit statements do not exist for OpenACC yet.
-#endif
+  //IMPERATIVE.  Must incorporate error handling
+  //#ifdef use_libMPI
+  //  MPI_Abort(MPI_COMM_WORLD, -1);
+  //#else
+  //  exit statements do not exist for OpenACC yet.
+  //#endif
 
 #endif //ifndef _OPENACC
-
 
 
 } /* error_handler */
@@ -219,7 +218,7 @@ double minval_double(int size, const double *data)
   double avgval_double(int size, double *data)
   get the average value of double array
 *******************************************************************************/
-#pragma acc routine seq 
+#pragma acc routine seq
 double avgval_double(int size, const double *data)
 {
   int n;

--- a/tools/libfrencutils/mosaic_util.h
+++ b/tools/libfrencutils/mosaic_util.h
@@ -45,7 +45,6 @@ struct Node{
   struct Node *Next;
 };
 
-#pragma acc routine seq
 void error_handler(const char *msg);
 int nearest_index(double value, const double *array, int ia);
 int lon_fix(double *x, double *y, int n_in, double tlon);


### PR DESCRIPTION
In this PR, the following functions have been introduced:

1. `get_nxy` which gets the number of grid points in the lat and lon arrays.
2. `get_mask` which mallocs and assigns the mask array
3. `get_start_end` which gets the lat indices of the input grid that overlaps with the output grid
4. `get_interp` which takes the arrays holding the exchange grid information and copies that information over to the interp structure.