### PR TITLE
Use full path for several applications

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,16 +194,50 @@ AS_IF([test x$ac_compiler_gnu = xyes], [RPATH_FLAGS=""
   done])
 AC_SUBST(RPATH_FLAGS) dnl
 
+# Check for additional programs
+AC_PATH_PROGS([NCDUMP], [ncdump], [], [$_ax_c_lib_netcdf_bin$PATH_SEPARATOR$PATH])
+AS_IF([test -z $NCDUMP],dnl
+  AC_MSG_ERROR([Unable to find ncdump.  Add to PATH or set the NCDUMP variable to the full path]))
+AC_ARG_VAR([NCDUMP], [Full path to ncdump])
+
+AC_PATH_PROGS([NCRCAT], [ncrcat], [])
+AS_IF([test -z $NCRCAT], dnl
+  AC_MSG_ERROR([Unable to find ncrcat.  Add to PATH or set the NCRCAT variable to the full path]))
+AC_ARG_VAR([NCRCAT], [Full path to ncrcat])
+
+AC_PATH_PROGS([NCKS], [ncks], [])
+AS_IF([test -z $NCKS], dnl
+  AC_MSG_ERROR([Unable to find ncks.  Add to PATH or set the NCKS variable to the full path]))
+AC_ARG_VAR([NCKS], [Full path to ncks])
+
+AC_PATH_PROGS([NCWA], [ncwa], [])
+AS_IF([test -z $NCWA], dnl
+  AC_MSG_ERROR([Unable to find ncwa.  Add to PATH or set the NCWA variable to the full path]))
+AC_ARG_VAR([NCWA], [Full path to ncwa])
+
+AC_PATH_PROGS([NCATTED], [ncatted], [])
+AS_IF([test -z $NCATTED], dnl
+  AC_MSG_ERROR([Unable to find ncatted.  Add to PATH or set the NCATTED variable to the full path]))
+AC_ARG_VAR([NCATTED], [Full path to ncatted])
+
+AC_PATH_PROGS([NCRENAME], [ncrename], [])
+AS_IF([test -z $NCRENAME], dnl
+  AC_MSG_ERROR([Unable to find ncrename.  Add to PATH or set the NCRENAME variable to the full path]))
+AC_ARG_VAR([NCRENAME], [Full path to ncrename])
+
 # Output files
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile
                  postprocessing/combine_restarts/Makefile
                  postprocessing/iceberg_comb/Makefile
+                 postprocessing/iceberg_comb/iceberg_comb.sh
                  postprocessing/land_utils/Makefile
                  postprocessing/list_ncvars/Makefile
                  postprocessing/mppnccombine/Makefile
                  postprocessing/plevel/Makefile
                  postprocessing/split_ncvars/Makefile
+                 postprocessing/split_ncvars/varlist.csh
+                 postprocessing/split_ncvars/split_ncvars.pl
                  postprocessing/timavg/Makefile
                  tools/libfrencutils/Makefile
                  tools/libfrencutils_acc/Makefile

