### PR TITLE
 #361 Use Netcdf-3 64-bit offset format for split-ncvars single-file …

### DIFF
--- a/src/split_ncvars/split_ncvars.pl.in
+++ b/src/split_ncvars/split_ncvars.pl.in
@@ -495,10 +495,15 @@ foreach my $file (@ifiles) {
     }    ### end of variable loop ###
 
     #--- extract fields for single file option ---
+    # Hard-code Netcdf-3 output format for single-file option
+    # FRE uses the single-file option exclusively for creating the static pp file, which does not work properly with Netcdf-4. This error results:
+    # ERROR NC_ELATEFILL (formerly NC_EFILLVALUE) Attempt to define fill value when data already exists
+    # HINT: NC_ELATEFILL errors can occur when NCO attempts to create, modify, or overwrite a _FillValue attribute
+    # for an existing variable in a netCDF4 file. The netCDF4 format (unlike netCDF3) does not permit this.
     if ( $Opt{onefile} ) {
         my $vlist = join ",", @vlist;
-        print "$ncks -h -A -v $vlist $file $Opt{onefile}\n" if $Opt{VERBOSE} > 0;
-        system("$ncks -h -A -v $vlist $file $Opt{onefile}");
+        print "$ncks -6 -h -A -v $vlist $file $Opt{onefile}\n" if $Opt{VERBOSE} > 0;
+        system("$ncks -6 -h -A -v $vlist $file $Opt{onefile}");
         $ncstatus += $?;
 
         my @ncatted_opts = set_ncatted_opts( $Opt{onefile}, tailname( $Opt{onefile} ) );


### PR DESCRIPTION
**Description**
split-ncvars's "single file output" option must use Netcdf-3 64-bit offset format. Bronx frepp exclusively uses the `-f` single-file option to create a static pp file containing variables from different history files. frepp scripts run `split_ncvars.pl f` looping over the source history files. With Netcdf-4, this usage reliably causes this error:

```
ERROR NC_ELATEFILL (formerly NC_EFILLVALUE) Attempt to define fill value when data already exists
HINT: NC_ELATEFILL errors can occur when NCO attempts to create, modify, or overwrite a _FillValue attribute
for an existing variable in a netCDF4 file. The netCDF4 format (unlike netCDF3) does not permit this.
```

Fixes #361

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes
