### PR TITLE
Do not write time_avg_info variable attribute in fregrid

### DIFF
--- a/tools/fregrid/fregrid_util.c
+++ b/tools/fregrid/fregrid_util.c
@@ -1780,6 +1780,7 @@ void set_output_metadata (int ntiles_in, int nfiles, const File_config *file1_in
 	    char name[256], coords[512];
 	    memset(coords,0,512);
 	    mpp_get_var_attname(file_in[0].fid, scalar_in[0].var[l].vid, i, name);
+      if (strcmp(name, "time_avg_info") == 0) continue;
 	    /* check if we need to output coordinates attribute */
 	    if( !standard_dimension || !dst_is_latlon || strcmp(name, "coordinates") )
 	      mpp_copy_att_by_name(file_in[0].fid, scalar_in[0].var[l].vid, file_out[n].fid,

--- a/tools/fregrid/fregrid_util.c
+++ b/tools/fregrid/fregrid_util.c
@@ -1780,7 +1780,9 @@ void set_output_metadata (int ntiles_in, int nfiles, const File_config *file1_in
 	    char name[256], coords[512];
 	    memset(coords,0,512);
 	    mpp_get_var_attname(file_in[0].fid, scalar_in[0].var[l].vid, i, name);
+      /* Ignore the time_avg_info attribute */
       if (strcmp(name, "time_avg_info") == 0) continue;
+
 	    /* check if we need to output coordinates attribute */
 	    if( !standard_dimension || !dst_is_latlon || strcmp(name, "coordinates") )
 	      mpp_copy_att_by_name(file_in[0].fid, scalar_in[0].var[l].vid, file_out[n].fid,


### PR DESCRIPTION
After https://github.com/NOAA-GFDL/FRE-NCtools/pull/278, fregrid does not write the average_* variables, but the time_avg_info variable attribute still exists.

This causes issues with [split_ncvars.pl](http://split_ncvars.pl/) fails when trying to splitting the regridded output. It is seeing the "average_T1" in the time_avg_info attribute but fails when trying to include it in the split-out output.

With this PR, the time_avg_info attribute is not longer written. 