### PR TITLE
add workflow for automatic tag creation

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,27 @@
+name: Tag for release
+on:
+  push:
+    paths:
+      - configure.ac 
+jobs:
+  tag_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Get tag name
+      id: get-tag
+      run: echo "TAGNAME=`grep -o -E '?[0-9]{4}\.[0-9]{2}(\.[0-9]{2})?' configure.ac`" >> "$GITHUB_OUTPUT"
+    - name: Create tag
+      uses: actions/github-script@v5
+      env:
+        TAG: ${{ steps.get-tag.outputs.TAGNAME }}
+      with:
+        script: |
+          const title = process.env.TAG;
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: `refs/tags/${title}`,
+            sha: context.sha
+          })

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -3,6 +3,8 @@ on:
   push:
     paths:
       - configure.ac 
+    branches:
+      - 'main'
 jobs:
   tag_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,21 @@
+# appends -dev to the version upon release and opens pr
+# CI won't run on generated PR, easiest workaround is to close + reopen
+on:
+  release:
+    types: [published]
+jobs:
+  add-dev-to-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.2.2
+    - name: Append version with dev
+      run: sed -i '/20[0-9][0-9]\.[0-9][0-9]/ s/]/-dev]/' configure.ac
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v7.0.6
+      with:
+        base: main                   # creates a new branch off of main
+        branch: add-dev-post-release # name of the created branch
+        branch-suffix: timestamp     # add a timestamp to branch name
+        delete-branch: true          # delete afer merge
+        title: Append dev to version number post-release
+        body: automated change, adds '-dev' to the version number upon releases. This PR will need to be closed and reopened to run CI testing.


### PR DESCRIPTION
**Description**
adds a workflow that grabs the version number from the `configure.ac` and creates a new tag for releases. It will be triggered whenever `configure.ac` is modified but will not overwrite previously created tags. The grep command will match both `xxx.xx.xx` and `xxx.xx` style version numbers. End result basically ensures each new version number committed to main will have a corresponding tag.

Since my other PR is triggered by a tag (#357) and creates the release draft, once these both go in we'd have a (almost) fully automated release process. A PR containing a change to the version number would be merged in to main, and then we would just have to wait for the actions to run and manually release the created draft.

This kind of thing has potential for script injections, so I used a fairly strict grep command and called github's api directly (rather than using normal git commands). Hopefully that will mitigate any dangers, but any opinions are appreciated.

**How Has This Been Tested?**
my forks main branch

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
