### PR TITLE
de-duplicate CI workflow runs 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,13 @@
 # image dockerfile is maintained here:
 # https://gitlab.gfdl.noaa.gov/fre/hpc-me
 name: FRE-NCtools CI
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 jobs:
   CI:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description**
This pull request updates the CI workflow configuration to only trigger on pushes and pull requests targeting the `main` branch, rather than all branches.

Workflow trigger changes:

* Modified `.github/workflows/main.yml` to restrict CI runs to only when code is pushed to or a pull request is opened against the `main` branch.on: [push, pull_request]

 --> only for those two when they target main



**How Has This Been Tested?**
CI

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes
