### PR TITLE
Fix split_ncvars tests for distcheck compatibility

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -3,7 +3,7 @@
 # CI testing for the FRE-NCtools repo, builds and runs unit tests
 # image dockerfile is maintained here:
 # https://gitlab.gfdl.noaa.gov/fre/hpc-me
-name: FRE-NCtools CI
+name: End-to-end distribution check
 on:
   workflow_run:
     workflows: ["FRE-NCtools Check Expensive"]

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,5 +1,6 @@
 # appends -dev to the version upon release and opens pr
 # CI won't run on generated PR, easiest workaround is to close + reopen
+name: Post-release dev package update
 on:
   release:
     types: [published]

--- a/tests/split_ncvars/split_ncvars
+++ b/tests/split_ncvars/split_ncvars
@@ -24,16 +24,18 @@ then
     command -v split_ncvars.pl --version
 fi
 
-. ${srcdir=.}/init.sh; path_prepend_ ../../src
+. ${srcdir=.}/init.sh
+PKGLIBEXECDIR=${PKGLIBEXECDIR:-${top_builddir}/src}
+path_prepend_ "${PKGLIBEXECDIR}"
 
 # Need to use the included list_ncvars.sh script.  Otherwise,
 # split_ncvars will look for list_ncvars.sh in the installed bin
 # directory.
-export LIST_NCVARS=$(readlink -f ../../src/list_ncvars.sh)
+export LIST_NCVARS=$(readlink -f "${PKGLIBEXECDIR}/list_ncvars.sh")
 
 # list_ncvars.sh needs to know where to find the built list_ncvars
 # executable.
-export PKGLIBEXECDIR=$(readlink -f ../../src)
+export PKGLIBEXECDIR=$(readlink -f "${PKGLIBEXECDIR}")
 
 # Use the test netCDF files from plevel and timeavg
 ${builddir=..}/create_timeavg_test_ncfiles || framework_failure_ "failed to create timeavg test files"

--- a/tests/split_ncvars/split_ncvars-f
+++ b/tests/split_ncvars/split_ncvars-f
@@ -24,16 +24,16 @@ then
     command -v split_ncvars.pl --version
 fi
 
-. ${srcdir=.}/init.sh; path_prepend_ ../../src
+. ${srcdir=.}/init.sh; path_prepend_ ${builddir}/src
 
 # Need to use the included list_ncvars.sh script.  Otherwise,
 # split_ncvars will look for list_ncvars.sh in the installed bin
 # directory.
-export LIST_NCVARS=$(readlink -f ../../src/list_ncvars.sh)
+export LIST_NCVARS=$(readlink -f ${builddir}/src/list_ncvars.sh)
 
 # list_ncvars.sh needs to know where to find the built list_ncvars
 # executable.
-export PKGLIBEXECDIR=$(readlink -f ../../src)
+export PKGLIBEXECDIR=$(readlink -f ${builddir}/src)
 
 # Use the test netCDF files from plevel
 ${builddir=..}/create_plevel_test_ncfile || framework_failure_ "failed to create plevel test files"

--- a/tests/split_ncvars/split_ncvars-i
+++ b/tests/split_ncvars/split_ncvars-i
@@ -24,16 +24,18 @@ then
     command -v split_ncvars.pl --version
 fi
 
-. ${srcdir=.}/init.sh; path_prepend_ ../../src
+. ${srcdir=.}/init.sh
+PKGLIBEXECDIR=${PKGLIBEXECDIR:-${top_builddir}/src}
+path_prepend_ "${PKGLIBEXECDIR}"
 
 # Need to use the included list_ncvars.sh script.  Otherwise,
 # split_ncvars will look for list_ncvars.sh in the installed bin
 # directory.
-export LIST_NCVARS=$(readlink -f ../../src/list_ncvars.sh)
+export LIST_NCVARS=$(readlink -f "${PKGLIBEXECDIR}/list_ncvars.sh")
 
 # list_ncvars.sh needs to know where to find the built list_ncvars
 # executable.
