### PR TITLE
Fix combine-restarts file glob bug

### DIFF
--- a/src/combine-restarts/combine_restarts.in
+++ b/src/combine-restarts/combine_restarts.in
@@ -54,7 +54,7 @@ verbose=0
 remove_files=0
 dryrun=0
 combineNccOpts=""
-mppCombOpts_default='-64 -h 16384 -m'
+mppCombOpts_default='-h 16384 -m'
 mppCombOpts="$mppCombOpts_default"
 
 while getopts :hC:M:nrvV OPT; do
@@ -119,7 +119,7 @@ do
     then
         echoerr "debug1: processing for combined file '${f}'"
     fi
-    inputFiles=$( ls -1 | @EGREP@ "${f}${patternGrepTail}" | xargs )
+    inputFiles=$( ls -1 | @EGREP@ "^${f}${patternGrepTail}" | xargs )
     if [ $( echo ${inputFiles} | wc -w ) -gt 0 ]
     then
         # Check if file is a compressed file

--- a/tests/combine_restarts/glob_bugfix
+++ b/tests/combine_restarts/glob_bugfix
@@ -1,0 +1,118 @@
+#!/bin/sh
+
+# Copyright (C) 2024 Geophysical Fluid Dynamics Laboratory
+
+# This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+
+# FRE-NCtools is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+
+# FRE-NCtools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with FRE-NCTools.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+# Create two similar input files that will expose a previous bug.
+# e.g. land and testland
+# Verify that the combine line for land does not include testland.
+if test "$VERBOSE" = yes
+then
+    set -x
+    command -v combine_restarts
+    combine_restarts -V
+fi
+
+. "$srcdir/init.sh"
+
+ncgen -o land.nc.0000 << EOF || framework_failure_
+netcdf land.nc {
+dimensions:
+  lat = 10 ;
+  lon = 10 ;
+  lpt = 5 ;
+variables:
+  int lpt(lpt) ;
+    lpt:compress = "lat lon" ;
+  float lst(lpt);
+  float lat(lat) ;
+  float lon(lon) ;
+data:
+  lon = 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ;
+  lat = 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ;
+  lpt = 1, 5, 22, 35, 47 ;
+  lst = 100.0, 101.0, 102.0, 103.0, 104.0 ;
+}
+EOF
+
+ncgen -o land.nc.0001 << EOF || framework_failure_
+netcdf land.nc {
+dimensions:
+  lat = 10 ;
+  lon = 10 ;
+  lpt = 5 ;
+variables:
+  int lpt(lpt) ;
+    lpt:compress = "lat lon" ;
+  float lst(lpt);
+  float lat(lat) ;
+  float lon(lon) ;
+data:
+  lon = 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ;
+  lat = 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ;
+  lpt = 51, 63, 64, 77, 94 ;
+  lst = 105.0, 106.0, 107.0, 108.0, 109.0 ;
+}
+EOF
+
+ncgen -o testland.nc.0000 << EOF || framework_failure_
+netcdf testland.nc {
+dimensions:
+  lat = 10 ;
+  lon = 10 ;
+  lpt = 5 ;
+variables:
+  int lpt(lpt) ;
+    lpt:compress = "lat lon" ;
+  float lst(lpt);
+  float lat(lat) ;
+  float lon(lon) ;
+data:
+  lon = 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ;
+  lat = 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ;
+  lpt = 1, 5, 22, 35, 47 ;
+  lst = 100.0, 101.0, 102.0, 103.0, 104.0 ;
+}
+EOF
+
+ncgen -o testland.nc.0001 << EOF || framework_failure_
+netcdf testland.nc {
+dimensions:
+  lat = 10 ;
+  lon = 10 ;
+  lpt = 5 ;
+variables:
+  int lpt(lpt) ;
+    lpt:compress = "lat lon" ;
+  float lst(lpt);
+  float lat(lat) ;
+  float lon(lon) ;
+data:
+  lon = 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ;
+  lat = 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ;
+  lpt = 51, 63, 64, 77, 94 ;
+  lst = 105.0, 106.0, 107.0, 108.0, 109.0 ;
+}
+EOF
+
+output=$(combine_restarts -n 2>&1) || fail_ Dry run failed
+
+# Verify that the combined "land" file does not contain "testland"
+echo "$output" | grep "combine-ncc land.nc.0000 land.nc.0001 land.nc" || fail_ land combining line incorrect in output "\n******\n$output\n******"
+
+Exit $fail


### PR DESCRIPTION
**Description**
File globbing expression on line 122,

```
inputFiles=$( ls -1 | @EGREP@ "${f}${patternGrepTail}" | xargs )
```

was too expansive. If there are input files of the form "FOO$f", then they too will be included in the combined restart.

The fix is to use a beginning-of-string anchor `^` to prevent FOO$f files from being included.

As a bonus, remove the hard-coded Netcdf-3 option from mppnccombine as it is no longer needed (mppnccombine will use the format of the input file).

Fixes #364

**How Has This Been Tested?**
Used the test case provided in #364. Added a test case to prevent the bug from returning.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
