### PR TITLE
add release action to upload generated distribution file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,12 +23,12 @@ jobs:
       run: |
         mkdir build && cd build
         autoreconf -if ../configure.ac
-        ../configure --enable-mpi
+        ../configure
     - name: Build and create distribution file
       run: |
         cd build
         make
-        make -k distcheck
+        make distcheck
         make dist
     - name: Create release draft and upload file
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Create release draft with generated distribution file
 on:
   push:
     tags:
-      - 20*.* # TODO update in 75 years
+      - 20*.*
       - 20*.*.*
 
 jobs:
@@ -37,3 +37,5 @@ jobs:
           build/fre-nctools-*.*.tar.gz
           build/fre-nctools-*.*.*.tar.gz
         draft: True
+        generate_release_notes: True
+        make_latest: True

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Create release draft with generated distribution file
+
+on:
+  push:
+    tags:
+      - 20*.* # TODO update in 75 years
+      - 20*.*.*
+
+jobs:
+  create-release-dist:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y nco which netcdf-bin libnetcdf-dev \
+          libnetcdff-dev mpich gcc gfortran asciidoc docbook-xsl docbook-xml \
+          python3 python3-numpy python3-pytest perl git make libtool autoconf 
+    - name: Configure
+      run: |
+        mkdir build && cd build
+        autoreconf -if ../configure.ac
+        ../configure --enable-mpi
+    - name: Build and create distribution file
+      run: |
+        cd build
+        make
+        make -k distcheck
+        make dist
+    - name: Create release draft and upload file
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          build/fre-nctools-*.*.tar.gz
+          build/fre-nctools-*.*.*.tar.gz
+        draft: True

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -210,7 +210,9 @@ split_ncvars.pl: split_ncvars/split_ncvars.pl.in Makefile
 	$(do_subst) < $(srcdir)/split_ncvars/split_ncvars.pl.in > split_ncvars.pl
 	chmod +x split_ncvars.pl
 
-install-exec-hook:
-	ln $(DESTDIR)$(bindir)/split_ncvars.pl $(DESTDIR)$(bindir)/split_ncvars
-install-data-hook:
-	ln $(DESTDIR)$(mandir)/man1/split_ncvars.pl.1 $(DESTDIR)$(mandir)/man1/split_ncvars.1
+# TODO causes issues with distclean
+#install-exec-hook:
+#	ln $(DESTDIR)$(bindir)/split_ncvars.pl $(DESTDIR)$(bindir)/split_ncvars
+# TODO file not found, might run before docs are built
+#install-data-hook:
+#	ln $(DESTDIR)$(mandir)/man1/split_ncvars.pl.1 $(DESTDIR)$(mandir)/man1/split_ncvars.1

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -139,7 +139,6 @@ TESTS = \
     split_ncvars/split_ncvars-i \
     split_ncvars/split_ncvars-l \
     split_ncvars/split_ncvars-o \
-    split_ncvars/split_ncvars-p \
     split_ncvars/split_ncvars-s \
     split_ncvars/split_ncvars-v \
     timeavg/timavg \


### PR DESCRIPTION
**Description**
adds an action workflow to trigger when any `<year>.<version>[.<patch>]`  tag is created that will create a new release draft and upload the tarfile created by `make dist`. Once the tag is created and the action runs, the release will be a private draft until someone edits it and hits publish. The draft is set to include the same automatically generated release notes github creates.

Here's an example from my fork after I published it, with the `make dist` generated tar file:

https://github.com/rem1776/FRE-NCtools/releases/tag/2025.14

The uploaded tarfile name will follow whatever version is set in `configure.ac`, regardless of the tag.

I used ubuntu package installs in lieu of a custom image since I can't seem to get past errors building the docs with my spack based images.

This is a draft since the CI is failing right now, thats why I have some build changes in here to get it working. I think it just needs seth's next PR merged and then I'll get rid of any changes besides the workflow yaml.

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
