### PR TITLE
Fix gpu compile error from PR #328

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ AM_CONDITIONAL([WITH_MPI], [test x"$build_mpi" = x"yes"])
 AM_CONDITIONAL([WITH_MPI_TESTS], [test x"$build_mpi" = x"yes" -a -z "$SKIP_MPI_TEST"])
 
 #Build with OpenACC suport.  Default is 'no'
-AC_ARG_ENABLE([acc],
+AC_ARG_ENABLE([gpu],
             [AS_HELP_STRING([--enable-gpu],
                             [Builds with OpenACC. This will result in a second executable for fregrid, fregrid_gpu.(default no)])])
 AS_IF([test ${enable_gpu:-no} = yes],

--- a/configure.ac
+++ b/configure.ac
@@ -87,7 +87,7 @@ AM_CONDITIONAL([WITH_MPI_TESTS], [test x"$build_mpi" = x"yes" -a -z "$SKIP_MPI_T
 
 #Build with OpenACC suport.  Default is 'no'
 AC_ARG_ENABLE([acc],
-            [AS_HELP_STRING([--enable-acc],
+            [AS_HELP_STRING([--enable-gpu],
                             [Builds with OpenACC. This will result in a second executable for fregrid, fregrid_gpu.(default no)])])
 AS_IF([test ${enable_gpu:-no} = yes],
       [enable_gpu=yes],


### PR DESCRIPTION
**Description**
This PR fixes the missed argument changes from `acc` to `gpu` in `configure.ac`.

Fixes #332 

**How Has This Been Tested?**
Fregrid_gpu compiles with ./configure --enable-gpu=yes

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