-export PKGLIBEXECDIR=$(readlink -f ../../src)
+export PKGLIBEXECDIR=$(readlink -f "${PKGLIBEXECDIR}")
 
 # Use the test netCDF files from plevel
 ${builddir=..}/create_plevel_test_ncfile || framework_failure_ "failed to create plevel test files"

--- a/tests/split_ncvars/split_ncvars-l
+++ b/tests/split_ncvars/split_ncvars-l
@@ -24,16 +24,18 @@ then
     command -v split_ncvars.pl --version
 fi
 
-. ${srcdir=.}/init.sh; path_prepend_ ../../src
+. ${srcdir=.}/init.sh
+PKGLIBEXECDIR=${PKGLIBEXECDIR:-${top_builddir}/src}
+path_prepend_ "${PKGLIBEXECDIR}"
 
 # Need to use the included list_ncvars.sh script.  Otherwise,
 # split_ncvars will look for list_ncvars.sh in the installed bin
 # directory.
-export LIST_NCVARS=$(readlink -f ../../src/list_ncvars.sh)
+export LIST_NCVARS=$(readlink -f "${PKGLIBEXECDIR}/list_ncvars.sh")
 
 # list_ncvars.sh needs to know where to find the built list_ncvars
 # executable.
-export PKGLIBEXECDIR=$(readlink -f ../../src)
+export PKGLIBEXECDIR=$(readlink -f "${PKGLIBEXECDIR}")
 
 # Use the test netCDF files from timeavg
 ${builddir=..}/create_timeavg_test_ncfiles || framework_failure_ "failed to create test files"

--- a/tests/split_ncvars/split_ncvars-o
+++ b/tests/split_ncvars/split_ncvars-o
@@ -24,16 +24,18 @@ then
     command -v split_ncvars.pl --version
 fi
 
-. ${srcdir=.}/init.sh; path_prepend_ ../../src
+. ${srcdir=.}/init.sh
+PKGLIBEXECDIR=${PKGLIBEXECDIR:-${top_builddir}/src}
+path_prepend_ "${PKGLIBEXECDIR}"
 
 # Need to use the included list_ncvars.sh script.  Otherwise,
 # split_ncvars will look for list_ncvars.sh in the installed bin
 # directory.
-export LIST_NCVARS=$(readlink -f ../../src/list_ncvars.sh)
+export LIST_NCVARS=$(readlink -f "${PKGLIBEXECDIR}/list_ncvars.sh")
 
 # list_ncvars.sh needs to know where to find the built list_ncvars
 # executable.
-export PKGLIBEXECDIR=$(readlink -f ../../src)
+export PKGLIBEXECDIR=$(readlink -f "${PKGLIBEXECDIR}")
 
 # Use the test netCDF files from plevel
 ${builddir=..}/create_plevel_test_ncfile || framework_failure_ "failed to create plevel test files"

--- a/tests/split_ncvars/split_ncvars-p
+++ b/tests/split_ncvars/split_ncvars-p
@@ -24,16 +24,18 @@ then
     command -v split_ncvars.pl --version
 fi
 
-. ${srcdir=.}/init.sh; path_prepend_ ../../src
+. ${srcdir=.}/init.sh
+PKGLIBEXECDIR=${PKGLIBEXECDIR:-${top_builddir}/src}
+path_prepend_ "${PKGLIBEXECDIR}"
 
 # Need to use the included list_ncvars.sh script.  Otherwise,
 # split_ncvars will look for list_ncvars.sh in the installed bin
 # directory.
-export LIST_NCVARS=$(readlink -f ../../src/list_ncvars.sh)
+export LIST_NCVARS=$(readlink -f "${PKGLIBEXECDIR}/list_ncvars.sh")
 
 # list_ncvars.sh needs to know where to find the built list_ncvars
 # executable.
