### PR TITLE
Add "Upload test logs on failure" step to the tag.yaml CI action

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        make distcheck
+        make distcheck VERBOSE=1
     - name: Upload test logs on failure
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -45,11 +45,23 @@ jobs:
         mkdir build && cd build
         autoreconf -if ../configure.ac
         ../configure
-    - name: Build and create distribution file
+    - name: Build
       run: |
         cd build
         make
+    - name: Run tests
+      run: |
+        cd build
         make distcheck
+    - name: Upload test logs on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-logs
+        path: build/tests/test-suite.log
+    - name: Create distribution file
+      run: |
+        cd build
         make dist
     - name: Create release draft and upload file
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This update splits the build step: separate the "Build and create distribution file" step into three distinct steps:

- Build: Runs make to compile the code
- Run tests: Runs make distcheck to execute the test suite
- Create distribution file: Runs make dist to create the distribution package

Added the upload step: After the "Run tests" step, there is a new step called "Upload test logs on failure" that:

Only executes if the "Run tests" step fails (using if: failure()) Uses the actions/upload-artifact@v4 action to upload the test suite log file (test-suite.log) Names the artifact "test-logs" for easy identification This ensures that when make distcheck fails, the test logs will be automatically uploaded as artifacts, making it easier to debug test failures in the CI pipeline.

**Description**
The "tag for release" action is failing due to split-ncvars tests failing, but the failed logs are not uploaded presently. Therefore, let's add the "upload test logs on failure" step to the tag.yaml action.

**How Has This Been Tested?**
Not tested, and may not be correct

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes
