### PR TITLE
Set package version to 2026.01 (again) to re-trigger the tag & release pipelines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@
 AC_PREREQ([2.63])
 AC_INIT(
   [FRE NCTools],
-  [2026.01-dev],
+  [2026.01],
   [https://github.com/NOAA-GFDL/FRE-NCtools/issues],
   [fre-nctools],
   [https://github.com/NOAA-GFDL/FRE-NCtools])


### PR DESCRIPTION
**Description**
We previously tagged and released 2026.01, but since then discovered and fixed a list-vars bug (https://github.com/NOAA-GFDL/FRE-NCtools/issues/394) that we wanted to include in this release.

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