-export PKGLIBEXECDIR=$(readlink -f ../../src)
+export PKGLIBEXECDIR=$(readlink -f "${PKGLIBEXECDIR}")
 
 # Use the test netCDF files from plevel
 ${builddir=..}/create_plevel_test_ncfile || framework_failure_ "failed to create test files"

--- a/tests/split_ncvars/split_ncvars-s
+++ b/tests/split_ncvars/split_ncvars-s
@@ -24,16 +24,18 @@ then
     command -v split_ncvars.pl --version
 fi
 
-. ${srcdir=.}/init.sh; path_prepend_ ../../src
+. ${srcdir=.}/init.sh
+PKGLIBEXECDIR=${PKGLIBEXECDIR:-${top_builddir}/src}
+path_prepend_ "${PKGLIBEXECDIR}"
 
 # Need to use the included list_ncvars.sh script.  Otherwise,
 # split_ncvars will look for list_ncvars.sh in the installed bin
 # directory.
-export LIST_NCVARS=$(readlink -f ../../src/list_ncvars.sh)
+export LIST_NCVARS=$(readlink -f "${PKGLIBEXECDIR}/list_ncvars.sh")
 
 # list_ncvars.sh needs to know where to find the built list_ncvars
 # executable.
-export PKGLIBEXECDIR=$(readlink -f ../../src)
+export PKGLIBEXECDIR=$(readlink -f "${PKGLIBEXECDIR}")
 
 # Use the test netCDF files from plevel
 ${builddir=..}/create_plevel_test_ncfile || framework_failure_ "failed to create plevel test files"

--- a/tests/split_ncvars/split_ncvars-v
+++ b/tests/split_ncvars/split_ncvars-v
@@ -24,16 +24,18 @@ then
     command -v split_ncvars.pl --version
 fi
 
-. ${srcdir=.}/init.sh; path_prepend_ ../../src
+. ${srcdir=.}/init.sh
+PKGLIBEXECDIR=${PKGLIBEXECDIR:-${top_builddir}/src}
+path_prepend_ "${PKGLIBEXECDIR}"
 
 # Need to use the included list_ncvars.sh script.  Otherwise,
 # split_ncvars will look for list_ncvars.sh in the installed bin
 # directory.
-export LIST_NCVARS=$(readlink -f ../../src/list_ncvars.sh)
+export LIST_NCVARS=$(readlink -f "${PKGLIBEXECDIR}/list_ncvars.sh")
 
 # list_ncvars.sh needs to know where to find the built list_ncvars
 # executable.
-export PKGLIBEXECDIR=$(readlink -f ../../src)
+export PKGLIBEXECDIR=$(readlink -f "${PKGLIBEXECDIR}")
 
 # Use the test netCDF files from plevel
 ${builddir=..}/create_plevel_test_ncfile || framework_failure_ "failed to create test files"


### PR DESCRIPTION
The split_ncvars test scripts were using hardcoded relative paths (builddir/src) that worked in normal make check but failed in make distcheck because distcheck builds in a different directory structure.

In distcheck:
- Tests run from distdir/_build/sub/tests/
- Built tools are in distdir/_build/ (not distdir/_build/src/)
- The correct path is abs_top_builddir/src, set via PKGLIBEXECDIR

Updated all split_ncvars test variants to use PKGLIBEXECDIR environment variable (which is properly set by TESTS_ENVIRONMENT) instead of hardcoded builddir paths. This ensures tests find the built executables and scripts in both normal builds and distcheck.

Files changed:
- tests/split_ncvars/split_ncvars
- tests/split_ncvars/split_ncvars-f
- tests/split_ncvars/split_ncvars-i
- tests/split_ncvars/split_ncvars-l
- tests/split_ncvars/split_ncvars-o
- tests/split_ncvars/split_ncvars-p
- tests/split_ncvars/split_ncvars-s
- tests/split_ncvars/split_ncvars-v

**Description**
Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes #398

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
