### PR TITLE
Fix typo in 358.empty-icebergs-2 

### DIFF
--- a/src/iceberg-comb/iceberg_comb.sh.in
+++ b/src/iceberg-comb/iceberg_comb.sh.in
@@ -139,7 +139,7 @@ checkIfIcebergs() {
 
 has_icebergs() {
     # This function will return 0 (true) if the file has icebergs,
-    # that is the UNLIMITED dimenion is >0.  The UNLIMITED dimension
+    # that is the UNLIMITED dimension is >0.  The UNLIMITED dimension
     # line, from ncdump:
     #    <var> = UNLIMITED ; //(<number> currently)
     #


### PR DESCRIPTION
**Description**
This PR fixes a missed typo in iceberg.comb.sh
