### PR TITLE
fregrid_acc - convert 2d lon/lat_vertices arrays to 1d arrays 

### DIFF
--- a/tools/libfrencutils_acc/create_xgrid_acc.c
+++ b/tools/libfrencutils_acc/create_xgrid_acc.c
@@ -230,8 +230,8 @@ int create_xgrid_2dx2d_order1_acc(const int nlon_input_cells,  const int nlat_in
         output_cell_lon_min += rotate;
         output_cell_lon_max += rotate;
         for (int l=0; l<nvertices2; l++) {
-          output_cell_lon_vertices[l] = output_grid_cells->lon_vertices[ij2][l] + rotate;
-          output_cell_lat_vertices[l] = output_grid_cells->lat_vertices[ij2][l];
+          output_cell_lon_vertices[l] = output_grid_cells->lon_vertices[ij2*MAX_V+l] + rotate;
+          output_cell_lat_vertices[l] = output_grid_cells->lat_vertices[ij2*MAX_V+l];
         }
 
         //output_cell_lon should in the same range as input_cell_lon after lon_fix,
@@ -391,8 +391,8 @@ int create_xgrid_2dx2d_order2_acc(const int nlon_input_cells,  const int nlat_in
         output_cell_area = output_grid_cells->area[ij2];
 
         for (int l=0; l<nvertices2; l++) {
-          output_cell_lon_vertices[l] = output_grid_cells->lon_vertices[ij2][l] + rotate;
-          output_cell_lat_vertices[l] = output_grid_cells->lat_vertices[ij2][l];
+          output_cell_lon_vertices[l] = output_grid_cells->lon_vertices[ij2*MAX_V+l] + rotate;
+          output_cell_lat_vertices[l] = output_grid_cells->lat_vertices[ij2*MAX_V+l];
         }
 
         //output_cell_lon should in the same range as input_cell_lon after lon_fix,

--- a/tools/libfrencutils_acc/globals_acc.h
+++ b/tools/libfrencutils_acc/globals_acc.h
@@ -57,8 +57,8 @@ typedef struct {
   double *lon_cent;
   double *area;
   int *nvertices;
-  double **lon_vertices;
-  double **lat_vertices;
+  double *lon_vertices;
+  double *lat_vertices;
   double *recomputed_area;
   double *centroid_lon;
   double *centroid_lat;


### PR DESCRIPTION
In this PR, 

`lon_vertices` and `lat_vertices` members in the `Grid_cell_struct_config` struct have been changed from double pointers to single pointers and are now malloc-ed to be 1d arrays.  This change has been made after testing showed that computation with 1d arrays is faster than with 2d arrays on GPUs.