### PR TITLE
Restore split_ncvars.pl splitting behavior post NCO 5.1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.tar
 *.gz
 build.fre-nctools*
-build
+build*
 _build
 *.exe
 *.1

--- a/site-configs/gfdl-ws/env.sh
+++ b/site-configs/gfdl-ws/env.sh
@@ -32,18 +32,17 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # Variables to control versions used
-env_version=2024.02
-gcc_version=13.2.0
+env_version=2025.01
+gcc_version=13.3.0
 ncc_version=4.9.2
 ncf_version=4.6.1
-mpi_version=4.2.1
+mpi_version=4.2.3
 
 # Ensure the base spack modules are first in MODULEPATH
 module remove-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
 module prepend-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
 
-# bats, and python are needed for tests
-module load bats
+# python is needed for tests
 module load python
 module load nco
 

--- a/site-configs/gfdl/env.sh
+++ b/site-configs/gfdl/env.sh
@@ -32,18 +32,17 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # Variables to control versions used
-env_version=2024.02
-gcc_version=13.2.0
+env_version=2025.01
+gcc_version=13.3.0
 ncc_version=4.9.2
 ncf_version=4.6.1
-mpi_version=4.2.1
+mpi_version=4.2.3
 
 # Ensure the base spack modules are first in MODULEPATH
 module remove-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
 module prepend-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
 
-# bats, and python are needed for tests
-module load bats
+# python is needed for tests
 module load python
 module load nco
 

--- a/src/split_ncvars/split_ncvars.pl.in
+++ b/src/split_ncvars/split_ncvars.pl.in
@@ -363,9 +363,9 @@ foreach my $file (@ifiles) {
         print "   var=$var; timename=$timename; vlist=$vlist\n" if $Opt{VERBOSE} > 2;
         my $appendopt = "";
         $appendopt = "-A" if ( -f "$cwd/$tmp_var_filename" );
-        print "$ncks -h $appendopt -v $vlist $file $tmp_var_filename\n" if $Opt{VERBOSE};
+        print "$ncks -C -h $appendopt -v $vlist $file $tmp_var_filename\n" if $Opt{VERBOSE};
         next                                                            if $TEST;
-        system("$ncks -h $appendopt -v $vlist $file $tmp_var_filename");
+        system("$ncks -C -h $appendopt -v $vlist $file $tmp_var_filename");
         $ncstatus += $?;
 
         # remove dimensions called "scalar_axis" (i.e., length = 1)
@@ -502,8 +502,8 @@ foreach my $file (@ifiles) {
     # for an existing variable in a netCDF4 file. The netCDF4 format (unlike netCDF3) does not permit this.
     if ( $Opt{onefile} ) {
         my $vlist = join ",", @vlist;
-        print "$ncks -6 -h -A -v $vlist $file $Opt{onefile}\n" if $Opt{VERBOSE} > 0;
-        system("$ncks -6 -h -A -v $vlist $file $Opt{onefile}");
+        print "$ncks -C -6 -h -A -v $vlist $file $Opt{onefile}\n" if $Opt{VERBOSE} > 0;
+        system("$ncks -C -6 -h -A -v $vlist $file $Opt{onefile}");
         $ncstatus += $?;
 
         my @ncatted_opts = set_ncatted_opts( $Opt{onefile}, tailname( $Opt{onefile} ) );

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -143,6 +143,7 @@ TESTS = \
     plevel/plevel-nctypes \
     plevel/plevel-t \
     split_ncvars/split_ncvars \
+    split_ncvars/split_ncvars-f \
     split_ncvars/split_ncvars-i \
     split_ncvars/split_ncvars-l \
     split_ncvars/split_ncvars-o \

--- a/tests/create_plevel_test_ncfile.c
+++ b/tests/create_plevel_test_ncfile.c
@@ -108,6 +108,7 @@ int main(int argc, char **argv) {
     check_err(nc_put_att_text(ncid, pfull_id, "long_name", 23, "ref full pressure level"), __LINE__);
     check_err(nc_put_att_text(ncid, pfull_id, "cartesian_axis", 1, "Z"), __LINE__);
     check_err(nc_put_att_text(ncid, pfull_id, "positive", 4, "down"), __LINE__);
+    check_err(nc_put_att_text(ncid, pfull_id, "formula_terms", 6, "ps: ps"), __LINE__);
 
     check_err(nc_def_var(ncid, "pk", NC_FLOAT, 1, &phalf_dim, &pk_id), __LINE__);
     check_err(nc_put_att_text(ncid, pk_id, "units", 6, "pascal"), __LINE__);

--- a/tests/split_ncvars/split_ncvars-f
+++ b/tests/split_ncvars/split_ncvars-f
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Copyright (C) 2024 Geophysical Fluid Dynamics Laboratory
+
+# This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+
+# FRE-NCtools is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+
+# FRE-NCtools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with FRE-NCTools.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+if test "$VERBOSE" = yes
+then
+    set -x
+    command -v split_ncvars.pl --version
+fi
+
+. ${srcdir=.}/init.sh; path_prepend_ ../../src
+
+# Need to use the included list_ncvars.sh script.  Otherwise,
+# split_ncvars will look for list_ncvars.sh in the installed bin
+# directory.
+export LIST_NCVARS=$(readlink -f ../../src/list_ncvars.sh)
+
+# list_ncvars.sh needs to know where to find the built list_ncvars
+# executable.
+export PKGLIBEXECDIR=$(readlink -f ../../src)
+
+# Use the test netCDF files from plevel
+${builddir=..}/create_plevel_test_ncfile || framework_failure_ "failed to create plevel test files"
+mkdir idir || framework_failure_ "failed to create idir"
+mv test_input.nc idir || framework_failure_ "failed to move test_input.nc to idir"
+
+# Extract a static variable whose formula_terms contains a variable that contains time.
+# The output file should NOT contain time.
+split_ncvars.pl -v pfull -i idir test_input.nc -f output.nc || fail_ split_ncvars.pl test_input.nc failed
+
+# Check that the output.nc file was created, that it has pfull in it, and does not have time in it
+test -f output.nc || fail_ output.nc not created
+if ncdump -v time output.nc
+then
+    # Expected failure
+    fail_ "output.nc incorrectly contains time"
+fi
+ncdump -v pfull output.nc || fail_ "output.nc does not contain output variable pfull"


### PR DESCRIPTION
**Description**
NCO tools 5.1.9 changed the behavior of ncks to include more referenced variables in the split-out files. These extra variables turn out to be undesired FRE users, so this reverts to the previous behavior.

Fixes #372

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes
