### PR TITLE
fixes for gaussian topog type option

### DIFF
--- a/tools/make_topog/topog.c
+++ b/tools/make_topog/topog.c
@@ -144,7 +144,7 @@ void create_gaussian_topog(int nx, int ny, const double *x, const double *y, dou
   printf("The ocean floor rises with a slope of %f meters/deg towards the east and %f "
 	 " meters/deg to the north.", slope_x, slope_y) ;
 
-  for(j=0;i<nx*ny;j++){
+  for(j=0;j<nx*ny;j++){
       arg = pow(xt[i]-xcent,2) + pow(yt[i]-ycent,2);
       bottom = bottom_depth - bump_height*exp(-arg/pow(bump_scale,2));
       bottom = bottom - slope_x*(xt[i]-xw)- slope_y*(yt[i]-ys);

--- a/tools/make_topog/topog.c
+++ b/tools/make_topog/topog.c
@@ -108,7 +108,9 @@ void create_gaussian_topog(int nx, int ny, const double *x, const double *y, dou
   double bump_height, bump_scale, xcent, ycent, arg, bottom;
   double xe, xw, ys, yn;
   double *xt, *yt;
-  int i, j, nxp, nyp;
+  int i, j, nxp;
+
+  nxp = nx + 1;
 
   xt = (double *)malloc(nx*ny*sizeof(double));
   yt = (double *)malloc(nx*ny*sizeof(double));


### PR DESCRIPTION
**Description**
Fixes a uninitialized variable and a hanging loop in the `create_gaussian_topog` routine. This routine may need more changes for the data to actually be as intended, but at least now the option won't hang.

Fixes #339 

**How Has This Been Tested?**
Mainly tested with files from the make_topog test (tests/make_topog/ocean-topog).

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
