### PR TITLE
Fix compilation error and logic bug in mosaic_util.c

### DIFF
--- a/lib/libfrencutils/mosaic_util.c
+++ b/lib/libfrencutils/mosaic_util.c
@@ -1691,13 +1691,13 @@ int crosses_pole(const double x[] , int n) {
 void set_the_rotation_matrix() {
   static const double is2 = 1.0 /M_SQRT2;
 
-  static const double m00 = 0;
-  static const double m01 = - is2;
-  static const double m02 = is2;
-  static const double m11 = 1.0/2;
-  static const double m12 = 0.5;
+  const double m00 = 0;
+  const double m01 = - is2;
+  const double m02 = is2;
+  const double m11 = 1.0/2;
+  const double m12 = 0.5;
 
-  static const double m[3][3] = { {m00, m01, m02}, {m02, m11, m12},{m01, m12, m11} };
+  const double m[3][3] = { {m00, m01, m02}, {m02, m11, m12},{m01, m12, m11} };
 
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {


### PR DESCRIPTION
This change resolves a build failure in mosaic_util.c where a static const double array (m[3][3])was being initialized with variables calculated at runtime. Standard C requires static variables to be initialized with compile-time constants, which caused GCC to throw an "initializer element is not constant" error.

Removing the static keyword not only fixes the compilation issue but also corrects a likely logic bug. As an automatic local variable, the rotation matrix will now accurately populate with fresh, updated values on every function call, ensuring mathematical correctness and thread safety.

**Description**
Using intel-classic compilers, mosaic_util.c fails to compile. (GCC does not have this problem)

```
cc -DHAVE_CONFIG_H -I. -I../../lib -I..    -DpgiFortran -I/opt/cray/pe/netcdf/4.9.0.11/intel/2023.2/include -O2 -MT libfrencutils/mosaic_util.o -MD -MP -MF $depbase.Tpo -c -o libfrencutils/mosaic_util.o ../../lib/libfrencutils/mosaic_util.c &&\
mv -f $depbase.Tpo $depbase.Po
icc: remark #10441: The Intel(R) C++ Compiler Classic (ICC) is deprecated and will be removed from product release in the second half of 2023. The Intel(R) oneAPI DPC++/C++ Compiler (ICX) is the recommended compiler moving forward. Please transition to use this compiler. Use '-diag-disable=10441' to disable this message.
../../lib/libfrencutils/mosaic_util.c(1695): error: expression must have a constant value
    static const double m01 = - is2;
                                ^

../../lib/libfrencutils/mosaic_util.c(1696): error: expression must have a constant value
    static const double m02 = is2;
                              ^

../../lib/libfrencutils/mosaic_util.c(1700): error: expression must have a constant value
    static const double m[3][3] = { {m00, m01, m02}, {m02, m11, m12},{m01, m12, m11} };
                                     ^

../../lib/libfrencutils/mosaic_util.c(1700): error: expression must have a constant value
    static const double m[3][3] = { {m00, m01, m02}, {m02, m11, m12},{m01, m12, m11} };
                                          ^

../../lib/libfrencutils/mosaic_util.c(1700): error: expression must have a constant value
    static const double m[3][3] = { {m00, m01, m02}, {m02, m11, m12},{m01, m12, m11} };
```

Fixes #380

**How Has This Been Tested?**
Test suite passes on gaea and GFDL workstations.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
