### PR TITLE
Resolve compilation error involving static const local variables

### DIFF
--- a/lib/libfrencutils/mosaic_util.c
+++ b/lib/libfrencutils/mosaic_util.c
@@ -1687,17 +1687,15 @@ int crosses_pole(const double x[] , int n) {
   rotation away from the pole if what is being rotaed is near a pole.
   For rotation matricies formulas and examples, see F.S.Hill, Computer
   Graphics Using OpenGL, @nd ed., Chapter 5.3.
+
+  Note: M_SQRT1_2 is a compile-time constant availble in math.h
 */
 void set_the_rotation_matrix() {
-  static const double is2 = 1.0 /M_SQRT2;
-
-  static const double m00 = 0;
-  static const double m01 = - is2;
-  static const double m02 = is2;
-  static const double m11 = 1.0/2;
-  static const double m12 = 0.5;
-
-  static const double m[3][3] = { {m00, m01, m02}, {m02, m11, m12},{m01, m12, m11} };
+  static const double m[3][3] = {
+      {  0.0,       -M_SQRT1_2, M_SQRT1_2 },
+      {  M_SQRT1_2, 0.5,        0.5       },
+      { -M_SQRT1_2, 0.5,        0.5       }
+  };
 
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {


### PR DESCRIPTION
The fix correctly resolves the compilation error where static const local variables were being initialized with other static const variables (is2), which is not a valid constant expression in C.

**Description**
Fixes #380

**How Has This Been Tested?**
Passes tests on GFDL workstation and gaea (except the mpi tests that are expected to fail on the latter)

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
