### PR TITLE
Update package version to 2026.01; will trigger release actions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@
 AC_PREREQ([2.63])
 AC_INIT(
   [FRE NCTools],
-  [2024.05.02],
+  [2026.01],
   [https://github.com/NOAA-GFDL/FRE-NCtools/issues],
   [fre-nctools],
   [https://github.com/NOAA-GFDL/FRE-NCtools])


### PR DESCRIPTION
**Description**
Update the package version to 2026.01, which upon merging will tag and release (see https://github.com/NOAA-GFDL/FRE-NCtools/pull/364 )

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes
