### PR TITLE
List-ncvars should now include coordinate variables

### DIFF
--- a/site-configs/gfdl-ws/env.sh
+++ b/site-configs/gfdl-ws/env.sh
@@ -32,15 +32,15 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # Variables to control versions used
-env_version=2025.01
-gcc_version=13.3.0
+env_version=2026.01
+gcc_version=14.3.0
 ncc_version=4.9.2
 ncf_version=4.6.1
-mpi_version=4.2.3
+mpi_version=4.3.0
 
 # Ensure the base spack modules are first in MODULEPATH
-module remove-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
-module prepend-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
+module remove-path MODULEPATH /app/spack/${env_version}/lmod/linux-rhel8-x86_64/Core
+module prepend-path MODULEPATH /app/spack/${env_version}/lmod/linux-rhel8-x86_64/Core
 
 # python is needed for tests
 module load python

--- a/site-configs/gfdl/env.sh
+++ b/site-configs/gfdl/env.sh
@@ -32,15 +32,15 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # Variables to control versions used
-env_version=2025.01
-gcc_version=13.3.0
+env_version=2026.01
+gcc_version=14.3.0
 ncc_version=4.9.2
 ncf_version=4.6.1
-mpi_version=4.2.3
+mpi_version=4.3.0
 
 # Ensure the base spack modules are first in MODULEPATH
-module remove-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
-module prepend-path MODULEPATH /app/spack/${env_version}/modulefiles/linux-rhel8-x86_64
+module remove-path MODULEPATH /app/spack/${env_version}/lmod/linux-rhel8-x86_64/Core
+module prepend-path MODULEPATH /app/spack/${env_version}/lmod/linux-rhel8-x86_64/Core
 
 # python is needed for tests
 module load python

--- a/src/list-ncvars/list_ncvars.f90
+++ b/src/list-ncvars/list_ncvars.f90
@@ -71,10 +71,6 @@ program list_ncvars
       !--- skip if character fields ---
       if (xtype == NF90_CHAR) cycle
 
-      !--- skip dimensions ---
-      istat = NF90_INQ_DIMID (ncid, trim(name), dimid)
-      if (istat == NF90_NOERR) cycle
-
       !--- skip names ending in _T1, _T2, _DT  ---
       nc = len_trim(name)
       if (name(nc-2:nc) == '_T1' .or. name(nc-2:nc) == '_T2' .or. &

--- a/tests/list_ncvars/list_ncvars_ftn
+++ b/tests/list_ncvars/list_ncvars_ftn
@@ -101,8 +101,8 @@ vars=$(list_ncvars << EOF || fail_ "list_ncvars failed printing 1 static variabl
  &end
 EOF
 )
-nvars=$(echo $vars | wc -w) || framework_failure_ "failed to get number of 1 static variables"
-test $nvars -eq 1 || fail_ "list_ncvars should have printed 1 static vars, but printed $nvars \n*****\n$vars\n*****"
+nvars=$(echo $vars | wc -w) || framework_failure_ "failed to get number of 5 static variables"
+test $nvars -eq 5 || fail_ "list_ncvars should have printed 5 static vars, but printed $nvars \n*****\n$vars\n*****"
 
 vars=$(list_ncvars << EOF || fail_ "list_ncvars failed printing 1 non-static variable"
  &input
@@ -133,6 +133,5 @@ vars=$(list_ncvars << EOF || fail_ "list_ncvars failed with no output"
  &end
 EOF
 )
-nvars=$(echo $vars | wc -w) || framework_failure_ "failed to get number of 10 variables"
-test $nvars -eq 10 || fail_ "list_ncvars should have printed 10 vars, but printed $nvars \n*****\n$vars\n*****"
-
+nvars=$(echo $vars | wc -w) || framework_failure_ "failed to get number of 15 variables"
+test $nvars -eq 15 || fail_ "list_ncvars should have printed 15 vars, but printed $nvars \n*****\n$vars\n*****"

--- a/tests/list_ncvars/list_ncvars_sh
+++ b/tests/list_ncvars/list_ncvars_sh
@@ -117,5 +117,5 @@ test $nvars -eq 0 || \
 vars=$(list_ncvars.sh -s -14 file1.nc) || \
     fail_ list_ncvars.sh failed printing 2 static vars "\n***n$vars\n****"
 nvars=$(echo $vars | wc -w) || framework_failure_
-test $nvars -eq 2 || \
-    fail_ list_ncvars should have printed 2 vars, but printed $nvars "\n*****$vars\n*****"
+test $nvars -eq 6 || \
+    fail_ list_ncvars should have printed 6 vars, but printed $nvars "\n*****$vars\n*****"

--- a/tests/split_ncvars/split_ncvars-l
+++ b/tests/split_ncvars/split_ncvars-l
@@ -43,7 +43,8 @@ split_ncvars.pl -l test_input_1.nc || fail_ split_ncvars.pl test_input.nc failed
 # Check that the README file was created
 test -f README || fail_ README not created
 
-expected_output="           time_bnds = time axis boundaries (days)
+expected_output="                time =  ()
+           time_bnds = time axis boundaries (days)
                 var1 = variable 1 (s)
                 var2 =  ()"
 test x"$(cat README)" = x"$expected_output" || fail_ README does not contain expected output


### PR DESCRIPTION
**Description**
List-ncvars has always omitted the non-diagnostic grid-related coordinate variables (coordinate variables share the name as a dimension.) This was done to limit the "useless" non-diagnostic grid-related static variables, i.e. the coordinate variables.

The only known user of list-ncvars is FRE Bronx frepp, which uses it to create the static pp file. Until this fre-nctools release,
2026.01, split_ncvars.pl did NOT use the ncks -C option (which excludes coordinate/metadata) vars. Therefore, the coordinate variables (such as grid_xt) *were* included in the static pp file due to the lack of -C in the ncks call.

Last year, NCO changed the ncks to more assertively include metadata-referenced variables. This now included time-varying "ps" and "volcello". To prevent time-varying variables in the static pp files, split_ncvars was updated to add the -C (excluded coordinate/metadata vars). However, this then prevented the grid-related coordinate variables from being included in the static pp file, and some users require these outputs. To adjust to this, list-ncvars should now *include* the coordinate variables in the output.

Fixes #394 

**How Has This Been Tested?**
I updated the list-vars tests, which now expects the coordinate variables in the output. All other tests pass.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
