### PR TITLE
Fix intermittent parallel build failure in lib/libnfu

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -47,6 +47,8 @@ SUFFIXES = _mod.$(FC_MODEXT) .$(FC_MODEXT)
 	@$(MKDIR_P) $(@D)
 	$(AM_V_PPFC)$(PPFCCOMPILE) -c -o $(@D)/$(<F:.F90=.o) $<
 
+CLEANFILES =
+
 clean-local:
 	$(RM) *.$(FC_MODEXT)
 

--- a/lib/libnfu/local.mk
+++ b/lib/libnfu/local.mk
@@ -22,7 +22,17 @@ libnfu_libnfu_a_SOURCES = \
     libnfu/nfu.F90 \
     libnfu/nfu_compress.F90
 
+# nfu_mod.mod is a side effect of compiling nfu.F90 into nfu.o — both are
+# produced by the same gfortran invocation.  Without this explicit rule,
+# make -j would use the .F90.mod suffix rule to build nfu_mod.mod, which
+# compiles nfu.F90 a second time in parallel with the .F90.o job.  The two
+# simultaneous gfortran processes race to rename nfu_mod.mod0 → nfu_mod.mod
+# and the loser dies with "Cannot rename … No such file or directory".
+# This explicit no-op rule overrides the suffix rule and enforces that
+# nfu_mod.mod is only produced once, as a side effect of nfu.o.
+libnfu/nfu_mod.$(FC_MODEXT): libnfu/nfu.$(OBJEXT)
+	@:
+
 libnfu/nfu_compress.$(OBJEXT): libnfu/nfu_mod.$(FC_MODEXT)
 
-clean-local:
-	$(RM) *.$(FC_MODEXT)
+CLEANFILES += libnfu/nfu_mod.$(FC_MODEXT) libnfu/nfu_compress_mod.$(FC_MODEXT)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -126,6 +126,7 @@ EXTRA_DIST = \
 CLEANFILES = *.$(FC_MODEXT)
 clean-local:
 	$(RM) $(bin_SCRIPTS) $(BUILT_SOURCES)
+	$(RM) -r .mods plevel/.mods
 
 # Perform several substitutions
 do_subst = $(SED) -e 's,[@]prefix[@],$(prefix),g' \

--- a/tools/simple_hydrog/lakes/Makefile.am
+++ b/tools/simple_hydrog/lakes/Makefile.am
@@ -50,7 +50,7 @@ constants_mod.mod: constants.$(OBJEXT)
 mpp_mod.mod: mpp.$(OBJEXT)
 horiz_interp_type_mod.mod: mpp_mod.mod horiz_interp_type.$(OBJEXT)
 horiz_interp_bilinear_mod.mod: constants_mod.mod mpp_mod.mod horiz_interp_type_mod.mod horiz_interp_bilinear.$(OBJEXT)
-horiz_interp_mod.mod: constants_mod.mod mpp_mod.mod horiz_interp_type_mod.mod horiz_interp_bilinear_mod.mod horiz_intrep.$(OBJEXT)
+horiz_interp_mod.mod: constants_mod.mod mpp_mod.mod horiz_interp_type_mod.mod horiz_interp_bilinear_mod.mod horiz_interp.$(OBJEXT)
 
 mpp.$(OBJEXT): mpp.F90 mpp_error_a_a.h mpp_error_a_s.h mpp_error_s_a.h mpp_error_s_s.h
 horiz_interp_type.$(OBJEXT): horiz_interp_type.F90 mpp_mod.mod


### PR DESCRIPTION
  Under make -j, make scheduled two independent jobs that both compiled
  libnfu/nfu.F90: the .F90.o rule (producing nfu.o for libnfu.a) and the
  .F90.$(FC_MODEXT) suffix rule (producing nfu_mod.mod for
  nfu_compress.o's prerequisite). Because AM_FCFLAGS uses $(FC_MODOUT)$(@D),
  both gfortran processes wrote to the same libnfu/nfu_mod.mod0 temp file
  and raced to rename it, causing the intermittent error:

    f951: Fatal Error: Cannot rename module file 'libnfu/nfu_mod.mod0'
    to 'libnfu/nfu_mod.mod': No such file or directory

  Fix by adding an explicit no-op rule in lib/libnfu/local.mk:

    libnfu/nfu_mod.$(FC_MODEXT): libnfu/nfu.$(OBJEXT)
        @:

  This overrides the .F90.$(FC_MODEXT) suffix rule so nfu.F90 is compiled
  only once. nfu_mod.mod is treated as a side effect of building nfu.o,
  and nfu_compress.o waits for it via the existing prerequisite.

  Also replace the duplicate clean-local rule in local.mk (which produced
  a make warning) with CLEANFILES += entries, and add CLEANFILES = in
  lib/Makefile.am to initialise the variable before local.mk uses +=.

  Fix a typo in tools/simple_hydrog/lakes/Makefile.am: the prerequisite
  horiz_intrep.$(OBJEXT) did not match any source file; corrected to
  horiz_interp.$(OBJEXT).

  Closes: #405

**Description**
Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes # (issue)

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
