### PR TITLE
Keep the coordinate variables in regular split-ncvars usage

### DIFF
--- a/src/split_ncvars/split_ncvars.pl.in
+++ b/src/split_ncvars/split_ncvars.pl.in
@@ -363,9 +363,9 @@ foreach my $file (@ifiles) {
         print "   var=$var; timename=$timename; vlist=$vlist\n" if $Opt{VERBOSE} > 2;
         my $appendopt = "";
         $appendopt = "-A" if ( -f "$cwd/$tmp_var_filename" );
-        print "$ncks -C -h $appendopt -v $vlist $file $tmp_var_filename\n" if $Opt{VERBOSE};
+        print "$ncks -h $appendopt -v $vlist $file $tmp_var_filename\n" if $Opt{VERBOSE};
         next                                                            if $TEST;
-        system("$ncks -C -h $appendopt -v $vlist $file $tmp_var_filename");
+        system("$ncks -h $appendopt -v $vlist $file $tmp_var_filename");
         $ncstatus += $?;
 
         # remove dimensions called "scalar_axis" (i.e., length = 1)


### PR DESCRIPTION
Only omit them when generating the statics with single-file option.

**Description**
Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes #373 

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes
