### PR TITLE
Make MAXXGRID runtime-configurable via --maxxgrid flag

### DIFF
--- a/lib/libfrencutils/create_xgrid.c
+++ b/lib/libfrencutils/create_xgrid.c
@@ -37,14 +37,30 @@ int inside_edge(double x0, double y0, double x1, double y1, double x, double y);
 int line_intersect_2D_3D(double *a1, double *a2, double *q1, double *q2, double *q3,
 		         double *intersect, double *u_a, double *u_q, int *inbound);
 
+/* Global variable to store runtime MAXXGRID value */
+static size_t g_maxxgrid = 1e6;  /* Default: 1 million */
+
+/*******************************************************************************
+  void set_maxxgrid
+  Set the maximum exchange grid size at runtime.
+*******************************************************************************/
+void set_maxxgrid(size_t value)
+{
+  g_maxxgrid = value;
+}
+
+void set_maxxgrid_(size_t *value)
+{
+  set_maxxgrid(*value);
+}
 
 /*******************************************************************************
   int get_maxxgrid
-  return constants MAXXGRID.
+  Return the current MAXXGRID value (runtime configurable).
 *******************************************************************************/
 int get_maxxgrid(void)
 {
-  return MAXXGRID;
+  return (int)g_maxxgrid;
 }
 
 int get_maxxgrid_(void)
@@ -278,7 +294,7 @@ int create_xgrid_1dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
 	  i_out[nxgrid]   = i2;
 	  j_out[nxgrid]   = j2;
 	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+	  if(nxgrid > get_maxxgrid()) error_handler("nxgrid exceeds MAXXGRID limit; increase the value using --maxxgrid flag or reduce grid resolution");
 	}
       }
     }
@@ -379,7 +395,7 @@ int create_xgrid_1dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
 	  i_out[nxgrid]   = i2;
 	  j_out[nxgrid]   = j2;
 	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+	  if(nxgrid > get_maxxgrid()) error_handler("nxgrid exceeds MAXXGRID limit; increase the value using --maxxgrid flag or reduce grid resolution");
 	}
       }
     }
@@ -478,7 +494,7 @@ int create_xgrid_2dx1d_order1(const int *nlon_in, const int *nlat_in, const int 
 	  i_out[nxgrid]   = i2;
 	  j_out[nxgrid]   = j2;
 	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+	  if(nxgrid > get_maxxgrid()) error_handler("nxgrid exceeds MAXXGRID limit; increase the value using --maxxgrid flag or reduce grid resolution");
 	}
       }
     }
@@ -584,7 +600,7 @@ int create_xgrid_2dx1d_order2(const int *nlon_in, const int *nlat_in, const int 
 	  i_out[nxgrid] = i2;
 	  j_out[nxgrid] = j2;
 	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+	  if(nxgrid > get_maxxgrid()) error_handler("nxgrid exceeds MAXXGRID limit; increase the value using --maxxgrid flag or reduce grid resolution");
 	}
       }
     }
@@ -664,7 +680,7 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
   pstart = (int *)malloc(nblocks*sizeof(int));
   pnxgrid = (int *)malloc(nblocks*sizeof(int));
 
