### PR TITLE
make_land_domain: Allocate `land_ntile` array to correct size

### DIFF
--- a/tools/make_land_domain/make_land_domain.c
+++ b/tools/make_land_domain/make_land_domain.c
@@ -215,7 +215,7 @@ int main(int argc, char* argv[])
   printf("total number of land points is %d\n", nlands);
   land_ntile = (int **)malloc(nfaces*sizeof(int *));
   for(face=0; face<nfaces; face++) {
-    land_ntile[face] = (int *)malloc(nx*nx*sizeof(int));
+    land_ntile[face] = (int *)malloc(nx*ny*sizeof(int));
     for(n=0; n<nx*ny; n++) land_ntile[face][n] = 0;
   }
 


### PR DESCRIPTION
**Description**
In `make_land_domain.c`, allocate `nx*ny` integers per face in the `land_ntile` array, rather than `nx*nx`.

This doesn't make a difference when `nx == ny`, but should be the correct behavior in the general case.

**How Has This Been Tested?**
Compiles with icx 2023.2.0

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes