### PR TITLE
Update autoconf package verison to 2023.01.02

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@
 AC_PREREQ([2.63])
 AC_INIT(
   [FRE NC Tools],
-  [2023.01],
+  [2023.01.02],
   [oar.gfdl.help@noaa.gov],
   [fre-nctools],
   [https://github.com/NOAA-GFDL/FRE-NCtools])

--- a/site-configs/gfdl-ws/env.sh
+++ b/site-configs/gfdl-ws/env.sh
@@ -32,11 +32,11 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # Variables to control versions used
-env_version=2023.01
-gcc_version=11.2.0
-ncc_version=4.9.0
+env_version=2023.02
+gcc_version=12.3.0
+ncc_version=4.9.2
 ncf_version=4.6.0
-mpi_version=4.0.2
+mpi_version=4.1.1
 
 # Ensure the base spack modules are first in MODULEPATH
 module remove-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64

--- a/site-configs/gfdl/env.sh
+++ b/site-configs/gfdl/env.sh
@@ -32,11 +32,11 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # Variables to control versions used
-env_version=2023.01
-gcc_version=11.2.0
-ncc_version=4.9.0
+env_version=2023.02
+gcc_version=12.3.0
+ncc_version=4.9.2
 ncf_version=4.6.0
-mpi_version=4.0.2
+mpi_version=4.1.1
 
 # Ensure the base spack modules are first in MODULEPATH
 module remove-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel7-x86_64


### PR DESCRIPTION
Also, update the GFDL site build configurations to use GFDL SW enviroment version 2023.02. These site files are referenced in the README, but the GFDL Spack deployment of fre-nctools does not use them.