### PR TITLE
 #358 Exit 0 if all input iceberg restarts are empty

### DIFF
--- a/src/iceberg-comb/iceberg_comb.sh.in
+++ b/src/iceberg-comb/iceberg_comb.sh.in
@@ -321,6 +321,14 @@ then
     exit $EXIT_FAILURE
 fi
 
+# If all the iceberg files are empty, then there is no work to do.
+# Report this to the user and exit 0.
+if [ -z "$combine_files" ]
+then
+    echoerr "$script_name: Iceberg files are empty so no output file is written."
+    exit $EXIT_SUCCESS
+fi
+
 # Need to check if any files have no icebergs (the UNLIMITED dimension
 # has a zero length).  Remove these files from the list of files to
 # combine.


### PR DESCRIPTION
**Description**
Checks to see if all input files are empty. If so, print a message to the user stating all is fine, and exit 0.

Fixes #358 

**How Has This Been Tested?**
I tested it on empty input files and non-empty files.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes
