### PR TITLE
Update CI image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         with_mpi: ['','--with-mpi']
         enable_quad_precision: ['', '--enable-quad-precision']
     container:
-      image: ghcr.io/rem1776/fre-nctools-ci-rocky-gnu:14.1.0
+      image: ghcr.io/noaa-gfdl/fre-nctools-ci-rocky-gnu:14.1.0
       env:
         MPI: ${{ matrix.with_mpi }}
         QUAD_P: ${{ matrix.enable_quad_precision }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,6 @@ jobs:
       env:
         MPI: ${{ matrix.with_mpi }}
         QUAD_P: ${{ matrix.enable_quad_precision }}
-        FC: /opt/views/view/bin/mpifort
-        CC: /opt/views/view/bin/mpicc
-        CFLAGS: "-I/usr/include -I/usr/include/hdf5/serial"
-        FCFLAGS: "-I/usr/include"
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ jobs:
       env:
         MPI: ${{ matrix.with_mpi }}
         QUAD_P: ${{ matrix.enable_quad_precision }}
-        FC: mpifort
-        CC: mpicc
+        FC: /opt/views/view/bin/mpifort
+        CC: /opt/views/view/bin/mpicc
         CFLAGS: "-I/usr/include -I/usr/include/hdf5/serial"
         FCFLAGS: "-I/usr/include"
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,10 @@ jobs:
       env:
         MPI: ${{ matrix.with_mpi }}
         QUAD_P: ${{ matrix.enable_quad_precision }}
+        FC: mpifort
+        CC: mpicc
+        CFLAGS: "-I/usr/include -I/usr/include/hdf5/serial"
+        FCFLAGS: "-I/usr/include"
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         mkdir build && cd build
         autoreconf -i ../configure.ac
-        ../configure $MPI $QUAD_P
+        ../configure $MPI $QUAD_P || cat config.log
     - name: Build tools
       run: make -C build
     - name: Run all tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         with_mpi: ['','--with-mpi']
         enable_quad_precision: ['', '--enable-quad-precision']
     container:
-      image: ghcr.io/noaa-gfdl/fre-nctools-ci-rocky-gnu:14.1.0
+      image: ghcr.io/noaa-gfdl/fre-nctools-ci-rocky-gnu:14.2.0
       env:
         MPI: ${{ matrix.with_mpi }}
         QUAD_P: ${{ matrix.enable_quad_precision }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         with_mpi: ['','--with-mpi']
         enable_quad_precision: ['', '--enable-quad-precision']
     container:
-      image: noaagfdl/fre-nctools-base:2.0.0-focal
+      image: ghcr.io/rem1776/fre-nctools-ci-rocky-gnu:14.1.0
       env:
         MPI: ${{ matrix.with_mpi }}
         QUAD_P: ${{ matrix.enable_quad_precision }}


### PR DESCRIPTION
updates the ci image to a rocky 9 image with spack installed dependencies. The dockerfile is [here.](https://github.com/NOAA-GFDL/HPC-ME/pull/8)