--- a/m4/ax_lib_netcdf.m4
+++ b/m4/ax_lib_netcdf.m4
@@ -98,7 +98,7 @@ AS_IF([test $with_netcdf != no],
 AC_DEFUN([_AX_C_LIB_NETCDF], [
 # Was a path to NetCDF given?
 AS_IF([test $with_netcdf != yes], [_ax_c_lib_netcdf_prefix=$with_netcdf])
-test -z ${_ax_c_lib_netcdf_prefix+x} && _ax_c_lib_netcdf_bin=$_ax_c_lib_netcdf_prefix/bin
+test ! -z ${_ax_c_lib_netcdf_prefix+x} && _ax_c_lib_netcdf_bin=$_ax_c_lib_netcdf_prefix/bin
 # Check to see if NC_CONFIG is in the path, or NETCDF_PREFIX/bin.
 AC_PATH_PROGS([NC_CONFIG], [nc-config], [], [$_ax_c_lib_netcdf_bin$PATH_SEPARATOR$PATH])
 # If nc-config found, use it to get information on the NetCDF library
@@ -246,7 +246,7 @@ AS_IF([test $with_netcdf != no],
 AC_DEFUN([_AX_FC_LIB_NETCDF],[
 # Was a path to NetCDF given?
 AS_IF([test $with_netcdf != yes], [_ax_fc_lib_netcdf_prefix=$with_netcdf])
-test -z ${_ax_fc_lib_netcdf_prefix+x} && _ax_fc_lib_netcdf_bin=$_ax_fc_lib_netcdf_prefix/bin
+test ! -z ${_ax_fc_lib_netcdf_prefix+x} && _ax_fc_lib_netcdf_bin=$_ax_fc_lib_netcdf_prefix/bin
 # Check to see if NF_CONFIG is in the path, or NETCDF_PREFIX/bin.
 AC_PATH_PROGS([NF_CONFIG], [nf-config], [], [$_ax_fc_lib_netcdf_bin$PATH_SEPARATOR$PATH])
 # If nf-config found, use it to get information on the NetCDF library

--- a/postprocessing/iceberg_comb/iceberg_comb.sh.in
+++ b/postprocessing/iceberg_comb/iceberg_comb.sh.in
@@ -58,30 +58,20 @@ if [ $# -lt 2 ]; then
     exit 1
 fi
 
-# Verify the ncdump executable is in PATH and is executable
-ncdumpPath=$( which ncdump 2>&1 )
-if [ $? -ne 0 ]; then
-    echo "ERROR: Required command 'ncdump' is not in PATH."
+# Verify the ncdump is executable
+ncdumpPath=@NCDUMP@
+if [ ! -x $ncdumpPath ]; then
+    echoerr "ERROR: Required command 'ncdump' is not executable ($ncdumpPath)."
     exit 1
-else
-    if [ ! -x $ncdumpPath ]; then
-        echoerr "ERROR: Required command 'ncdump' is not executable ($ncdumpPath)."
-        exit 1
-    fi
 fi
 
-# Verify the ncrcat executable is in PATH and is executable (`ncrcat --version` exit status of 0)
-which ncrcat > /dev/null 2>&1
+# Verify the ncrcat  is executable (`ncrcat --version` exit status of 0)
+ncrcatPath=@NCRCAT@
+# Check that ncrcat is executable
+$ncrcatPath --version > /dev/null 2>&1
 if [ $? -ne 0 ]; then
-    echoerr "ERROR: NCO command 'ncrcat' is not in PATH."
+    echoerr "ERROR: NCO command 'ncrcat' is not executable."
     exit 1
-else
-    # Check that ncrcat is executable
-    ncrcat --version > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
-        echoerr "ERROR: NCO command 'ncrcat' is not executable."
-        exit 1
-    fi
 fi
 
 # All of the input files (<iceberg_res_file> [<iceberg_res_file> ...] need to exist.
@@ -108,7 +98,7 @@ while [ $# -gt 0 ]; do
             echoerr "ERROR: in file '$curFile' does not exist."
             exit 1
         else
-            ncdumpOut=$( ncdump -h $curFile 2>&1 )
+            ncdumpOut=$( $ncdumpPath -h $curFile 2>&1 )
             status=$?
             if [ $status -ne 0 ]; then
                 echoerr "WARNING: skipping in file '$curFile' as it is NOT a NetCDF formatted file."
@@ -129,7 +119,7 @@ done
 if [ "X$icebergFiles" = "X" ]; then
     echoerr "No files to record concatenate."
 else
-    ncrcat_cmd="ncrcat $icebergFiles $outFile"
+    ncrcat_cmd="$ncrcatPath $icebergFiles $outFile"
     if [ $verbose -gt 0 ]; then
         echo $ncrcat_cmd
     fi

--- a/postprocessing/split_ncvars/split_ncvars.pl
+++ b/postprocessing/split_ncvars/split_ncvars.pl
@@ -49,7 +49,7 @@ my $status = GetOptions ('h|help!'     => \$Opt{HELP},
                          'l|log!'      => \$Opt{LOG},
                          's|static!'   => \$Opt{STATIC},
                          'c|cmip!'     => \$Opt{CMIP},
-			 'p|ps'        => \$Opt{PS},
+                         'p|ps'        => \$Opt{PS},
                          'a|auto!'     => \$Opt{AUTO},
                          'f|onefile=s' => \$Opt{onefile},
                          'i|idir=s'    => \$Opt{idir},
@@ -62,15 +62,16 @@ my $first = 1;
 my $odir = $Opt{odir};
 
 ##################################################################
-# external scripts 
+# external scripts
 
 my $ncrcat = `which ncrcat 2>&1`;
 die "Unable to locate ncrcat, cannot continue.\n" if $ncrcat =~ /(: no)|(not found)/;
-chomp $ncrcat; $ncrcat .= " -t 2 --header_pad 65536";
+chomp $ncrcat;
+$ncrcat .= " -t 2 --header_pad 65536";
 
-my $ncks = `which ncks 2>&1`; 
+my $ncks = `which ncks 2>&1`;
 die "Unable to locate ncks, cannot continue.\n" if $ncks =~ /(: no)|(not found)/;
-chomp $ncks; 
+chomp $ncks;
 $ncks .= ' --header_pad 65536';
 
 my $list_ncvars = `which list_ncvars.csh 2>&1`;
@@ -109,343 +110,339 @@ print "split_ncvars.pl version $VERSION\n" if $Opt{VERBOSE};
 my %ps_includes;
 my $file_copied = 0;
 foreach my $file (@ifiles) {
-    print STDERR "Cowardly refusing to process files without a .nc filename" and next
-	unless $file =~ /\.nc/;
-    my ($ext) = (basename $file) =~ /\.nc(.*)/;
-    my ($tile) = (basename $file) =~ /(\.tile\d)/;
-    if ($Opt{idir} ) {
-	if ($dmget_available
-	    and File::Spec->rel2abs($Opt{idir}) =~ m@^/arch@) {
-	    print  "dmget ".$Opt{idir}."/$file\n" if $Opt{VERBOSE} > 2;
-	    system("dmget ".$Opt{idir}."/$file");
+  print STDERR "Cowardly refusing to process files without a .nc filename" and next
+      unless $file =~ /\.nc/;
+  my ($ext) = (basename $file) =~ /\.nc(.*)/;
+  my ($tile) = (basename $file) =~ /(\.tile\d)/;
+  if ($Opt{idir} ) {
+    if ($dmget_available
+      and File::Spec->rel2abs($Opt{idir}) =~ m@^/arch@) {
+      print  "dmget ".$Opt{idir}."/$file\n" if $Opt{VERBOSE} > 2;
+      system("dmget ".$Opt{idir}."/$file");
 
-	    if ( $Opt{idir} ne '.' ) {
-		print  "gcp ".$Opt{idir}."/$file $file\n" if $Opt{VERBOSE} > 2;
-		system("gcp ".$Opt{idir}."/$file $file");
-		$file_copied++;
-	    }
-	}
-	$file = "$Opt{idir}/$file";
+      if ( $Opt{idir} ne '.' ) {
+        print  "gcp ".$Opt{idir}."/$file $file\n" if $Opt{VERBOSE} > 2;
+        system("gcp ".$Opt{idir}."/$file $file");
+        $file_copied++;
+      }
+    }
+    $file = "$Opt{idir}/$file";
+  }
+
+  print STDERR "Unable to read $file, skipping\n" and next unless -r $file;
+  my $dump = qx{$ncdump -h $file};
+
+  # generate variable list (if not user supplied)
+  if (!@varlist) {
+    if (!$Opt{STATIC}) {
+      print tailname($list_ncvars)." -t01234 $file\n" if $Opt{VERBOSE} > 1;
+      @varlist = split /\n/, `$list_ncvars -t01234 $file`;
+    } else {
+      print tailname($list_ncvars)." -s0123 $file\n" if $Opt{VERBOSE} > 1;
+      @varlist = split /\n/, `$list_ncvars -s0123 $file`;
+    }
+  }
+
+  # get time axis name
+  my $timename = get_time_dimension($dump) if !$Opt{STATIC};
+
+  #Balaji: add all variables that appear in a coordinate attribute
+  #    set coords = ( `ncdump -h $file |grep :coordinates |cut -f2 -d\" |sed "s/ /\n/g" |sort -u` \
+  #                   `ncdump -h $file |grep "float geol[oa][nt]" | awk '{print $2}' |cut -f1 -d\(` )
+  #    set coords = `echo $coords |sed "s/ /\n/g" |sort -u`
+  #     exec echo coords = $coords
+  my @coords;
+  foreach my $coord (qw/geolat geolon GEOLAT GEOLON/) {
+    push @coords, $coord if ($dump =~ /\t\w+ $coord\(.+\)/);
+  }
+
+  #-------------------------------------
+  #-----  loop through variables  ------
+  #-------------------------------------
+
+  print "processing ".scalar(@varlist)." variables\n\n" if $Opt{VERBOSE} > 2;
+
+  my @vlist = @coords;
+  my @xlist = ();
+
+  foreach my $var (@varlist) {
+    $var =~ s/^\s+//; $var =~ s/\s+$//;
+
+    # skip this variable if it does not exist
+    # the second clause below is needed for dimensionless variables
+    if ($dump !~ /\t\w+ $var\(.+\)/ and $dump !~ /\t\w+ $var\s+;/) {
+      print "WARNING: variable $var does not exist ... skipping.\n" if !$Opt{QUIET};
+      next;
+    }
+    print "Processing variable: $var\n" if $Opt{VERBOSE} > 1;
+    print "Size of vlist = ".scalar(@vlist)."  (INITIAL)\n" if $Opt{VERBOSE} > 3;
+
+    # add variable to list of variables to extract
+    push @vlist, $var;
+
+    # Add the cell_measures to the list of variables to include in the external_variables global attribute
+    my @cell_measures_variables = get_cell_measures($dump,$var);
+    if (@cell_measures_variables) {
+      push @xlist, @cell_measures_variables;
+      print "   $var: external_variables = ".join(", ",@cell_measures_variables)."\n" if $Opt{VERBOSE} > 1;
     }
 
-    print STDERR "Unable to read $file, skipping\n" and next unless -r $file;
-    my $dump = qx{$ncdump -h $file};
+    # automatically detect if this a a cmip variable - if attrib standard_name exists
+    my $CMIP = $Opt{CMIP};
+    if ($Opt{AUTO} && !$Opt{CMIP}) {
+      $CMIP = 1 if (get_variable_att($dump,$var,"standard_name"));
+    }
 
-    # generate variable list (if not user supplied)
-    if (!@varlist) {
-        if (!$Opt{STATIC}) {
-	    print tailname($list_ncvars)." -t01234 $file\n" if $Opt{VERBOSE} > 1;
-	    @varlist = split /\n/, `$list_ncvars -t01234 $file`;
-        } else {
-	    print tailname($list_ncvars)." -s0123 $file\n" if $Opt{VERBOSE} > 1;
-	    @varlist = split /\n/, `$list_ncvars -s0123 $file`;
+    # get the number of dimensions if ps is provided on the commandline
+    if ( $Opt{PS} ){
+      my $dimensions = get_variable_dimensions($dump,$var);
+      if ( grep ( /(pfull|phalf)/, @{$dimensions} ) and scalar @{$dimensions} >= 4 ) {
+        print "Setting ps_incluides for $var\n" if $Opt{VERBOSE} > 1;
+        $ps_includes{$var} = 1;
+      } else {
+        print "Not setting ps_includes of $var\n" if $Opt{VERBOSE} > 1;
+        $ps_includes{$var} = 0;
+      }
+    }
+
+    my $output = "$odir/$var$tile.nc";
+    my $output_barefile = "$var$tile.nc";
+    #------------------------------------------------------------
+    # FIRST TIME ONLY (when output file does not exist)
+    # need to extract additional static fields
+    # 1) dimension bounds, 2) coordinate variables, 3) formula terms
+    #------------------------------------------------------------
+    if (!-e $output) {
+      # get variable names of all dimension bounds/edges (except for time)
+      my @bounds = get_variable_bounds   ($dump,$var,$CMIP);
+      if (@bounds) {
+        print "   $var: bounds = ".join(", ",@bounds)."\n" if $Opt{VERBOSE} > 1;
+        push @vlist, @bounds;
+      }
+
+      # get variables specified by the coordinates attribute
+      my @coordinates = get_variables_from_att($dump,$var,"coordinates");
+      if (@coordinates) {
+        print "   $var: coordinates = ".join(", ",@bounds)."\n" if $Opt{VERBOSE} > 1;
+        push @vlist, @coordinates;
+        # add bounds for coordinate variables
+        foreach my $coord (@coordinates) {
+          push @vlist, get_dimension_bounds ($dump,$coord);
         }
+      }
+
+      # formula terms
+      # only add static terms to the vlist
+      # time-varying terms are "external_variables"
+      my ($vterms,$xterms) = get_formula_terms($dump,$var);
+      if (@$vterms) {
+        print "   $var: formula_terms(static) = ".join(", ",@$vterms)."\n" if $Opt{VERBOSE} > 1;
+        push @vlist, @$vterms;
+      }
+      if (@$xterms) {
+        print "   $var: external_variables = ".join(", ",@$xterms)."\n" if $Opt{VERBOSE} > 1;
+        push @xlist, @$xterms;
+      }
+    }
+    if ( $ps_includes{$var} ){
+      print "Appending ps,pk,bk to variables to include.\n" if $Opt{VERBOSE} > 1;
+      push @vlist, qw{ps pk bk};
+    }
+    #-------------------------------------------------
+    # EVERY TIME (when there is a time dimension)
+    # need to extract time bounds/average_XX variables
+    #-------------------------------------------------
+    if ($timename) {
+      # fms-style time avg variables
+      if (!$CMIP) {
+        my @time_avg_info = get_time_avg_info($dump,$var);
+        if (@time_avg_info) {
+          print "   $var: time_avg_info = ".join(", ",@time_avg_info)."\n" if $Opt{VERBOSE} > 1;
+          push @vlist, @time_avg_info;
+        }
+      }
+
+      # CF compliant time avg variables (bounds or climatology)
+      my $SKIPVAR = 0;
+      foreach my $bounds_type ( qw/bounds climatology/ ) {
+        my $bounds_name = get_variable_att($dump,$timename,$bounds_type);
+        if ($bounds_name) {
+          if ($bounds_name eq $var) {
+            # skip this variable because it is a time bounds variable
+            print "   $var: SKIPPING because it is a time bounds variable\n" if $Opt{VERBOSE} > 1;
+            $SKIPVAR = 1;
+            last;
+          }
+          print "   $var: $timename: $bounds_type = $bounds_name\n" if $Opt{VERBOSE} > 1;
+          push @vlist, $bounds_name;
+        }
+      }
+
+      # skip this variable, reset the variable list
+      if ($SKIPVAR) {
+        @vlist = @coords;
+        @xlist = ();
+        next;
+      }
     }
 
-    # get time axis name
-    my $timename = get_time_dimension($dump) if !$Opt{STATIC};
+    # if a single file is desired then do not extract into single-field files
+    next if $Opt{onefile};
 
-    #Balaji: add all variables that appear in a coordinate attribute
-    #    set coords = ( `ncdump -h $file |grep :coordinates |cut -f2 -d\" |sed "s/ /\n/g" |sort -u` \
-    #                   `ncdump -h $file |grep "float geol[oa][nt]" | awk '{print $2}' |cut -f1 -d\(` )
-    #    set coords = `echo $coords |sed "s/ /\n/g" |sort -u`
-    #     exec echo coords = $coords
-    my @coords;
-    foreach my $coord (qw/geolat geolon GEOLAT GEOLON/) {
-	push @coords, $coord if ($dump =~ /\t\w+ $coord\(.+\)/);
+    #-----------------------
+    #--- extract fields ----
+    #-----------------------
+    print "Size of vlist = ".scalar(@vlist)."  (NCKS)\n" if $Opt{VERBOSE} > 3;
+    my $vlist = join ",",@vlist;
+    print "   var=$var; timename=$timename; vlist=$vlist\n" if $Opt{VERBOSE} > 2;
+    my $appendopt = "";
+    $appendopt = "-A" if (-f "$cwd/$tmp_var_filename");
+    print   "$ncks -h $appendopt -v $vlist $file $tmp_var_filename\n" if $Opt{VERBOSE};
+    next if $TEST;
+    system ("$ncks -h $appendopt -v $vlist $file $tmp_var_filename");
+    $ncstatus += $?;
+
+    # remove dimensions called "scalar_axis" (i.e., length = 1)
+    # these are typically in the near-surface field files
+    my @commands = remove_degenerate_dimension("$tmp_var_filename","scalar_axis");
+    foreach my $cmd (@commands) {
+      print "$cmd\n" if $Opt{VERBOSE} > 0;
+      system($cmd);
     }
-#-------------------------------------
-#-----  loop through variables  ------
-#-------------------------------------
 
-     print "processing ".scalar(@varlist)." variables\n\n" if $Opt{VERBOSE} > 2;
+    #--- write to the output file ---
+    if (-e $output) {
+      die "ERROR: try to append to unlimited dimension when no unlimited dimension found" if !$timename;
 
-     my @vlist = @coords;
-     my @xlist = ();
+      #--- append to existing file ---
+      #push @commands, "dmget ".$Opt{odir}."/$var.nc";
+      print  "mv $output $odir/.split_ncvars.$$.tmp.nc\n" if $Opt{VERBOSE} > 2;
+      system("mv $output $odir/.split_ncvars.$$.tmp.nc");
+      print "ncrcat $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename $output\n" if $Opt{VERBOSE} > 0;
+      system ("$ncrcat -h $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename $output");
+      $ncstatus += $?;
+      print  "rm -f $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename\n" if $Opt{VERBOSE} > 2;
+      system("rm -f $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename");
+    } else {
+      #--- create new file ---
+      #--- modify filename attribute ---
+      #--- move to output directory ---
 
-     foreach my $var (@varlist) {
-         $var =~ s/^\s+//; $var =~ s/\s+$//;
+      my @ncatted_opts = set_ncatted_opts("$tmp_var_filename","$output_barefile",$var,$CMIP);
+      # external_variables attribute (cell_measures & time-varying formula terms)
+      if (@xlist) {
+        push @ncatted_opts, "-a external_variables,global,c,c,\"".join(" ",@xlist)."\"";
+      }
 
-         # skip this variable if it does not exist
-         # the second clause below is needed for dimensionless variables
-         if ($dump !~ /\t\w+ $var\(.+\)/ and $dump !~ /\t\w+ $var\s+;/) {
-           print "WARNING: variable $var does not exist ... skipping.\n" if !$Opt{QUIET};
-           next;
-         }
-         print "Processing variable: $var\n" if $Opt{VERBOSE} > 1;
-         print "Size of vlist = ".scalar(@vlist)."  (INITIAL)\n" if $Opt{VERBOSE} > 3;
+      # rename coordinate variables
+      if (!$Opt{onefile}) {
+        my $vdump = `ncdump -h $tmp_var_filename`;
+        my @coordinates = get_variables_from_att($vdump,$var,"coordinates");
 
-         # add variable to list of variables to extract
-         push @vlist, $var;
+        # rename "height#" (coordinate) variables to just "height"
+        my @height = grep{/height\d+/} @coordinates;
+        if (@height == 1) {
+          print  "ncrename -h -v $height[0],height $tmp_var_filename\n";
+          system("ncrename -h -v $height[0],height $tmp_var_filename");
+          for (@coordinates) {
+            s/$height[0]/height/;
+          }
+          push @ncatted_opts, "-a coordinates,$var,m,c,\"@coordinates\"";
+        } elsif (@height > 1) {
+          die "ERROR: can not have more than one height coordinate attribute/variable";
+        }
 
-         # Add the cell_measures to the list of variables to include in the external_variables global attribute
-         my @cell_measures_variables = get_cell_measures($dump,$var);
-         if (@cell_measures_variables) {
-            push @xlist, @cell_measures_variables;
-            print "   $var: external_variables = ".join(", ",@cell_measures_variables)."\n" if $Opt{VERBOSE} > 1;
-         }
-
-         # automatically detect if this a a cmip variable - if attrib standard_name exists
-         my $CMIP = $Opt{CMIP};
-         if ($Opt{AUTO} && !$Opt{CMIP}) {
-           $CMIP = 1 if (get_variable_att($dump,$var,"standard_name"));
-         }
-
-	 # get the number of dimensions if ps is provided on the commandline
-	 if ( $Opt{PS} ){
-	     my $dimensions = get_variable_dimensions($dump,$var);
-	     if ( grep ( /(pfull|phalf)/, @{$dimensions} ) and scalar @{$dimensions} >= 4 ) {
-		 print "Setting ps_incluides for $var\n" if $Opt{VERBOSE} > 1;
-		 $ps_includes{$var} = 1;
-	     } else {
-		 print "Not setting ps_includes of $var\n" if $Opt{VERBOSE} > 1;
-		 $ps_includes{$var} = 0;
-	     }
-	 }
-
-	 my $output = "$odir/$var$tile.nc";
-	 my $output_barefile = "$var$tile.nc";
-        #------------------------------------------------------------
-        # FIRST TIME ONLY (when output file does not exist)
-        # need to extract additional static fields
-        # 1) dimension bounds, 2) coordinate variables, 3) formula terms
-        #------------------------------------------------------------
-         if (!-e $output) {
-
-            # get variable names of all dimension bounds/edges (except for time)
-            my @bounds = get_variable_bounds   ($dump,$var,$CMIP);
-            if (@bounds) {
-              print "   $var: bounds = ".join(", ",@bounds)."\n" if $Opt{VERBOSE} > 1;
-              push @vlist, @bounds;
+        # Do some extra CMORizing if --cmip
+        if ($CMIP) {
+          # rename "p###" (coordinate) variables to just "plev"
+          my @plev = grep{/p\d+/} @coordinates;
+          push @plev, grep{/pl700/} @coordinates;
+          if (@plev == 1) {
+            if (get_variable_att($vdump,$plev[0],"units") eq "Pa") {
+              print  "ncrename -h -v $plev[0],plev $tmp_var_filename\n";
+              system("ncrename -h -v $plev[0],plev $tmp_var_filename");
+              for (@coordinates) {
+                s/$plev[0]/plev/;
+              }
+              push @ncatted_opts, "-a coordinates,$var,m,c,\"@coordinates\"";
             }
-
-            # get variables specified by the coordinates attribute
-            my @coordinates = get_variables_from_att($dump,$var,"coordinates");
-            if (@coordinates) {
-              print "   $var: coordinates = ".join(", ",@bounds)."\n" if $Opt{VERBOSE} > 1;
-              push @vlist, @coordinates;
-              # add bounds for coordinate variables
-              foreach my $coord (@coordinates) {
-                push @vlist, get_dimension_bounds ($dump,$coord);
+            # also rename the bounds variable/attribute (if there is one)
+            my $plev_bnds = get_variable_att($vdump,$plev[0],"bounds");
+            if ($plev_bnds) {
+              if ($vdump =~ /\t\w+ $plev_bnds\(.+\)/) {
+                print  "ncrename -h -v $plev_bnds,plev_bnds $tmp_var_filename\n";
+                system("ncrename -h -v $plev_bnds,plev_bnds $tmp_var_filename");
+                push @ncatted_opts, "-a bounds,plev,m,c,\"plev_bnds\"";
               }
             }
+          } elsif (@plev > 1) {
+            die "ERROR: can not have more than one plev coordinate attribute/variable";
+          }
 
-	    
-
-            # formula terms
-            # only add static terms to the vlist
-            # time-varying terms are "external_variables"
-            my ($vterms,$xterms) = get_formula_terms($dump,$var);
-            if (@$vterms) {
-              print "   $var: formula_terms(static) = ".join(", ",@$vterms)."\n" if $Opt{VERBOSE} > 1;
-              push @vlist, @$vterms;
-            }
-            if (@$xterms) {
-              print "   $var: external_variables = ".join(", ",@$xterms)."\n" if $Opt{VERBOSE} > 1;
-              push @xlist, @$xterms;
-            }
-         }
-	 if ( $ps_includes{$var} ){
-	   print "Appending ps,pk,bk to variables to include.\n" if $Opt{VERBOSE} > 1;
-	   push @vlist, qw{ps pk bk};
-         }
-        #-------------------------------------------------
-        # EVERY TIME (when there is a time dimension)
-        # need to extract time bounds/average_XX variables
-        #-------------------------------------------------
-         if ($timename) {
-
-            # fms-style time avg variables
-            if (!$CMIP) {
-              my @time_avg_info = get_time_avg_info($dump,$var);
-              if (@time_avg_info) {
-                print "   $var: time_avg_info = ".join(", ",@time_avg_info)."\n" if $Opt{VERBOSE} > 1;
-                push @vlist, @time_avg_info;
+          # rename vertical dimensions (plev## -> plev, levhalf -> lev)
+          foreach my $dim (get_vertical_dimensions($vdump,$var)) {
+            if ($dim =~ /^plev\d+/) {
+              print  "ncrename -h -d $dim,plev -v $dim,plev $tmp_var_filename\n";
+              system("ncrename -h -d $dim,plev -v $dim,plev $tmp_var_filename");
+            } elsif ($dim eq "levhalf") {
+              print  "ncrename -h -d $dim,lev -v $dim,lev $tmp_var_filename\n";
+              system("ncrename -h -d $dim,lev -v $dim,lev $tmp_var_filename");
+              # also rename the formula terms
+              if (get_variable_att($vdump,$dim,"formula_terms") eq "ap: ap_half b: b_half ps: ps") {
+                print  "ncrename -h -v ap_half,ap -v b_half,b $tmp_var_filename\n";
+                system("ncrename -h -v ap_half,ap -v b_half,b $tmp_var_filename");
+                push @ncatted_opts, "-a formula_terms,lev,m,c,\"ap: ap b: b ps: ps\"";
               }
             }
+          }
+        }
+      }
 
-           # CF compliant time avg variables (bounds or climatology)
-            my $SKIPVAR = 0;
-            foreach my $bounds_type ( qw/bounds climatology/ ) {
-               my $bounds_name = get_variable_att($dump,$timename,$bounds_type);
-               if ($bounds_name) {
-                  if ($bounds_name eq $var) {
-                    # skip this variable because it is a time bounds variable
-                    print "   $var: SKIPPING because it is a time bounds variable\n" if $Opt{VERBOSE} > 1;
-                    $SKIPVAR = 1;
-                    last;
-                  }
-                  print "   $var: $timename: $bounds_type = $bounds_name\n" if $Opt{VERBOSE} > 1;
-                  push @vlist, $bounds_name;
-               }
-            }
+      # my $destination = "$odir/$var.nc$ext"; #  . ($Opt{UNCOMB} ? $ext : '');
+      my $destination = "$output$ext";
+      print  "mv $tmp_var_filename $destination\n" if $Opt{VERBOSE} > 2;
+      system("mv $tmp_var_filename $destination");
 
-            # skip this variable, reset the variable list
-            if ($SKIPVAR) {
-              @vlist = @coords;
-              @xlist = ();
-              next;
-            }
-         }
+      if (@ncatted_opts) {
+        print  "ncatted -h -O @ncatted_opts $destination\n" if $Opt{VERBOSE} > 1;
+        system("ncatted -h -O @ncatted_opts $destination");
+      }
+    }
 
-         # if a single file is desired then do not extract into single-field files
-         next if $Opt{onefile};
+    # reset the variable lists
+    @vlist = @coords;
+    @xlist = ();
+  }   ### end of variable loop ###
 
-     #-----------------------
-     #--- extract fields ----
-     #-----------------------
-         print "Size of vlist = ".scalar(@vlist)."  (NCKS)\n" if $Opt{VERBOSE} > 3;
-         my $vlist = join ",",@vlist;
-         print "   var=$var; timename=$timename; vlist=$vlist\n" if $Opt{VERBOSE} > 2;
-         my $appendopt = "";
-         $appendopt = "-A" if (-f "$cwd/$tmp_var_filename");
-         print   "$ncks -h $appendopt -v $vlist $file $tmp_var_filename\n" if $Opt{VERBOSE};
-         next if $TEST;
-         system ("$ncks -h $appendopt -v $vlist $file $tmp_var_filename");
-         $ncstatus += $?;
+  #--- extract fields for single file option ---
+  if ($Opt{onefile}) {
+    my $vlist = join ",",@vlist;
+    print  "$ncks -h -A -v $vlist $file $Opt{onefile}\n" if $Opt{VERBOSE} > 0;
+    system ("$ncks -h -A -v $vlist $file $Opt{onefile}");
+    $ncstatus += $?;
 
-         # remove dimensions called "scalar_axis" (i.e., length = 1)
-         # these are typically in the near-surface field files
-         my @commands = remove_degenerate_dimension("$tmp_var_filename","scalar_axis");
-         foreach my $cmd (@commands) {
-           print "$cmd\n" if $Opt{VERBOSE} > 0;
-           system($cmd);
-         }
+    my @ncatted_opts = set_ncatted_opts($Opt{onefile},tailname($Opt{onefile}));
+    # external_variables attribute (missin & time-varying formula terms)
+    if (@xlist) {
+      push @ncatted_opts, "-a external_variables,global,c,c,\"".join(" ",@xlist)."\"";
+    }
+    if (@ncatted_opts) {
+      print  "ncatted -h -O @ncatted_opts ".$Opt{onefile}."\n" if $Opt{VERBOSE} > 1;
+      system("ncatted -h -O @ncatted_opts ".$Opt{onefile})
+    }
+  }
 
-     #--- write to the output file ---
-         if (-e $output) {
-             die "ERROR: try to append to unlimited dimension when no unlimited dimension found" if !$timename;
+  #--- create readme ---
+  if ($first && $Opt{LOG}) {
+    variable_log($file,"$odir/README") if !$TEST;
+    $first = 0;
+  }
+  # remove file if copied from archive
+  unlink $file if $file_copied;
 
-            #--- append to existing file ---
-            #push @commands, "dmget ".$Opt{odir}."/$var.nc";
-             print  "mv $output $odir/.split_ncvars.$$.tmp.nc\n" if $Opt{VERBOSE} > 2;
-             system("mv $output $odir/.split_ncvars.$$.tmp.nc");
-             print "ncrcat $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename $output\n" if $Opt{VERBOSE} > 0;
-             system ("$ncrcat -h $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename $output");
-             $ncstatus += $?;
-             print  "rm -f $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename\n" if $Opt{VERBOSE} > 2;
-             system("rm -f $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename");
-         } else {
-            #--- create new file ---
-            #--- modify filename attribute ---
-            #--- move to output directory ---
-
-             my @ncatted_opts = set_ncatted_opts("$tmp_var_filename","$output_barefile",$var,$CMIP);
-             # external_variables attribute (cell_measures & time-varying formula terms)
-             if (@xlist) {
-               push @ncatted_opts, "-a external_variables,global,c,c,\"".join(" ",@xlist)."\"";
-             }
-
-             # rename coordinate variables
-             if (!$Opt{onefile}) {
-               my $vdump = `ncdump -h $tmp_var_filename`;
-               my @coordinates = get_variables_from_att($vdump,$var,"coordinates");
-
-               # rename "height#" (coordinate) variables to just "height"
-               my @height = grep{/height\d+/} @coordinates;
-               if (@height == 1) {
-                 print  "ncrename -h -v $height[0],height $tmp_var_filename\n";
-                 system("ncrename -h -v $height[0],height $tmp_var_filename");
-                 for (@coordinates) {
-                   s/$height[0]/height/;
-                 }
-                 push @ncatted_opts, "-a coordinates,$var,m,c,\"@coordinates\"";
-               } elsif (@height > 1) {
-                 die "ERROR: can not have more than one height coordinate attribute/variable";
-               }
-
-               # Do some extra CMORizing if --cmip
-               if ($CMIP) {
-                 # rename "p###" (coordinate) variables to just "plev"
-                 my @plev = grep{/p\d+/} @coordinates;
-                 push @plev, grep{/pl700/} @coordinates;
-                 if (@plev == 1) {
-                   if (get_variable_att($vdump,$plev[0],"units") eq "Pa") {
-                     print  "ncrename -h -v $plev[0],plev $tmp_var_filename\n";
-                     system("ncrename -h -v $plev[0],plev $tmp_var_filename");
-                     for (@coordinates) {
-                       s/$plev[0]/plev/;
-                     }
-                     push @ncatted_opts, "-a coordinates,$var,m,c,\"@coordinates\"";
-                   }
-                   # also rename the bounds variable/attribute (if there is one)
-                   my $plev_bnds = get_variable_att($vdump,$plev[0],"bounds");
-                   if ($plev_bnds) {
-                     if ($vdump =~ /\t\w+ $plev_bnds\(.+\)/) {
-                       print  "ncrename -h -v $plev_bnds,plev_bnds $tmp_var_filename\n";
-                       system("ncrename -h -v $plev_bnds,plev_bnds $tmp_var_filename");
-                       push @ncatted_opts, "-a bounds,plev,m,c,\"plev_bnds\"";
-                     }
-                   }
-                 } elsif (@plev > 1) {
-                   die "ERROR: can not have more than one plev coordinate attribute/variable";
-                 }
-
-                 # rename vertical dimensions (plev## -> plev, levhalf -> lev)
-                 foreach my $dim (get_vertical_dimensions($vdump,$var)) {
-                   if ($dim =~ /^plev\d+/) {
-                     print  "ncrename -h -d $dim,plev -v $dim,plev $tmp_var_filename\n";
-                     system("ncrename -h -d $dim,plev -v $dim,plev $tmp_var_filename");
-                   } elsif ($dim eq "levhalf") {
-                     print  "ncrename -h -d $dim,lev -v $dim,lev $tmp_var_filename\n";
-                     system("ncrename -h -d $dim,lev -v $dim,lev $tmp_var_filename");
-                     # also rename the formula terms
-                     if (get_variable_att($vdump,$dim,"formula_terms") eq "ap: ap_half b: b_half ps: ps") {
-                       print  "ncrename -h -v ap_half,ap -v b_half,b $tmp_var_filename\n";
-                       system("ncrename -h -v ap_half,ap -v b_half,b $tmp_var_filename");
-                       push @ncatted_opts, "-a formula_terms,lev,m,c,\"ap: ap b: b ps: ps\"";
-                     }
-                   }
-                 }
-               }
-             }
-
-#	     my $destination = "$odir/$var.nc$ext"; #  . ($Opt{UNCOMB} ? $ext : '');
-	     my $destination = "$output$ext";
-	     print  "mv $tmp_var_filename $destination\n" if $Opt{VERBOSE} > 2;
-	     system("mv $tmp_var_filename $destination");
-	     
-	     if (@ncatted_opts) {
-		 print  "ncatted -h -O @ncatted_opts $destination\n" if $Opt{VERBOSE} > 1;
-		 system("ncatted -h -O @ncatted_opts $destination");
-	     }
-         }
-
-         # reset the variable lists
-         @vlist = @coords;
-         @xlist = ();
-     }   ### end of variable loop ###
-
-    #--- extract fields for single file option ---
-     if ($Opt{onefile}) {
-         my $vlist = join ",",@vlist;
-         print  "$ncks -h -A -v $vlist $file $Opt{onefile}\n" if $Opt{VERBOSE} > 0;
-         system ("$ncks -h -A -v $vlist $file $Opt{onefile}");
-         $ncstatus += $?;
-
-         my @ncatted_opts = set_ncatted_opts($Opt{onefile},tailname($Opt{onefile}));
-         # external_variables attribute (missin & time-varying formula terms)
-         if (@xlist) {
-            push @ncatted_opts, "-a external_variables,global,c,c,\"".join(" ",@xlist)."\"";
-         }
-         if (@ncatted_opts) {
-           print  "ncatted -h -O @ncatted_opts ".$Opt{onefile}."\n" if $Opt{VERBOSE} > 1;
-           system("ncatted -h -O @ncatted_opts ".$Opt{onefile})
-         }
-     }
-
-    #--- create readme ---
-     if ($first && $Opt{LOG}) {
-        variable_log($file,"$odir/README") if !$TEST;
-        $first = 0;
-     }
-    # remove file if copied from archive
-     unlink $file if $file_copied;
-
-    # clean up ncks dropping
-    unlink "ncks.out" if (-e "ncks.out");
-
- }   ### end of file loop ###
+  # clean up ncks dropping
+  unlink "ncks.out" if (-e "ncks.out");
+}   ### end of file loop ###
 
 exit 1 if $ncstatus;
 
@@ -482,14 +479,14 @@ Usage:  $name [-d] [-l] [-i idir] [-o odir] [-f file] [-v vars]  files.....
 #------------------------------------------------
 
 sub get_time_dimension {
-   my $dump = shift;
-   my $timeName;
-   my $timeSize;
-   if ($dump =~ /\t(.+) = UNLIMITED ; \/\/ \((\d+) currently\)/) {
-      $timeName = $1; 
-      $timeSize = $1; 
-   }   
-   return $timeName;
+  my $dump = shift;
+  my $timeName;
+  my $timeSize;
+  if ($dump =~ /\t(.+) = UNLIMITED ; \/\/ \((\d+) currently\)/) {
+    $timeName = $1;
+    $timeSize = $1;
+  }
+  return $timeName;
 }
 
 #-------------------------------------------
@@ -501,7 +498,7 @@ sub get_variable_dimensions {
   my @coords;
   # Get a list of the cartesian coordinates that are in a file
   while ( $dump =~ /\t\t(.*):(cartesian_axis|axis) = "(.*)"/g ){
-      $cartesian_coords{$1} = $2;
+    $cartesian_coords{$1} = $2;
   }
   # Compare the cartesian coords to those of the variables
   if ( $dump =~ /\t.*$var\((.+)\)/){
@@ -537,7 +534,7 @@ sub get_variable_att {
   my $value;
   if ($dump =~ /\t\t$var:$att = "(.+)" ;/) {
     $value = $1;
-  }   
+  }
   return $value;
 }
 
@@ -591,8 +588,8 @@ sub get_variable_bounds {
     foreach my $dim (@axes) {
       next if ($dim eq $timename);
       push @bounds, get_dimension_bounds($dump,$dim,$CMIPVAR);
-    }     
-  }     
+    }
+  }
   return @bounds;
 }
 
@@ -627,14 +624,14 @@ sub get_formula_terms {
     # check each axis for formula terms
     foreach my $dim (@axes) {
       my $form = get_variable_att($dump,$dim,"formula_terms");
-     #print "   $dim:formula_terms = \"$form\"\n" if $form;
+      #print "   $dim:formula_terms = \"$form\"\n" if $form;
       foreach my $term ($form =~ /\w+:\s+(\w+)/g) {
         push @allterms, $term if !grep{$_ eq $term} @allterms;
       }
       # also check bounds for formula terms
       my $bnds = get_variable_att($dump,$dim,"bounds");
       my $form = get_variable_att($dump,$bnds,"formula_terms");
-     #print "   $bnds:formula_terms = \"$form\"\n" if $form;
+      #print "   $bnds:formula_terms = \"$form\"\n" if $form;
       foreach my $term ($form =~ /\w+:\s+(\w+)/g) {
         push @allterms, $term if !grep{$_ eq $term} @allterms;
       }
@@ -667,13 +664,13 @@ sub is_static {
   }
   return $static;
 }
-  
+
 #-------------------------------------------
 
 sub tailname {
-   my $tail = shift;
-   while ($tail =~ s/^.*\///) {}
-   return $tail;
+  my $tail = shift;
+  while ($tail =~ s/^.*\///) {}
+  return $tail;
 }
 
 #-------------------------------------------
@@ -735,11 +732,11 @@ sub cleanup_dim_atts {
   my $cal = get_variable_att($dump,$dim,"calendar");
   my $calt = get_variable_att($dump,$dim,"calendar_type");
   if ($cal) {
-     my $calc = lc($cal);
-     push @opts, "-a calendar,$dim,m,c,\"$calc\"" if ($cal ne $calc);
+    my $calc = lc($cal);
+    push @opts, "-a calendar,$dim,m,c,\"$calc\"" if ($cal ne $calc);
   } elsif ($calt) {
-     my $calc = lc($cal);
-     push @opts, "-a calendar,$dim,c,c,\"$calc\"";
+    my $calc = lc($cal);
+    push @opts, "-a calendar,$dim,c,c,\"$calc\"";
   }
   push @opts, "-a calendar_type,$dim,d,," if $calt;
 
@@ -797,4 +794,3 @@ sub variable_log {
   close(OUT);
   return 0;
 }
-

--- a/postprocessing/split_ncvars/split_ncvars.pl.in
+++ b/postprocessing/split_ncvars/split_ncvars.pl.in
@@ -64,23 +64,23 @@ my $odir = $Opt{odir};
 ##################################################################
 # external scripts
 
-my $ncrcat = `which ncrcat 2>&1`;
-die "Unable to locate ncrcat, cannot continue.\n" if $ncrcat =~ /(: no)|(not found)/;
-chomp $ncrcat;
+my $ncrcat = "@NCRCAT@";
 $ncrcat .= " -t 2 --header_pad 65536";
 
-my $ncks = `which ncks 2>&1`;
-die "Unable to locate ncks, cannot continue.\n" if $ncks =~ /(: no)|(not found)/;
-chomp $ncks;
+my $ncks = "@NCKS@";
 $ncks .= ' --header_pad 65536';
+
+my $ncwa = "@NCWA@";
+
+my $ncatted = "@NCATTED@";
+
+my $ncrename = "@NCRENAME@";
 
 my $list_ncvars = `which list_ncvars.csh 2>&1`;
 die "Unable to locate list_ncvars.csh, cannot continue.\n" if $list_ncvars =~ /(: no)|(not found)/;
 chomp $list_ncvars;
 
-my $ncdump = `which ncdump 2>&1`;
-die "Unable to locate ncdump, cannot continue.\n" if $ncdump =~ /(: no)|(not found)/;
-chomp $ncdump;
+my $ncdump = "@NCDUMP@";
 
 my $dmget_available = `which dmget 2>&1`;
 $dmget_available = 0 if $dmget_available =~ /(: no)|(not found)/;
@@ -318,7 +318,7 @@ foreach my $file (@ifiles) {
       #push @commands, "dmget ".$Opt{odir}."/$var.nc";
       print  "mv $output $odir/.split_ncvars.$$.tmp.nc\n" if $Opt{VERBOSE} > 2;
       system("mv $output $odir/.split_ncvars.$$.tmp.nc");
-      print "ncrcat $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename $output\n" if $Opt{VERBOSE} > 0;
+      print "$ncrcat -h $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename $output\n" if $Opt{VERBOSE} > 0;
       system ("$ncrcat -h $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename $output");
       $ncstatus += $?;
       print  "rm -f $odir/.split_ncvars.$$.tmp.nc $tmp_var_filename\n" if $Opt{VERBOSE} > 2;
@@ -336,14 +336,14 @@ foreach my $file (@ifiles) {
 
       # rename coordinate variables
       if (!$Opt{onefile}) {
-        my $vdump = `ncdump -h $tmp_var_filename`;
+        my $vdump = `$ncdump -h $tmp_var_filename`;
         my @coordinates = get_variables_from_att($vdump,$var,"coordinates");
 
         # rename "height#" (coordinate) variables to just "height"
         my @height = grep{/height\d+/} @coordinates;
         if (@height == 1) {
-          print  "ncrename -h -v $height[0],height $tmp_var_filename\n";
-          system("ncrename -h -v $height[0],height $tmp_var_filename");
+          print  "$ncrename -h -v $height[0],height $tmp_var_filename\n";
+          system("$ncrename -h -v $height[0],height $tmp_var_filename");
           for (@coordinates) {
             s/$height[0]/height/;
           }
@@ -359,8 +359,8 @@ foreach my $file (@ifiles) {
           push @plev, grep{/pl700/} @coordinates;
           if (@plev == 1) {
             if (get_variable_att($vdump,$plev[0],"units") eq "Pa") {
-              print  "ncrename -h -v $plev[0],plev $tmp_var_filename\n";
-              system("ncrename -h -v $plev[0],plev $tmp_var_filename");
+              print  "$ncrename -h -v $plev[0],plev $tmp_var_filename\n";
+              system("$ncrename -h -v $plev[0],plev $tmp_var_filename");
               for (@coordinates) {
                 s/$plev[0]/plev/;
               }
@@ -370,8 +370,8 @@ foreach my $file (@ifiles) {
             my $plev_bnds = get_variable_att($vdump,$plev[0],"bounds");
             if ($plev_bnds) {
               if ($vdump =~ /\t\w+ $plev_bnds\(.+\)/) {
-                print  "ncrename -h -v $plev_bnds,plev_bnds $tmp_var_filename\n";
-                system("ncrename -h -v $plev_bnds,plev_bnds $tmp_var_filename");
+                print  "$ncrename -h -v $plev_bnds,plev_bnds $tmp_var_filename\n";
+                system("$ncrename -h -v $plev_bnds,plev_bnds $tmp_var_filename");
                 push @ncatted_opts, "-a bounds,plev,m,c,\"plev_bnds\"";
               }
             }
@@ -382,15 +382,15 @@ foreach my $file (@ifiles) {
           # rename vertical dimensions (plev## -> plev, levhalf -> lev)
           foreach my $dim (get_vertical_dimensions($vdump,$var)) {
             if ($dim =~ /^plev\d+/) {
-              print  "ncrename -h -d $dim,plev -v $dim,plev $tmp_var_filename\n";
-              system("ncrename -h -d $dim,plev -v $dim,plev $tmp_var_filename");
+              print  "$ncrename -h -d $dim,plev -v $dim,plev $tmp_var_filename\n";
+              system("$ncrename -h -d $dim,plev -v $dim,plev $tmp_var_filename");
             } elsif ($dim eq "levhalf") {
-              print  "ncrename -h -d $dim,lev -v $dim,lev $tmp_var_filename\n";
-              system("ncrename -h -d $dim,lev -v $dim,lev $tmp_var_filename");
+              print  "$ncrename -h -d $dim,lev -v $dim,lev $tmp_var_filename\n";
+              system("$ncrename -h -d $dim,lev -v $dim,lev $tmp_var_filename");
               # also rename the formula terms
               if (get_variable_att($vdump,$dim,"formula_terms") eq "ap: ap_half b: b_half ps: ps") {
-                print  "ncrename -h -v ap_half,ap -v b_half,b $tmp_var_filename\n";
-                system("ncrename -h -v ap_half,ap -v b_half,b $tmp_var_filename");
+                print  "$ncrename -h -v ap_half,ap -v b_half,b $tmp_var_filename\n";
+                system("$ncrename -h -v ap_half,ap -v b_half,b $tmp_var_filename");
                 push @ncatted_opts, "-a formula_terms,lev,m,c,\"ap: ap b: b ps: ps\"";
               }
             }
@@ -404,8 +404,8 @@ foreach my $file (@ifiles) {
       system("mv $tmp_var_filename $destination");
 
       if (@ncatted_opts) {
-        print  "ncatted -h -O @ncatted_opts $destination\n" if $Opt{VERBOSE} > 1;
-        system("ncatted -h -O @ncatted_opts $destination");
+        print  "$ncatted -h -O @ncatted_opts $destination\n" if $Opt{VERBOSE} > 1;
+        system("$ncatted -h -O @ncatted_opts $destination");
       }
     }
 
@@ -427,8 +427,8 @@ foreach my $file (@ifiles) {
       push @ncatted_opts, "-a external_variables,global,c,c,\"".join(" ",@xlist)."\"";
     }
     if (@ncatted_opts) {
-      print  "ncatted -h -O @ncatted_opts ".$Opt{onefile}."\n" if $Opt{VERBOSE} > 1;
-      system("ncatted -h -O @ncatted_opts ".$Opt{onefile})
+      print  "$ncatted -h -O @ncatted_opts ".$Opt{onefile}."\n" if $Opt{VERBOSE} > 1;
+      system("$ncatted -h -O @ncatted_opts ".$Opt{onefile})
     }
   }
 
@@ -679,7 +679,7 @@ sub tailname {
 sub set_ncatted_opts ($$;$$) {
   my ($file,$filename,$var,$CMIPVAR) = @_;
   my @opts;
-  my $dump = `ncdump -h $file`;
+  my $dump = `$ncdump -h $file`;
   push @opts, "-a filename,global,m,c,\"$filename\"" if ($dump =~ /\t\t:filename = ".+" ;/);
 
   my $svar = "\w+"; # globally edit attributes
@@ -761,13 +761,13 @@ sub cleanup_dim_atts {
 
 sub remove_degenerate_dimension {
   my ($file,$dim) = @_;
-  my $dump =`ncdump -h $file`;
+  my $dump =`$ncdump -h $file`;
   my @cmds;
   # is this a singleton dimension?
   if ($dump =~ /\t$dim = 1 ;/) {
     # remove dim by averaging, then (un)extract the unused dimension
-    push @cmds, "ncwa -h -a $dim $file $file.ztmp";
-    push @cmds, "ncks -h -O -x -v scalar_axis $file.ztmp $file";
+    push @cmds, "$ncwa -h -a $dim $file $file.ztmp";
+    push @cmds, "$ncks -h -O -x -v scalar_axis $file.ztmp $file";
     push @cmds, "rm -f $file.ztmp";
   }
   return @cmds;
@@ -778,7 +778,7 @@ sub remove_degenerate_dimension {
 sub variable_log {
   my $ncfile = shift;
   my $prtfile = shift;
-  my $dump = `ncdump -h $ncfile`;
+  my $dump = `$ncdump -h $ncfile`;
 
   open (OUT,"> $prtfile") || die "Cannot open $prtfile for output";
 

--- a/postprocessing/split_ncvars/varlist.csh.in
+++ b/postprocessing/split_ncvars/varlist.csh.in
@@ -1,14 +1,9 @@
 #!/bin/tcsh -f
 #
-# $Id: varlist.csh,v 1.1.2.1.2.2 2010/06/01 23:01:57 afy Exp $
 # ------------------------------------------------------------------------------
 # FMS/FRE Project: Script to Print Info About netCDF Variables
 # ------------------------------------------------------------------------------
-# afy    Ver   1.00  Copied from ~fms/local/ia64/netcdf4.fix        June 10
-# afy    Ver   2.00  Don't source the 'init.csh' script             June 10
-# afy    Ver   2.01  Use 'which' to locate the 'list_ncvars.csh'    June 10
-# ------------------------------------------------------------------------------
-# Copyright (C) NOAA Geophysical Fluid Dynamics Laboratory, 2000-2010
+# Copyright (C) NOAA Geophysical Fluid Dynamics Laboratory, 2000-2010, 2024
 # Designed and written by V. Balaji, Amy Langenhorst and Aleksey Yakovlev
 #
 
@@ -25,16 +20,16 @@ if (-e .tmpdump) then
    exit 1
 endif
 
-ncdump -h $file > .tmpdump
+@NCDUMP@ -h $file > .tmpdump
 set vars = `list_ncvars.csh -t0123 $file`
 
 foreach var ($vars)
-#   --- get the long name and units ---
-    set string = `grep "	${var}:long_name" .dump`
+    #   --- get the long name and units ---
+    set string = `grep "	${var}:long_name" .tmpdump`
     set name = `echo $string[3-] | sed -e 's/"/ /g' | sed -e 's/;/ /g'`
-    set string = `grep "	${var}:units" .dump`
+    set string = `grep "	${var}:units" .tmpdump`
     set units = `echo $string[3-] | sed -e 's/"/ /g' | sed -e 's/;/ /g'`
     echo $var.nc $name "("$units")" | awk '{printf "%20s = ", $1}{for (i = 2; i < NF; ++i) printf "%s ", $i}{printf "%s\n", $NF}'
 end
 
-if (-e .dump) rm -f .tmpdump
+if (-e .tmpdump) rm -f .tmpdump


### PR DESCRIPTION
Use the full path for `ncdump`, and the NCO tools that are found during the configure step.  This will remove the need to have several modules loaded.

The downfall is that users cannot easily move to newer versions of these tools (using modules), and if the tools are removed (the particular version is removed) then the applications will fail.