### PR TITLE
Change split_ncvars.pl regex to work for both dimensionless and with-dimensions

### DIFF
--- a/postprocessing/split_ncvars/split_ncvars.pl
+++ b/postprocessing/split_ncvars/split_ncvars.pl
@@ -172,7 +172,8 @@ foreach my $file (@ifiles) {
          $var =~ s/^\s+//; $var =~ s/\s+$//;
 
          # skip this variable if it does not exist
-         if ($dump !~ /\t\w+ $var\s+;/) {
+         # the second clause below is needed for dimensionless variables
+         if ($dump !~ /\t\w+ $var\(.+\)/ and $dump !~ /\t\w+ $var\s+;/) {
            print "WARNING: variable $var does not exist ... skipping.\n" if !$Opt{QUIET};
            next;
          }


### PR DESCRIPTION
resolves #297

Embarrassingly, #298 was broken and only worked with dimensionless variables but we need it work for both types.

It's hand tested for both types of variables, this time.