### PR TITLE
add m4 check for openacc flags and fix for intel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        mpi_or_acc: ['','--with-mpi', '--enable-acc']
+        with_mpi: ['','--with-mpi']
         enable_quad_precision: ['', '--enable-quad-precision']
     container:
       image: noaagfdl/fre-nctools-base:2.0.0-focal
       env:
-        MPI: ${{ matrix.mpi_or_acc }}
+        MPI: ${{ matrix.with_mpi }}
         QUAD_P: ${{ matrix.enable_quad_precision }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Configure
@@ -29,10 +29,10 @@ jobs:
     - name: Build tools
       run: make -C build
     - name: Run all tests
-      if: matrix.mpi_or_acc == ''
+      if: matrix.with_mpi == ''
       run: make -C build -j check LOG_DRIVER_FLAGS=--comments
     - name: Run most tests (skip the slow ones)
-      if: matrix.mpi_or_acc == '--with-mpi'
+      if: matrix.with_mpi == '--with-mpi'
       env:
         SKIP_TESTS: 4
       run: make -C build -j check LOG_DRIVER_FLAGS=--comments

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        with_mpi: ['','--with-mpi']
+        mpi_or_acc: ['','--with-mpi', '--enable-acc']
         enable_quad_precision: ['', '--enable-quad-precision']
     container:
       image: noaagfdl/fre-nctools-base:2.0.0-focal
       env:
-        MPI: ${{ matrix.with_mpi }}
+        MPI: ${{ matrix.mpi_or_acc }}
         QUAD_P: ${{ matrix.enable_quad_precision }}
     steps:
     - name: Checkout
@@ -29,10 +29,10 @@ jobs:
     - name: Build tools
       run: make -C build
     - name: Run all tests
-      if: matrix.with_mpi == ''
+      if: matrix.mpi_or_acc == ''
       run: make -C build -j check LOG_DRIVER_FLAGS=--comments
     - name: Run most tests (skip the slow ones)
-      if: matrix.with_mpi == '--with-mpi'
+      if: matrix.mpi_or_acc == '--with-mpi'
       env:
         SKIP_TESTS: 4
       run: make -C build -j check LOG_DRIVER_FLAGS=--comments

--- a/configure.ac
+++ b/configure.ac
@@ -85,11 +85,19 @@ AS_IF([test x"$with_mpi" = x"yes"],
 AM_CONDITIONAL([WITH_MPI], [test x"$build_mpi" = x"yes"])
 AM_CONDITIONAL([WITH_MPI_TESTS], [test x"$build_mpi" = x"yes" -a -z "$SKIP_MPI_TEST"])
 
-#Build with OpenACC suport.  Default is 'no'
+
+# --with-openacc
 AC_ARG_ENABLE([acc],
-  [AS_HELP_STRING([--enable-acc], [Build with OpenACC support.  Defaults to 'no'])] )
-AS_IF([test ${enable_acc:no} = "yes"], [enable_acc=yes], [enable_acc=no])
-AM_CONDITIONAL([ENABLE_ACC], [test $enable_acc = "yes"])
+            [AS_HELP_STRING([--enable-acc],
+                            [Builds with openacc flags for nvidias nvc compiler if available. This will result in a second executable for fregrid, fregrid_gpu. Flags added: -acc -O2 -g -tp native -gpu=ccnative -Minfo=accel -Mnoinline (default no)])])
+AS_IF([test ${enable_acc:-no} = yes],
+      [enable_acc=yes],
+      [enable_acc=no])
+# check compile flags
+AS_IF([test ${enable_acc} = yes],
+      [GX_OPENACC_FLAGS()])
+AM_CONDITIONAL([ENABLE_ACC], [test "$enable_acc" = "yes"])
+
 
 AC_CHECK_FUNCS(gettid, [], [])
 
@@ -123,7 +131,7 @@ AC_CHECK_PROGS(PROVE, [prove])
 AM_CONDITIONAL([WITH_CHECK_PROGS], [test -n "$PROVE" -a -n "$BATS"])
 
 # Check if openacc.h exists
-if test $enable_acc = yes ; then
+if test "$enable_acc" = yes ; then
    AC_CHECK_HEADERS([openacc.h], [], [AC_MSG_ERROR(["Cannot find OpenACC header file"])] )
    AC_MSG_WARN(Currently only NVIDIA compilers are supported to compile with OpenACC in FRE-NCTOOLS)
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ AM_CONDITIONAL([WITH_MPI_TESTS], [test x"$build_mpi" = x"yes" -a -z "$SKIP_MPI_T
 #Build with OpenACC suport.  Default is 'no'
 AC_ARG_ENABLE([acc],
             [AS_HELP_STRING([--enable-acc],
-                            [Builds with openacc flags for nvidias nvc compiler if available. This will result in a second executable for fregrid, fregrid_gpu.(default no)])])
+                            [Builds with OpenACC. This will result in a second executable for fregrid, fregrid_gpu.(default no)])])
 AS_IF([test ${enable_acc:-no} = yes],
       [enable_acc=yes],
       [enable_acc=no])

