### PR TITLE
Update gaea site files

### DIFF
--- a/site-configs/ncrc5/env.sh
+++ b/site-configs/ncrc5/env.sh
@@ -33,17 +33,13 @@
 
 module rm PrgEnv-pgi PrgEnv-intel PrgEnv-gnu PrgEnv-cray
 module load python
-module load PrgEnv-gnu/8.5.0
-module load gcc-native/12.3
+module load PrgEnv-gnu/8.6.0
+module load gcc-native/14.2
 module load cray-hdf5/1.12.2.11
-module load cray-netcdf/4.9.0.9
+module load cray-netcdf/4.9.0.11
 
 # Additional required modules
-module load nco/5.1.9
-
-# Add bats to PATH
-# Needed for testing
-module append-path PATH /ncrc/home2/Seth.Underwood/opt/bats/0.4.0/bin
+module load nco
 
 # **********************************************************************
 # Set environment variablesSetup and Load the Modules

--- a/site-configs/ncrc6/env.sh
+++ b/site-configs/ncrc6/env.sh
@@ -33,17 +33,13 @@
 
 module rm PrgEnv-pgi PrgEnv-intel PrgEnv-gnu PrgEnv-cray
 module load python
-module load PrgEnv-gnu/8.5.0
-module load gcc-native/12.3
+module load PrgEnv-gnu/8.6.0
+module load gcc-native/14.2
 module load cray-hdf5/1.12.2.11
-module load cray-netcdf/4.9.0.9
+module load cray-netcdf/4.9.0.11
 
 # Additional required modules
-module load nco/5.1.9
-
-# Add bats to PATH
-# Needed for testing
-module append-path PATH /ncrc/home2/Seth.Underwood/opt/bats/0.4.0/bin
+module load nco
 
 # **********************************************************************
 # Set environment variablesSetup and Load the Modules

--- a/tests/init.cfg
+++ b/tests/init.cfg
@@ -16,9 +16,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Get the number of CPUs on the current system.
+# If $SLURM_NTASKS is set, return it instead.
 get_ncpu_()
 {
-    if sysctl -n hw.physicalcpu >/dev/null 2>&1
+    if [ -n "$SLURM_NTASKS" ]
+    then
+        ncpu=$SLURM_NTASKS
+    elif sysctl -n hw.physicalcpu >/dev/null 2>&1
     then
         ncpu=$(sysctl -n hw.physicalcpu)
     elif nproc --all >/dev/null 2>&1


### PR DESCRIPTION
**Description**
For production deployment we use Spack. For testing, we use the `site-configs/<site>/env.sh` to set a suitable build environment for GFDL sites.

This updates the ncrc5 and ncrc6 development env.sh site files.

Also, while testing I found that the `make_topog/ocean-topog-mpi` and `make_coupler_mosaic/coupled-model-mpi` tests were failing due to two `srun` failures.
1. $SLURM_PARTITION is not set
2. srun --ntasks is getting set to the number of cores on the node, which is too high and inappropriate for gaea login nodes

I worked around this by setting $SLURM_PARTITION and $SLURM_NTASKS outside of the test environment. However, because the `srun --ntasks` option takes precedence over the environment variable, I modified the helper utility `get_ncpu_` to return $SLURM_NTASKS if it is set.

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [x] `make distcheck` passes