-  nxgrid_block_max = MAXXGRID/nblocks;
+  nxgrid_block_max = get_maxxgrid()/nblocks;
 
   for(m=0; m<nblocks; m++) {
     pnxgrid[m] = 0;
@@ -679,11 +695,11 @@ int create_xgrid_2dx2d_order1(const int *nlon_in, const int *nlat_in, const int 
     pxgrid_area = xgrid_area;
   }
   else {
-    pi_in = (int *)malloc(MAXXGRID*sizeof(int));
-    pj_in = (int *)malloc(MAXXGRID*sizeof(int));
-    pi_out = (int *)malloc(MAXXGRID*sizeof(int));
-    pj_out = (int *)malloc(MAXXGRID*sizeof(int));
-    pxgrid_area = (double *)malloc(MAXXGRID*sizeof(double));
+    pi_in = (int *)malloc(get_maxxgrid()*sizeof(int));
+    pj_in = (int *)malloc(get_maxxgrid()*sizeof(int));
+    pi_out = (int *)malloc(get_maxxgrid()*sizeof(int));
+    pj_out = (int *)malloc(get_maxxgrid()*sizeof(int));
+    pxgrid_area = (double *)malloc(get_maxxgrid()*sizeof(double));
   }
 
   npts_left = nx2*ny2;
@@ -806,9 +822,9 @@ nxgrid = 0;
 	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
 	  if( xarea/min_area > AREA_RATIO_THRESH ) {
 	    pnxgrid[m]++;
-            if(pnxgrid[m]>= MAXXGRID/nthreads)
+            if(pnxgrid[m]>= get_maxxgrid()/nthreads)
 	      error_handler("The xgrid size is too large for resources.\n"
-        " nxgrid is greater than MAXXGRID/nthreads; increase MAXXGRID,\n"
+        " nxgrid exceeds MAXXGRID/nthreads limit; increase MAXXGRID using --maxxgrid flag,\n"
         " decrease nthreads, or increase number of MPI ranks.");
 	    nn = pstart[m] + pnxgrid[m]-1;
 
@@ -937,7 +953,7 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
   pstart = (int *)malloc(nblocks*sizeof(int));
   pnxgrid = (int *)malloc(nblocks*sizeof(int));
 
-  nxgrid_block_max = MAXXGRID/nblocks;
+  nxgrid_block_max = get_maxxgrid()/nblocks;
 
   for(m=0; m<nblocks; m++) {
     pnxgrid[m] = 0;
@@ -954,13 +970,13 @@ int create_xgrid_2dx2d_order2(const int *nlon_in, const int *nlat_in, const int 
     pxgrid_clat = xgrid_clat;
   }
   else {
-    pi_in = (int *)malloc(MAXXGRID*sizeof(int));
-    pj_in = (int *)malloc(MAXXGRID*sizeof(int));
-    pi_out = (int *)malloc(MAXXGRID*sizeof(int));
-    pj_out = (int *)malloc(MAXXGRID*sizeof(int));
-    pxgrid_area = (double *)malloc(MAXXGRID*sizeof(double));
-    pxgrid_clon = (double *)malloc(MAXXGRID*sizeof(double));
-    pxgrid_clat = (double *)malloc(MAXXGRID*sizeof(double));
+    pi_in = (int *)malloc(get_maxxgrid()*sizeof(int));
+    pj_in = (int *)malloc(get_maxxgrid()*sizeof(int));
+    pi_out = (int *)malloc(get_maxxgrid()*sizeof(int));
+    pj_out = (int *)malloc(get_maxxgrid()*sizeof(int));
+    pxgrid_area = (double *)malloc(get_maxxgrid()*sizeof(double));
+    pxgrid_clon = (double *)malloc(get_maxxgrid()*sizeof(double));
+    pxgrid_clat = (double *)malloc(get_maxxgrid()*sizeof(double));
   }
 
   npts_left = nx2*ny2;
@@ -1084,8 +1100,8 @@ nxgrid = 0;
 	  min_area = min(area_in[j1*nx1+i1], area_out[j2*nx2+i2]);
 	  if( xarea/min_area > AREA_RATIO_THRESH ) {
 	    pnxgrid[m]++;
-            if(pnxgrid[m]>= MAXXGRID/nthreads)
-	      error_handler("nxgrid is greater than MAXXGRID/nthreads, increase MAXXGRID, decrease nthreads, or increase number of MPI ranks");
+            if(pnxgrid[m]>= get_maxxgrid()/nthreads)
+	      error_handler("nxgrid exceeds MAXXGRID/nthreads limit; increase MAXXGRID using --maxxgrid flag, decrease nthreads, or increase number of MPI ranks");
 	    nn = pstart[m] + pnxgrid[m]-1;
 	    pxgrid_area[nn] = xarea;
 	    pxgrid_clon[nn] = poly_ctrlon(x_out, y_out, n_out, lon_in_avg);
@@ -1444,7 +1460,7 @@ int create_xgrid_great_circle(const int *nlon_in, const int *nlat_in, const int 
 	  i_out[nxgrid]      = i2;
 	  j_out[nxgrid]      = j2;
 	  ++nxgrid;
-	  if(nxgrid > MAXXGRID) error_handler("nxgrid is greater than MAXXGRID, increase MAXXGRID");
+	  if(nxgrid > get_maxxgrid()) error_handler("nxgrid exceeds MAXXGRID limit; increase the value using --maxxgrid flag or reduce grid resolution");
 	}
       }
     }
@@ -3036,13 +3052,13 @@ int main(int argc, char* argv[])
       double *xarea, *xclon, *xclat, *mask1;
 
       mask1 = (double *)malloc(nlon1*nlat1*sizeof(double));
-      i1    = (int    *)malloc(MAXXGRID*sizeof(int));
-      j1    = (int    *)malloc(MAXXGRID*sizeof(int));
-      i2    = (int    *)malloc(MAXXGRID*sizeof(int));
-      j2    = (int    *)malloc(MAXXGRID*sizeof(int));
-      xarea = (double *)malloc(MAXXGRID*sizeof(double));
-      xclon = (double *)malloc(MAXXGRID*sizeof(double));
-      xclat = (double *)malloc(MAXXGRID*sizeof(double));
+      i1    = (int    *)malloc(get_maxxgrid()*sizeof(int));
+      j1    = (int    *)malloc(get_maxxgrid()*sizeof(int));
+      i2    = (int    *)malloc(get_maxxgrid()*sizeof(int));
+      j2    = (int    *)malloc(get_maxxgrid()*sizeof(int));
+      xarea = (double *)malloc(get_maxxgrid()*sizeof(double));
+      xclon = (double *)malloc(get_maxxgrid()*sizeof(double));
+      xclat = (double *)malloc(get_maxxgrid()*sizeof(double));
 
       for(i=0; i<nlon1*nlat1; i++) mask1[i] = 1.0;
 

--- a/lib/libfrencutils/create_xgrid.h
+++ b/lib/libfrencutils/create_xgrid.h
@@ -36,6 +36,7 @@ double poly_ctrlon(const double lon[], const double lat[], int n, double clon);
 double poly_ctrlat(const double lon[], const double lat[], int n);
 double box_ctrlon(double ll_lon, double ll_lat, double ur_lon, double ur_lat, double clon);
 double box_ctrlat(double ll_lon, double ll_lat, double ur_lon, double ur_lat);
+void set_maxxgrid(size_t value);
 int get_maxxgrid(void);
 void get_grid_area(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);
 void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *lon, const double *lat, double *area);

--- a/lib/libfrencutils/interp.c
+++ b/lib/libfrencutils/interp.c
@@ -268,11 +268,11 @@ void conserve_interp(int nx_src, int ny_src, int nx_dst, int ny_dst, const doubl
   double *xgrid_area, *dst_area, *area_frac;
 
   /* get the exchange grid between source and destination grid. */
-  xgrid_i1   = (int    *)malloc(MAXXGRID*sizeof(int));
-  xgrid_j1   = (int    *)malloc(MAXXGRID*sizeof(int));
-  xgrid_i2   = (int    *)malloc(MAXXGRID*sizeof(int));
-  xgrid_j2   = (int    *)malloc(MAXXGRID*sizeof(int));
-  xgrid_area = (double *)malloc(MAXXGRID*sizeof(double));
+  xgrid_i1   = (int    *)malloc(get_maxxgrid()*sizeof(int));
+  xgrid_j1   = (int    *)malloc(get_maxxgrid()*sizeof(int));
+  xgrid_i2   = (int    *)malloc(get_maxxgrid()*sizeof(int));
+  xgrid_j2   = (int    *)malloc(get_maxxgrid()*sizeof(int));
+  xgrid_area = (double *)malloc(get_maxxgrid()*sizeof(double));
   dst_area   = (double *)malloc(nx_dst*ny_dst*sizeof(double));
   nxgrid = create_xgrid_2dx2d_order1(&nx_src, &ny_src, &nx_dst, &ny_dst, x_src, y_src, x_dst, y_dst, mask_src,
 	                       xgrid_i1, xgrid_j1, xgrid_i2, xgrid_j2, xgrid_area );
@@ -318,13 +318,13 @@ void conserve_interp_great_circle(int nx_src, int ny_src, int nx_dst, int ny_dst
   double *xgrid_area, *dst_area, *area_frac, *xgrid_di, *xgrid_dj;
 
   /* get the exchange grid between source and destination grid. */
-  xgrid_i1   = (int    *)malloc(MAXXGRID*sizeof(int));
-  xgrid_j1   = (int    *)malloc(MAXXGRID*sizeof(int));
-  xgrid_i2   = (int    *)malloc(MAXXGRID*sizeof(int));
-  xgrid_j2   = (int    *)malloc(MAXXGRID*sizeof(int));
-  xgrid_area = (double *)malloc(MAXXGRID*sizeof(double));
-  xgrid_di   = (double *)malloc(MAXXGRID*sizeof(double));
-  xgrid_dj   = (double *)malloc(MAXXGRID*sizeof(double));
+  xgrid_i1   = (int    *)malloc(get_maxxgrid()*sizeof(int));
+  xgrid_j1   = (int    *)malloc(get_maxxgrid()*sizeof(int));
+  xgrid_i2   = (int    *)malloc(get_maxxgrid()*sizeof(int));
+  xgrid_j2   = (int    *)malloc(get_maxxgrid()*sizeof(int));
+  xgrid_area = (double *)malloc(get_maxxgrid()*sizeof(double));
+  xgrid_di   = (double *)malloc(get_maxxgrid()*sizeof(double));
+  xgrid_dj   = (double *)malloc(get_maxxgrid()*sizeof(double));
   dst_area   = (double *)malloc(nx_dst*ny_dst*sizeof(double));
   nxgrid = create_xgrid_great_circle(&nx_src, &ny_src, &nx_dst, &ny_dst, x_src, y_src, x_dst, y_dst, mask_src,
 				     xgrid_i1, xgrid_j1, xgrid_i2, xgrid_j2, xgrid_area, xgrid_di, xgrid_dj );

--- a/man/fregrid.txt
+++ b/man/fregrid.txt
@@ -1,6 +1,6 @@
 // These are words to have cspell ignore in this file
 // cspell:ignore --nlon --nlat --Klevel --Lstep
-// cspell:ignore --dst_vgrid --nthreads
+// cspell:ignore --dst_vgrid --nthreads --maxxgrid
 
 fregrid(1)
 ==========
@@ -268,6 +268,13 @@ input file settings.
 
 If using NetCDF4 , use shuffle if 1 and don't use if 0 Defaults to
 input file settings.
+
+*--maxxgrid* _size_::
+
+Set maximum exchange grid size. Controls memory allocation for remapping
+operations. Default: 1e6 (1 million). Increase this value if you encounter
+'nxgrid exceeds MAXXGRID' errors when working with high-resolution grids.
+Valid range: 1e3 to 1e10.
 
 EXAMPLES
 --------

--- a/src/fre-grid/conserve_interp.c
+++ b/src/fre-grid/conserve_interp.c
@@ -125,13 +125,13 @@ void setup_conserve_interp(int ntiles_in, const Grid_config *grid_in, int ntiles
     if(mpp_pe() == mpp_root_pe())printf("NOTE: Finish reading index and weight for conservative interpolation from file.\n");
   }
   else {
-    i_in       = (int    *)malloc(MAXXGRID   * sizeof(int   ));
-    j_in       = (int    *)malloc(MAXXGRID   * sizeof(int   ));
-    i_out      = (int    *)malloc(MAXXGRID   * sizeof(int   ));
-    j_out      = (int    *)malloc(MAXXGRID   * sizeof(int   ));
-    xgrid_area = (double *)malloc(MAXXGRID   * sizeof(double));
-    xgrid_clon = (double *)malloc(MAXXGRID   * sizeof(double));
-    xgrid_clat = (double *)malloc(MAXXGRID   * sizeof(double));;
+    i_in       = (int    *)malloc(get_maxxgrid()   * sizeof(int   ));
+    j_in       = (int    *)malloc(get_maxxgrid()   * sizeof(int   ));
+    i_out      = (int    *)malloc(get_maxxgrid()   * sizeof(int   ));
+    j_out      = (int    *)malloc(get_maxxgrid()   * sizeof(int   ));
+    xgrid_area = (double *)malloc(get_maxxgrid()   * sizeof(double));
+    xgrid_clon = (double *)malloc(get_maxxgrid()   * sizeof(double));
+    xgrid_clat = (double *)malloc(get_maxxgrid()   * sizeof(double));;
     cell_in    = (CellStruct *)malloc(ntiles_in * sizeof(CellStruct));
     for(m=0; m<ntiles_in; m++) {
       nx_in = grid_in[m].nx;

--- a/src/fre-grid/fregrid.c
+++ b/src/fre-grid/fregrid.c
@@ -54,6 +54,7 @@
 #include "conserve_interp.h"
 #include "bilinear_interp.h"
 #include "fregrid_util.h"
+#include "create_xgrid.h"
 
 char *usage[] = {
   "",
@@ -266,6 +267,11 @@ char *usage[] = {
   "--shuffle #                   If using NetCDF4 , use shuffle if 1 and don't use if 0  ",
   "                              Defaults to input file settings.                        ",
   "                                                                                      ",
+  "--maxxgrid #                  Set maximum exchange grid size. Controls memory          ",
+  "                              allocation for remapping operations. Default: 1e6       ",
+  "                              (1 million). Increase if you encounter 'nxgrid exceeds  ",
+  "                              MAXXGRID' errors with high-resolution grids.            ",
+  "                                                                                      ",
   "  Example 1: Remap C48 data onto N45 grid.                                            ",
   "             (use GFDL-CM3 data as example)                                           ",
   "   fregrid --input_mosaic C48_mosaic.nc --input_dir input_dir --input_file input_file ",
@@ -406,6 +412,7 @@ int main(int argc, char* argv[])
     {"deflation",        required_argument, NULL, 'S'},
     {"shuffle",          required_argument, NULL, 'T'},
     {"format",           required_argument, NULL, 'U'},
+    {"maxxgrid",         required_argument, NULL, 'V'},
     {"help",             no_argument,       NULL, 'h'},
     {0, 0, 0, 0},
   };
@@ -557,6 +564,15 @@ int main(int argc, char* argv[])
 	break;
     case 'U':
       format = optarg;
+      break;
+    case 'V':
+      {
+        size_t maxxgrid_val = (size_t)atof(optarg);
+        if(maxxgrid_val < 1e3 || maxxgrid_val > 1e10) {
+          mpp_error("fregrid: --maxxgrid value must be between 1e3 and 1e10");
+        }
+        set_maxxgrid(maxxgrid_val);
+      }
       break;
     case '?':
       errflg++;

--- a/src/make-coupler-mosaic/make_coupler_mosaic.c
+++ b/src/make-coupler-mosaic/make_coupler_mosaic.c
@@ -132,6 +132,11 @@ char *usage[] = {
   " ",
   "--verbose                      Set --verbose to print out messages during running.        ",
   "",
+  "--maxxgrid #                   Set maximum exchange grid size. Controls memory allocation ",
+  "                               for remapping operations. Default: 1e6 (1 million). Increase ",
+  "                               if you encounter 'exceeds MAXXGRID' errors with high-resolution ",
+  "                               grids. Valid range: 1e3 to 1e10.                             ",
+  "",
 
   "A sample call to make_coupler_mosaic that makes exchange grids for atmosphere, land and ocean ",
   "mosaic (atmosphere and land are coincident) is: ",
@@ -420,6 +425,7 @@ int main (int argc, char *argv[])
     {"verbose",              no_argument,       NULL, 'v'},
     {"print_memory",         no_argument,       NULL, 'p'},
     {"rotate_poly",          no_argument,       NULL, 'u'},
+    {"maxxgrid",             required_argument, NULL, 'x'},
     {NULL, 0, NULL, 0}
   };
 
@@ -469,6 +475,15 @@ int main (int argc, char *argv[])
       break;
     case 'u':
       rotate_poly = 1;
+      break;
+    case 'x':
+      {
+        size_t maxxgrid_val = (size_t)atof(optarg);
+        if(maxxgrid_val < 1e3 || maxxgrid_val > 1e10) {
+          mpp_error("make_coupler_mosaic: --maxxgrid value must be between 1e3 and 1e10");
+        }
+        set_maxxgrid(maxxgrid_val);
+      }
       break;
     case '?':
       errflg++;
@@ -1163,34 +1178,34 @@ int main (int argc, char *argv[])
       }
 
       for(nl=0; nl<ntile_lnd; nl++) {
-	atmxlnd_area[na][nl] = (double *)malloc(MAXXGRID*sizeof(double));
-	atmxlnd_ia  [na][nl] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	atmxlnd_ja  [na][nl] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	atmxlnd_il  [na][nl] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	atmxlnd_jl  [na][nl] = (int    *)malloc(MAXXGRID*sizeof(int   ));
+	atmxlnd_area[na][nl] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	atmxlnd_ia  [na][nl] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	atmxlnd_ja  [na][nl] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	atmxlnd_il  [na][nl] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	atmxlnd_jl  [na][nl] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
 	if(interp_order == 2 ) {
-	  atmxlnd_clon[na][nl] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxlnd_clat[na][nl] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxlnd_dia [na][nl] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxlnd_dja [na][nl] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxlnd_dil [na][nl] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxlnd_djl [na][nl] = (double *)malloc(MAXXGRID*sizeof(double));
+	  atmxlnd_clon[na][nl] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxlnd_clat[na][nl] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxlnd_dia [na][nl] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxlnd_dja [na][nl] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxlnd_dil [na][nl] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxlnd_djl [na][nl] = (double *)malloc(get_maxxgrid()*sizeof(double));
 	}
       }
 
       for(no=0; no<ntile_ocn; no++) {
-	atmxocn_area[na][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	atmxocn_ia  [na][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	atmxocn_ja  [na][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	atmxocn_io  [na][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	atmxocn_jo  [na][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
+	atmxocn_area[na][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	atmxocn_ia  [na][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	atmxocn_ja  [na][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	atmxocn_io  [na][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	atmxocn_jo  [na][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
 	if(interp_order == 2 ) {
-	  atmxocn_clon[na][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxocn_clat[na][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxocn_dia [na][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxocn_dja [na][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxocn_dio [na][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  atmxocn_djo [na][no] = (double *)malloc(MAXXGRID*sizeof(double));
+	  atmxocn_clon[na][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxocn_clat[na][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxocn_dia [na][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxocn_dja [na][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxocn_dio [na][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  atmxocn_djo [na][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
 	}
       }
     }
@@ -1655,7 +1670,7 @@ int main (int argc, char *argv[])
 		    atmxocn_clat[na][no][naxo[na][no]] = poly_ctrlat ( x_out, y_out, n_out )*ocn_frac;
 		  }
 		  ++(naxo[na][no]);
-		  if(naxo[na][no] > MAXXGRID) mpp_error("naxo is greater than MAXXGRID, increase MAXXGRID");
+		  if(naxo[na][no] > get_maxxgrid()) mpp_error("naxo exceeds MAXXGRID limit; increase the value using --maxxgrid flag");
 		}
 	      }
 	    }
@@ -1722,7 +1737,7 @@ int main (int argc, char *argv[])
 	      atmxlnd_clat[na][nl][naxl[na][nl]] = axl_clat[l];
 	    }
 	    ++(naxl[na][nl]);
-	    if(naxl[na][nl] > MAXXGRID) mpp_error("naxl is greater than MAXXGRID, increase MAXXGRID");
+	    if(naxl[na][nl] > get_maxxgrid()) mpp_error("naxl exceeds MAXXGRID limit; increase the value using --maxxgrid flag");
 	  }
 	}
 
@@ -2513,18 +2528,18 @@ int main (int argc, char *argv[])
 	lndxocn_clat[nl] = (double **)malloc(ntile_ocn*sizeof(double *));
       }
       for(no=0; no<ntile_ocn; no++) {
-	lndxocn_area[nl][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	lndxocn_il  [nl][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	lndxocn_jl  [nl][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	lndxocn_io  [nl][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	lndxocn_jo  [nl][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
+	lndxocn_area[nl][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	lndxocn_il  [nl][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	lndxocn_jl  [nl][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	lndxocn_io  [nl][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	lndxocn_jo  [nl][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
 	if(interp_order == 2 ) {
-	  lndxocn_dil[nl][no]  = (double *)malloc(MAXXGRID*sizeof(double));
-	  lndxocn_djl[nl][no]  = (double *)malloc(MAXXGRID*sizeof(double));
-	  lndxocn_dio[nl][no]  = (double *)malloc(MAXXGRID*sizeof(double));
-	  lndxocn_djo[nl][no]  = (double *)malloc(MAXXGRID*sizeof(double));
-	  lndxocn_clon[nl][no] = (double *)malloc(MAXXGRID*sizeof(double *));
-	  lndxocn_clat[nl][no] = (double *)malloc(MAXXGRID*sizeof(double *));
+	  lndxocn_dil[nl][no]  = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  lndxocn_djl[nl][no]  = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  lndxocn_dio[nl][no]  = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  lndxocn_djo[nl][no]  = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  lndxocn_clon[nl][no] = (double *)malloc(get_maxxgrid()*sizeof(double *));
+	  lndxocn_clat[nl][no] = (double *)malloc(get_maxxgrid()*sizeof(double *));
 	}
       }
     }
@@ -2690,7 +2705,7 @@ int main (int argc, char *argv[])
 		  lndxocn_clat[nl][no][nlxo[nl][no]] = poly_ctrlat ( x_out, y_out, n_out )*ocn_frac;
 		}
 		++(nlxo[nl][no]);
-		if(nlxo[nl][no] > MAXXGRID) mpp_error("nlxo is greater than MAXXGRID, increase MAXXGRID");
+		if(nlxo[nl][no] > get_maxxgrid()) mpp_error("nlxo exceeds MAXXGRID limit; increase the value using --maxxgrid flag");
 	      }
 	    }
 	  } /* end of io, jo loop */
@@ -3031,18 +3046,18 @@ int main (int argc, char *argv[])
       }
 
       for(no=0; no<ntile_ocn; no++) {
-	wavxocn_area[nw][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	wavxocn_iw  [nw][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	wavxocn_jw  [nw][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	wavxocn_io  [nw][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
-	wavxocn_jo  [nw][no] = (int    *)malloc(MAXXGRID*sizeof(int   ));
+	wavxocn_area[nw][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	wavxocn_iw  [nw][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	wavxocn_jw  [nw][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	wavxocn_io  [nw][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
+	wavxocn_jo  [nw][no] = (int    *)malloc(get_maxxgrid()*sizeof(int   ));
 	if(interp_order == 2 ) {
-	  wavxocn_clon[nw][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  wavxocn_clat[nw][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  wavxocn_diw [nw][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  wavxocn_djw [nw][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  wavxocn_dio [nw][no] = (double *)malloc(MAXXGRID*sizeof(double));
-	  wavxocn_djo [nw][no] = (double *)malloc(MAXXGRID*sizeof(double));
+	  wavxocn_clon[nw][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  wavxocn_clat[nw][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  wavxocn_diw [nw][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  wavxocn_djw [nw][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  wavxocn_dio [nw][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
+	  wavxocn_djo [nw][no] = (double *)malloc(get_maxxgrid()*sizeof(double));
 	}
       }
     }
@@ -3222,7 +3237,7 @@ int main (int argc, char *argv[])
 		    wavxocn_clat[nw][no][nwxo[nw][no]] = poly_ctrlat ( x_out, y_out, n_out )*ocn_frac;
 		  }
 		  ++(nwxo[nw][no]);
-		  if(nwxo[nw][no] > MAXXGRID) mpp_error("nwxo is greater than MAXXGRID, increase MAXXGRID");
+		  if(nwxo[nw][no] > get_maxxgrid()) mpp_error("nwxo exceeds MAXXGRID limit; increase the value using --maxxgrid flag");
 		}
 	      }
 	    }


### PR DESCRIPTION
Convert MAXXGRID from a compile-time constant to a runtime parameter configurable via command-line flag in both fregrid and make_coupler_mosaic tools.

**Description**
- Fix issue #390 
- Add global variable and getter/setter functions in create_xgrid.c
- Replace all MAXXGRID macro uses with get_maxxgrid() calls
- Add --maxxgrid flag to fregrid and make_coupler_mosaic
- Validate range: 1e3 to 1e10, default: 1e6
- Update error messages to reference the new flag
- Update fregrid man page documentation

Benefits:
- No recompilation needed to adjust MAXXGRID
- Better default value (1e6 vs 1e8) for memory management
- Clearer error messages with actionable guidance
- Consistent interface across both tools

Files modified:
- lib/libfrencutils/create_xgrid.{c,h}
- lib/libfrencutils/interp.c
- src/fre-grid/conserve_interp.c
- src/fre-grid/fregrid.c
- src/make-coupler-mosaic/make_coupler_mosaic.c
- man/fregrid.txt

**How Has This Been Tested?**
- make check-expensive    
  results  # TOTAL: 84,# PASS:  80,# SKIP:  1,# XFAIL: 0,# FAIL:  3,# XPASS: 0,# ERROR: 0
  main branch makes the same SKIP and FAIL

- tested fregrid via command line argument 

 fregrid without --maxxgrid fails for this high resolution data with 
FATAL Error: The xgrid size is too large for resources.
 nxgrid exceeds MAXXGRID/nthreads limit; increase MAXXGRID using --maxxgrid flag,

```
cd /xtmp/Niki.Zadeh/work/hiresCM5

/nbhome/Niki.Zadeh/projects/FRE-NCtools/builds/gfdlpan/src/fregrid --standard_dimension --input_mosaic /archive/oar.gfdl.cm5/input_files/om5/OM5_0625/coupled_mosaic_v20250617_unpacked/ocean_mosaic.nc  --input_file ocean_monthly.002601-003012.tos --interp_method conserve_order1  --nlon 360 --nlat 180 --scalar_field tos --output_fi
le ocean_monthly.002601-003012.tos.fregrid.nc
```

 fregrid with passing --maxxgrid

```
cd /xtmp/Niki.Zadeh/work/hiresCM5

   /nbhome/Niki.Zadeh/projects/FRE-NCtools/builds/gfdlpan/src/fregrid --standard_dimension --input_mosaic /archive/oar.gfdl.cm5/input_files/om5/OM5_0625/coupled_mosaic_v20250617_unpacked/ocean_mosaic.nc  --input_file ocean_monthly.002601-003012.tos --interp_method conserve_order1  --nlon 360 --nlat 180 --scalar_field tos --output_fi
le ocean_monthly.002601-003012.tos.maxxgrid.fregrid.nc  --maxxgrid  1e8

mpirun -n 4 /nbhome/Niki.Zadeh/projects/FRE-NCtools/builds/gfdlpan/src/fregrid_parallel --standard_dimension --input_mosaic /archive/oar
.gfdl.cm5/input_files/om5/OM5_0625/coupled_mosaic_v20250617_unpacked/ocean_mosaic.nc  --input_file ocean_monthly.002601-003012.tos --interp_method conserve_order1  --nlon 360 --nlat 180 --scalar_
field tos --output_file ocean_monthly.002601-003012.tos.maxxgrid.fregrid_parallel4.nc --maxxgrid 1e8


```

- vefiried the remapped data checksums are the same with and without --maxxgrid




**Checklist:**
- [* ] My code follows the style guidelines of this project
- [* ] I have performed a self-review of my own code
- [ *] I have commented my code, particularly in hard-to-understand areas
- [ *] I have made corresponding changes to the documentation
- [ *] My changes generate no new warnings
- [ *] Any dependent changes have been merged and published in downstream modules
- [ *] New check tests, if applicable, are included
- [ *] `make check` passes