--- a/configure.ac
+++ b/configure.ac
@@ -85,8 +85,7 @@ AS_IF([test x"$with_mpi" = x"yes"],
 AM_CONDITIONAL([WITH_MPI], [test x"$build_mpi" = x"yes"])
 AM_CONDITIONAL([WITH_MPI_TESTS], [test x"$build_mpi" = x"yes" -a -z "$SKIP_MPI_TEST"])
 
-
-# --with-openacc
+#Build with OpenACC suport.  Default is 'no'
 AC_ARG_ENABLE([acc],
             [AS_HELP_STRING([--enable-acc],
                             [Builds with openacc flags for nvidias nvc compiler if available. This will result in a second executable for fregrid, fregrid_gpu. Flags added: -acc -O2 -g -tp native -gpu=ccnative -Minfo=accel -Mnoinline (default no)])])

--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ AM_CONDITIONAL([WITH_MPI_TESTS], [test x"$build_mpi" = x"yes" -a -z "$SKIP_MPI_T
 #Build with OpenACC suport.  Default is 'no'
 AC_ARG_ENABLE([acc],
             [AS_HELP_STRING([--enable-acc],
-                            [Builds with openacc flags for nvidias nvc compiler if available. This will result in a second executable for fregrid, fregrid_gpu. Flags added: -acc -O2 -g -tp native -gpu=ccnative -Minfo=accel -Mnoinline (default no)])])
+                            [Builds with openacc flags for nvidias nvc compiler if available. This will result in a second executable for fregrid, fregrid_gpu.(default no)])])
 AS_IF([test ${enable_acc:-no} = yes],
       [enable_acc=yes],
       [enable_acc=no])

--- a/m4/gx_openacc_flags.m4
+++ b/m4/gx_openacc_flags.m4
@@ -1,0 +1,91 @@
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   GX_OPENACC_CFLAGS()
+#
+# DESCRIPTION
+#
+#  Checks C compiler flags for openacc support.
+#
+# LICENSE
+#
+#   Copyright (c) 2024 Ryan Mulhall
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+
+# ----------------------------------------------------------------------
+#
+#  Will set OPENACC_CFLAGS to openacc flags for a given compiler if accepted.
+#
+#  First checks for general openacc support flag, then optimizations and targets.
+#
+#  Mainly for nvhpc, offloading with gcc has not been tested and is not currently supported,
+#  although the build will still work.
+#
+AC_DEFUN([GX_OPENACC_FLAGS],[
+AC_CACHE_CHECK([whether C compiler accepts OpenACC flags], [gx_cv_openacc_cflags],[
+
+AC_LANG_ASSERT(C)
+gx_cv_openacc_cflags=unknown
+gx_openacc_flags_CFLAGS_save=$CFLAGS
+
+dnl check for base openacc flag
+for ac_flag in '-acc' \
+               '-fopenacc'; do
+  AC_LINK_IFELSE([AC_LANG_SOURCE(
+          extern int acc_get_device_type();
+          int main(int argc, char** argv){
+              acc_get_device_type();
+              return 0;
+          })],
+     [gx_cv_openacc_cflags="$gx_openacc_flags_CFLAGS_save ${ac_flag}"]; break)
+done
+rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
+
+dnl check for optimization, target and any other compiler-specific flags to use for gpu offloading
+dnl TODO gcc flags for the offload, -foffload=nvptx-none could work if configured properly
+for extra_flags in '-O2 -tp native -gpu=ccnative -Minfo=accel -Mnoinline' \
+                   '-O2'; do
+  test "x$extra_flags" != xnone && CFLAGS="${ac_flag} ${extra_flags}"
+  AC_LINK_IFELSE([AC_LANG_SOURCE(
+          extern int acc_get_device_type();
+          int main(int argc, char** argv){
+              acc_get_device_type();
+              return 0;
+          })],
+     [gx_cv_openacc_cflags="$ac_flag $extra_flags"]; break)
+done
+rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
+
+CFLAGS="$gx_openacc_flags_CFLAGS_save"
+
+if test "x$gx_cv_openacc_cflags" = xunknown; then
+  m4_default([$2],
+              [AC_MSG_ERROR([no])])
+else
+  OPENACC_CFLAGS="${gx_cv_openacc_cflags}"
+  AC_MSG_RESULT([yes])
+fi
+],
+AC_SUBST([OPENACC_CFLAGS])
+)])

--- a/m4/gx_openacc_flags.m4
+++ b/m4/gx_openacc_flags.m4
@@ -37,9 +37,7 @@
 #
 #  Will set OPENACC_CFLAGS to openacc flags for a given compiler if accepted.
 #
-#  First checks for general openacc support flag, then optimizations and targets.
-#
-#  Mainly for nvhpc, offloading with gcc has not been tested and is not currently supported,
+#  Mainly for nvhpc, offloading with gcc is not currently supported,
 #  although the build will still work.
 #
 AC_DEFUN([GX_OPENACC_FLAGS],[
@@ -59,21 +57,6 @@ for ac_flag in '-acc' \
               return 0;
           })],
      [gx_cv_openacc_flags="$gx_openacc_flags_CFLAGS_save ${ac_flag}"]; break)
