### PR TITLE
Change split_ncvars.pl regex to work for dimensionless variables

### DIFF
--- a/postprocessing/split_ncvars/split_ncvars.pl
+++ b/postprocessing/split_ncvars/split_ncvars.pl
@@ -172,7 +172,7 @@ foreach my $file (@ifiles) {
          $var =~ s/^\s+//; $var =~ s/\s+$//;
 
          # skip this variable if it does not exist
-         if ($dump !~ /\t\w+ $var\(.+\)/) {
+         if ($dump !~ /\t\w+ $var\s+;/) {
            print "WARNING: variable $var does not exist ... skipping.\n" if !$Opt{QUIET};
            next;
          }


### PR DESCRIPTION
The semicolon at the end of the each ncdump line can be used for the regex.

resolves #297