### PR TITLE
iceberg-comb.sh to accept iceberg-less input files

### DIFF
--- a/src/iceberg-comb/iceberg_comb.sh.in
+++ b/src/iceberg-comb/iceberg_comb.sh.in
@@ -139,7 +139,7 @@ checkIfIcebergs() {
 
 has_icebergs() {
     # This function will return 0 (true) if the file has icebergs,
-    # that is the UNLIMITED dimenion is >0.  The UNLIMITED dimension
+    # that is the UNLIMITED dimension is >0.  The UNLIMITED dimension
     # line, from ncdump:
     #    <var> = UNLIMITED ; //(<number> currently)
     #

--- a/src/iceberg-comb/iceberg_comb.sh.in
+++ b/src/iceberg-comb/iceberg_comb.sh.in
@@ -330,17 +330,39 @@ do
     has_icebergs $f && combine_files="$combine_files $f"
 done
 
-# Run ncrcat on the files
-ncrcat_cmd="$ncrcat $combine_files $out_file"
-if [ $verbose -gt 0 ]
+# Normally, run ncrcat on the input files. However,
+# if all input files have no icebergs, then use one of the input files
+# as the output file, print a message, and exit normally.
+# This unambigously indicates that there are no icebergs,
+# and the iceberg model can read an iceberg restart with no icebergs.
+if [ -n "$combine_files" ]
 then
-    echoerr "debug1: Running '$ncrcat_cmd'"
-fi
-eval $ncrcat_cmd
-if [ $? -ne 0 ]
-then
-    echoerr "$script_name: Error during executing '$ncrcat_cmd'"
-    exit $EXIT_FAILURE
+    # Run ncrcat on the files
+    ncrcat_cmd="$ncrcat $combine_files $out_file"
+    if [ $verbose -gt 0 ]
+    then
+        echoerr "debug1: Running '$ncrcat_cmd'"
+    fi
+    eval $ncrcat_cmd
+    if [ $? -ne 0 ]
+    then
+        echoerr "$script_name: Error during executing '$ncrcat_cmd'"
+        exit $EXIT_FAILURE
+    fi
+else
+    # Copy first empty iceberg file to the output file
+    echoerr "debug1: Input files contain no icebergs; this is fine"
+    copy_cmd="cp ${in_files%% *} $out_file"
+    if [ $verbose -gt 0 ]
+    then
+        echoerr "debug1: Running '$copy_cmd'"
+    fi
+    $copy_cmd
+    if [ $? -ne 0 ]
+    then
+        echoerr "$script_name: Error during executing '$copy_cmd'"
+        exit $EXIT_FAILURE
+    fi
 fi
 
 ncatted_cmd="$ncatted -a NumFilesInSet,global,d,, $out_file"

--- a/src/iceberg-comb/iceberg_comb.sh.in
+++ b/src/iceberg-comb/iceberg_comb.sh.in
@@ -78,7 +78,7 @@ find_command() {
 get_NumFilesInSet() {
     # Check for the global attribute "NumFilesInSet". If that attribute is
     # found, the function will return the number of files in this set.  If not
-    # found, the funcation will return -1. Get the output from ncdump
+    # found, the function will return -1. Get the output from ncdump
     local output=$($ncdump -h $1)
     local rtn=-1 # Return value if NumFilesInSet not in file
     numFilesInSet=$(echo $output | sed -n 's/.*:NumFilesInSet *= *\([0-9][0-9]*\) *;.*/\1/p')
@@ -333,7 +333,7 @@ done
 # Normally, run ncrcat on the input files. However,
 # if all input files have no icebergs, then use one of the input files
 # as the output file, print a message, and exit normally.
-# This unambigously indicates that there are no icebergs,
+# This unambiguously indicates that there are no icebergs,
 # and the iceberg model can read an iceberg restart with no icebergs.
 if [ -n "$combine_files" ]
 then
@@ -357,7 +357,7 @@ else
     then
         echoerr "debug1: Running '$copy_cmd'"
     fi
-    $copy_cmd
+    eval $copy_cmd
     if [ $? -ne 0 ]
     then
         echoerr "$script_name: Error during executing '$copy_cmd'"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -103,6 +103,7 @@ combine_tests = \
     combine_restarts/extra_options \
     iceberg_comb/check-valid-file \
     iceberg_comb/combine \
+    iceberg_comb/combine-mixed-icebergs \
     iceberg_comb/combine-no-icebergs \
     iceberg_comb/missing-file \
     iceberg_comb/outfile-exists \

--- a/tests/iceberg_comb/combine-mixed-icebergs
+++ b/tests/iceberg_comb/combine-mixed-icebergs
@@ -35,7 +35,7 @@ fi
 ncgen -o iceberg_test.nc.0000 << EOF || framework_failure_
 netcdf iceberg_test.nc {
 dimensions:
-  i = UNLIMITED ; // (0 currently)
+  i = UNLIMITED ; // (5 currently)
 variables:
   double lon(i) ;
     lon:long_name = "longitude" ;
@@ -50,7 +50,9 @@ variables:
                 :file_format_minor_version = 1 ;
                 :time_axis = 0 ;
 data:
-  i = 0 ;
+  i = 5 ;
+  lon = 1, 2, 3, 4, 5 ;
+  lat = 13, 12, 11, 10, 9 ;
 }
 EOF
 
@@ -79,7 +81,7 @@ EOF
 ncgen -o iceberg_test.nc.0002 << EOF || framework_failure_
 netcdf iceberg_test.nc {
 dimensions:
-  i = UNLIMITED ; // (0 currently)
+  i = UNLIMITED ; // (8 currently)
 variables:
   double lon(i) ;
     lon:long_name = "longitude" ;
@@ -94,7 +96,9 @@ variables:
                 :file_format_minor_version = 1 ;
                 :time_axis = 0 ;
 data:
-  i = 0 ;
+  i = 5 ;
+  lon = 6, 7, 8, 9, 10, 11, 12, 13 ;
+  lat = 8, 7, 6, 5, 4, 3, 2, 1 ;
 }
 EOF
 


### PR DESCRIPTION
If input files have no icebergs, then use one of the empty input files as the output file. This will unambiguously indicate that there are no icebergs, and the iceberg model can accept a restart file with no icebergs (per Alex Huth).

**Description**
* Updates iceberg-comb.sh to detect if all input files contain no icebergs; if so, output one of the empty input files as the output file
* Added test`combine-no-icebergs`

Fixes #358 

**How Has This Been Tested?**
Hand-tested on input files with icebergs and input files without icebergs.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
