### PR TITLE
update deprecated `upload-artifact` action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         SKIP_TESTS: 4
       run: make -C build -j check LOG_DRIVER_FLAGS=--comments
     - name: Save log file on failure
-      uses: actions/upload-artifact@v2.2.1
+      uses: actions/upload-artifact@v4.4.0
       if: failure()
       with:
         name: test-suite.log


### PR DESCRIPTION
Github just deprecated the version of the action that uploads the build log, so this just bumps its up to the most recent version.