### PR TITLE
Add --rotate-poly option to transfer_to_mosaic.c

### DIFF
--- a/man/transfer_to_mosaic_grid.txt
+++ b/man/transfer_to_mosaic_grid.txt
@@ -25,6 +25,11 @@ OPTIONS
 
 The file name of previous version grid.
 
+*--rotate_poly*::
+
+Set to calculate polar polygon areas by calculating the area of a copy of the
+polygon, with the copy being rotated far away from the pole.
+
 BUGS
 ----
 Open bug reports at {package_bugreport}.

--- a/src/transfer-mosaic-grid/transfer_to_mosaic.c
+++ b/src/transfer-mosaic-grid/transfer_to_mosaic.c
@@ -27,10 +27,11 @@
 #include "mpp_domain.h"
 #include "mpp_io.h"
 #include "create_xgrid.h"
+#include "mosaic_util.h"
 
 char *usage[] = {
   "",
-  " transfer_to_mosaic_grid --input_file input_file                             ",
+  " transfer_to_mosaic_grid --input_file input_file --rotate_poly               ",
   "                                                                             ",
   " transfer_to_mosaic_grid transfers previous version grid file (The grid file ",
   " has field x_T.y_T ) into a mosaic grid. The input file could be a ocean     ",
@@ -42,6 +43,11 @@ char *usage[] = {
   "                                                                             ",
   "--input_file input_file  The file name of previous version grid.             ",
   "                                                                             ",
+  "OPTIONAL:                                                                    ",
+  "                                                                             ",
+  "--rotate_poly            Set to calculate polar polygon areas by calculating ",
+  "                         the area of a copy of the polygon, with the copy    ",
+  "                         being rotated far away from the pole.               ",
   NULL};  
 const int MAXBOUNDS = 100;
 const int STRINGLEN = 255;
@@ -81,11 +87,13 @@ int main(int argc, char* argv[])
 
   int is_coupled_grid = 0, is_ocean_only =1; 
   int interp_order=1;
+  int rotate_poly=0;
   
   int option_index;
   static struct option long_options[] = {
     {"input_file",       required_argument, NULL, 'o'},
     {"mosaic_dir",       required_argument, NULL, 'd'},    
+    {"rotate_poly",      no_argument,       NULL, 'n'},
     {NULL, 0, NULL, 0}
   };
 
@@ -103,6 +111,9 @@ int main(int argc, char* argv[])
       case 'd':
         strcpy(mosaic_dir, optarg);
 	break;
+      case 'n':
+        rotate_poly = 1;
+	break;
       case '?':
       errflg++;	
     }
@@ -117,7 +128,8 @@ int main(int argc, char* argv[])
     contact_tile1[n]=0; contact_tile2[n]=0;
   }
 			  
-  
+  if(rotate_poly) set_rotate_poly_true();
+
   if(mpp_field_exist(old_file, "AREA_ATMxOCN") ) is_coupled_grid = 1;
   if(mpp_field_exist(old_file, "AREA_ATM") ) is_ocean_only = 0;
   if(mpp_field_exist(old_file, "DI_ATMxOCN") ) interp_order= 2;


### PR DESCRIPTION
**Description**
This PR adds the `--rotate_poly` option to `transfer_to_mosaic.c`. 

Fixes #362 

**How Has This Been Tested?**
I've converted old format grids to mosaic format using the added option. Areas at/near the pole are more sensible than without `--rotate_poly`.

<img width="1260" alt="Screenshot 2025-05-29 at 9 35 23 am" src="https://github.com/user-attachments/assets/37964f24-f855-4e76-acc4-c459db6bb7c8" />

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
