### PR TITLE
Fix path to list_ncvars in split_ncvars

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@
 AC_PREREQ([2.63])
 AC_INIT(
   [FRE NCTools],
-  [2024.05],
+  [2024.05.02],
   [https://github.com/NOAA-GFDL/FRE-NCtools/issues],
   [fre-nctools],
   [https://github.com/NOAA-GFDL/FRE-NCtools])

--- a/src/split_ncvars/split_ncvars.pl.in
+++ b/src/split_ncvars/split_ncvars.pl.in
@@ -125,7 +125,7 @@ my $ncatted
 my $list_ncvars
     = defined( $ENV{LIST_NCVARS} )
     ? $ENV{LIST_NCVARS}
-    : "$prefix/list_ncvars.sh";
+    : "$prefix/bin/list_ncvars.sh";
 
 my $ncdump
     = defined( $ENV{NCDUMP} )


### PR DESCRIPTION
**Description**
This is a patch fix for 2024.05.01 to the split_ncvars.pl command.  This adds `bin` to the patch for list_ncvars.sh.  This needs to be merged in to future releases.  We should also tag this branch with 2024.05.02.
