### PR TITLE
Fix split-vars tests

### DIFF
--- a/src/split_ncvars/split_ncvars.pl.in
+++ b/src/split_ncvars/split_ncvars.pl.in
@@ -127,6 +127,10 @@ my $list_ncvars
     ? $ENV{LIST_NCVARS}
     : "$prefix/bin/list_ncvars.sh";
 
+unless (-f $list_ncvars) {
+    die "ERROR: required list-vars script not available (was looking for '$list_ncvars')";
+}
+
 my $ncdump
     = defined( $ENV{NCDUMP} )
     ? $ENV{NCDUMP}

--- a/tests/split_ncvars/split_ncvars
+++ b/tests/split_ncvars/split_ncvars
@@ -26,6 +26,10 @@ fi
 
 . ${srcdir=.}/init.sh; path_prepend_ ../src
 
+# Set paths to list-vars script and just-compiled exec
+export LIST_NCVARS=`find ../.. -name list_ncvars.sh`
+export PKGLIBEXECDIR=$(dirname $LIST_NCVARS)
+
 # Use the test netCDF files from plevel and timeavg
 ${builddir=.}/create_timeavg_test_ncfiles || framework_failure_ "failed to create timeavg test files"
 ${builddir=.}/create_plevel_test_ncfile || framework_failure_ "failed to create plevel test files"

--- a/tests/split_ncvars/split_ncvars-i
+++ b/tests/split_ncvars/split_ncvars-i
@@ -26,6 +26,10 @@ fi
 
 . ${srcdir=.}/init.sh; path_prepend_ ../src
 
+# Set paths to list-vars script and just-compiled exec
+export LIST_NCVARS=`find ../.. -name list_ncvars.sh`
+export PKGLIBEXECDIR=$(dirname $LIST_NCVARS)
+
 # Use the test netCDF files from plevel
 ${builddir=.}/create_plevel_test_ncfile || framework_failure_ "failed to create plevel test files"
 mkdir idir || framework_failure_ "failed to create idir"

--- a/tests/split_ncvars/split_ncvars-l
+++ b/tests/split_ncvars/split_ncvars-l
@@ -26,6 +26,10 @@ fi
 
 . ${srcdir=.}/init.sh; path_prepend_ ../src
 
+# Set paths to list-vars script and just-compiled exec
+export LIST_NCVARS=`find ../.. -name list_ncvars.sh`
+export PKGLIBEXECDIR=$(dirname $LIST_NCVARS)
+
 # Use the test netCDF files from timeavg
 ${builddir=.}/create_timeavg_test_ncfiles || framework_failure_ "failed to create test files"
 

--- a/tests/split_ncvars/split_ncvars-o
+++ b/tests/split_ncvars/split_ncvars-o
@@ -26,6 +26,10 @@ fi
 
 . ${srcdir=.}/init.sh; path_prepend_ ../src
 
+# Set paths to list-vars script and just-compiled exec
+export LIST_NCVARS=`find ../.. -name list_ncvars.sh`
+export PKGLIBEXECDIR=$(dirname $LIST_NCVARS)
+
 # Use the test netCDF files from plevel
 ${builddir=.}/create_plevel_test_ncfile || framework_failure_ "failed to create plevel test files"
 

--- a/tests/split_ncvars/split_ncvars-p
+++ b/tests/split_ncvars/split_ncvars-p
@@ -26,6 +26,10 @@ fi
 
 . ${srcdir=.}/init.sh; path_prepend_ ../src
 
+# Set paths to list-vars script and just-compiled exec
+export LIST_NCVARS=`find ../.. -name list_ncvars.sh`
+export PKGLIBEXECDIR=$(dirname $LIST_NCVARS)
+
 # Use the test netCDF files from plevel
 ${builddir=.}/create_plevel_test_ncfile || framework_failure_ "failed to create test files"
 

--- a/tests/split_ncvars/split_ncvars-s
+++ b/tests/split_ncvars/split_ncvars-s
@@ -26,6 +26,10 @@ fi
 
 . ${srcdir=.}/init.sh; path_prepend_ ../src
 
+# Set paths to list-vars script and just-compiled exec
+export LIST_NCVARS=`find ../.. -name list_ncvars.sh`
+export PKGLIBEXECDIR=$(dirname $LIST_NCVARS)
+
 # Use the test netCDF files from plevel
 ${builddir=.}/create_plevel_test_ncfile || framework_failure_ "failed to create plevel test files"
 

--- a/tests/split_ncvars/split_ncvars-v
+++ b/tests/split_ncvars/split_ncvars-v
@@ -26,6 +26,10 @@ fi
 
 . ${srcdir=.}/init.sh; path_prepend_ ../src
 
+# Set paths to list-vars script and just-compiled exec
+export LIST_NCVARS=`find ../.. -name list_ncvars.sh`
+export PKGLIBEXECDIR=$(dirname $LIST_NCVARS)
+
 # Use the test netCDF files from plevel
 ${builddir=.}/create_plevel_test_ncfile || framework_failure_ "failed to create test files"
 


### PR DESCRIPTION
**Description**
The new split-ncvars tests cannot find the just-built script and executable location.

This resolves that problem and does not add any new functionality.

Fixes #353

**How Has This Been Tested?**
Hand-tested, and CI tests will pass

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes
