### PR TITLE
Fix bad xgrid along zero longitude when LND grid not same as ATM

### DIFF
--- a/src/make-coupler-mosaic/make_coupler_mosaic.c
+++ b/src/make-coupler-mosaic/make_coupler_mosaic.c
@@ -1662,7 +1662,15 @@ int main (int argc, char *argv[])
 	    if(lnd_frac > MIN_AREA_FRAC) { /* over land */
 	      /* find the overlap of atmxlnd and ocean cell */
 	      for(l=0; l<count; l++) {
-		if( clip_method == GREAT_CIRCLE_CLIP )
+            /*Apply a longitude fix to ocean cell xo based on the center of the atmxlnd cell
+            Otherwise, when lnd and atm grids are not the same some exchange grids may be missed, particularly around the Prime Meridian lon=0 
+            */
+            if(!lnd_same_as_atm){
+              no_in = fix_lon (xo, yo, 4, atmxlnd_x[l][0]); //Shifts xo so the center to be within atmxlnd_x[l][0]-pi to atmxlnd_x[l][0]+pi, 
+              xo_min = minval_double (no_in, xo);
+              xo_max = maxval_double (no_in, xo);		
+           }
+    if( clip_method == GREAT_CIRCLE_CLIP )
 		  n_out = clip_2dx2d_great_circle(atmxlnd_x[l], atmxlnd_y[l], atmxlnd_z[l], num_v[l], xo, yo, zo, 4,
 						  x_out, y_out, z_out);
 		else {


### PR DESCRIPTION
- Address issue #366
- When LND grid is not the same as ATM the xgrid is wrong along the Prime Meridian, E.g., if ATM is c96 and LND is c48, the xgrid cell areas are small by almost a factor of 2 along longitude=0 and the land mask has a spurious line along longitude=0
- The root cause is the Ocean grid is shifted right by 360 degree assuming that the land and atmos grids are the same which cause the atmXlnd exchange grid cells that are just to the left of the longitude=0 to be ignored.
- The fix is to (re)apply the fixlon to shift Ocean grid based on the atmxlnd_x[l][0] rather than the atm_avg.

**Description**
Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes # (issue)

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes
