### PR TITLE
Fregrid Optimization: Device Pointers

### DIFF
--- a/tools/fregrid_gpu/interp_utils_gpu.c
+++ b/tools/fregrid_gpu/interp_utils_gpu.c
@@ -78,14 +78,12 @@ void get_input_grid_mask_gpu(const int mask_size, double **input_grid_mask)
 {
 
   double *p_input_grid_mask;
-
-  *input_grid_mask = (double *)malloc(mask_size*sizeof(double));
+  *input_grid_mask = (double*) acc_malloc(mask_size*sizeof(double));
   p_input_grid_mask = *input_grid_mask;
 
-
-#pragma acc enter data create(p_input_grid_mask[:mask_size])
-#pragma acc parallel loop independent present(p_input_grid_mask[:mask_size])
+#pragma acc parallel loop independent deviceptr(p_input_grid_mask)
   for( int i=0 ; i<mask_size; i++) p_input_grid_mask[i]=1.0;
+
 
 }
 
@@ -95,7 +93,6 @@ void free_input_grid_mask_gpu(const int mask_size, double **input_grid_mask)
 
   p_input_grid_mask = *input_grid_mask;
 
-#pragma acc exit data delete(p_input_grid_mask[:mask_size])
-  free(p_input_grid_mask);
+  acc_free(p_input_grid_mask);
   p_input_grid_mask = NULL;
 }

--- a/tools/libfrencutils_gpu/create_xgrid_utils_gpu.h
+++ b/tools/libfrencutils_gpu/create_xgrid_utils_gpu.h
@@ -47,16 +47,8 @@ int clip_2dx2d_great_circle_gpu(const double x1_in[], const double y1_in[], cons
 void get_grid_cell_struct_gpu( const int nlon, const int nlat, const Grid_config *output_grid,
                                 Grid_cells_struct_config *grid_cells);
 
-void free_grid_cell_struct_gpu( const int ncells, Grid_cells_struct_config *grid_cells);
-
 #pragma acc routine seq
 void get_cell_vertices_gpu( const int ij, const int nlon, const double *lon, const double *lat, double *x, double *y );
-
-void create_upbound_nxcells_arrays_on_device_gpu(const int n, int **approx_nxcells_per_ij1,
-                                                 int **ij2_start, int **ij2_end);
-
-void free_upbound_nxcells_arrays_gpu( const int n, int **approx_nxcells_per_ij1,
-                                              int **ij2_start, int **ij2_end);
 
 void copy_data_to_xgrid_on_device_gpu(const int nxcells, const int input_ncells, const int upbound_nxcells,
                                       int *xcells_per_ij1, double *xcell_clon, double *xcell_clat,


### PR DESCRIPTION

**Description**
- During exchange grid generation and remapping data, allocate temporary arrays on the device.
            - Allocate data memory on device using acc_malloc -Remove instances of `data create` –  data will only be housed on device, so there is no need to match creation on host.

-  Modify `present` clause, removing data allocated memory using acc_malloc

- Utilize deviceptr clause to declare that pointers in list refer to a device pointer that does not need to be allocated / moved between host and device.


**How Has This Been Tested?**

- Standard build and installation process 
- Performed benchmark tests for fregrid_gpu with various input grids 

**Checklist:**
[✓] My code follows the style guidelines of this project
[✓ ] I have performed a self-review of my own code
[ ] I have commented my code, particularly in hard-to-understand areas
[ ] I have made corresponding changes to the documentation
[✓] My changes generate no new warnings
[ ] Any dependent changes have been merged and published in downstream modules
[ ] New check tests, if applicable, are included
[x ] `make distcheck` passes
split_ncvars/ fails but all other checks pass or are skipped