-done
-rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
-
-dnl check for optimization, target and any other compiler-specific flags to use for gpu offloading
-dnl TODO gcc flags for the offload, -foffload=nvptx-none could work if configured properly
-for extra_flags in '-O2 -tp native -gpu=ccnative -Minfo=accel -Mnoinline' \
-                   '-O2'; do
-  test "x$extra_flags" != xnone && CFLAGS="${ac_flag} ${extra_flags}"
-  AC_LINK_IFELSE([AC_LANG_SOURCE(
-          extern int acc_get_device_type();
-          int main(int argc, char** argv){
-              acc_get_device_type();
-              return 0;
-          })],
-     [gx_cv_openacc_flags="$ac_flag $extra_flags"]; break)
 done
 rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
 

--- a/m4/gx_openacc_flags.m4
+++ b/m4/gx_openacc_flags.m4
@@ -2,7 +2,7 @@
 #
 # SYNOPSIS
 #
-#   GX_OPENACC_CFLAGS()
+#   GX_OPENACC_FLAGS()
 #
 # DESCRIPTION
 #
@@ -43,10 +43,10 @@
 #  although the build will still work.
 #
 AC_DEFUN([GX_OPENACC_FLAGS],[
-AC_CACHE_CHECK([whether C compiler accepts OpenACC flags], [gx_cv_openacc_cflags],[
+AC_CACHE_CHECK([whether C compiler accepts OpenACC flags], [gx_cv_openacc_flags],[
 
 AC_LANG_ASSERT(C)
-gx_cv_openacc_cflags=unknown
+gx_cv_openacc_flags=unknown
 gx_openacc_flags_CFLAGS_save=$CFLAGS
 
 dnl check for base openacc flag
@@ -58,7 +58,7 @@ for ac_flag in '-acc' \
               acc_get_device_type();
               return 0;
           })],
-     [gx_cv_openacc_cflags="$gx_openacc_flags_CFLAGS_save ${ac_flag}"]; break)
+     [gx_cv_openacc_flags="$gx_openacc_flags_CFLAGS_save ${ac_flag}"]; break)
 done
 rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
 
@@ -73,17 +73,17 @@ for extra_flags in '-O2 -tp native -gpu=ccnative -Minfo=accel -Mnoinline' \
               acc_get_device_type();
               return 0;
           })],
-     [gx_cv_openacc_cflags="$ac_flag $extra_flags"]; break)
+     [gx_cv_openacc_flags="$ac_flag $extra_flags"]; break)
 done
 rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
 
 CFLAGS="$gx_openacc_flags_CFLAGS_save"
 
-if test "x$gx_cv_openacc_cflags" = xunknown; then
+if test "x$gx_cv_openacc_flags" = xunknown; then
   m4_default([$2],
               [AC_MSG_ERROR([no])])
 else
-  OPENACC_CFLAGS="${gx_cv_openacc_cflags}"
+  OPENACC_CFLAGS="${gx_cv_openacc_flags}"
   AC_MSG_RESULT([yes])
 fi
 ],

--- a/tools/fregrid_acc/Makefile.am
+++ b/tools/fregrid_acc/Makefile.am
@@ -21,7 +21,8 @@ bin_PROGRAMS = fregrid_acc
 
 AM_CFLAGS = -I$(top_srcdir)/tools/libfrencutils $(NETCDF_CFLAGS) \
             -I$(top_srcdir)/tools/libfrencutils_acc \
-            -I$(top_srcdir)/tools/fregrid -acc
+            -I$(top_srcdir)/tools/fregrid \
+            $(OPENACC_CFLAGS)
 LDADD = $(NETCDF_LDFLAGS) $(NETCDF_LIBS) $(RPATH_FLAGS)
 
 fregrid_acc_SOURCES = conserve_interp_acc.c \

--- a/tools/libfrencutils_acc/Makefile.am
+++ b/tools/libfrencutils_acc/Makefile.am
@@ -19,7 +19,7 @@
 #***********************************************************************
 noinst_LIBRARIES = libfrencutils_acc.a
 
-AM_CFLAGS = $(NETCDF_CFLAGS) -I$(top_srcdir)/tools/libfrencutils -acc
+AM_CFLAGS = $(NETCDF_CFLAGS) $(OPENACC_CFLAGS) -I$(top_srcdir)/tools/libfrencutils
 
 libfrencutils_acc_a_SOURCES = create_xgrid_acc.c \
                               create_xgrid_acc.h

--- a/tools/mppncscatter/mppncscatter.c
+++ b/tools/mppncscatter/mppncscatter.c
@@ -44,6 +44,8 @@
 
 #define CHECK_NC_ERRSTAT(ierr) check_error(ierr,__FILE__,__LINE__)
 
+void check_error(int ierr, const char* file, int line);
+
 /*-------------------------------------------------------------------*/
 void printsizetarray(size_t *a, int n) {
   int i=0;


### PR DESCRIPTION
adds an m4 for checking valid openacc flags with compilers that support it (currently only nvc and gcc).

Also adds a header that was needed for mppncscatter to compile with intel due to the sync updates (forgot function order matters for C, gcc doesn't seem to care though) .